### PR TITLE
改正了教程和”兄弟传说“战役里的一些翻译错误和疏漏

### DIFF
--- a/translations/wesnoth/po/wesnoth-tb/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-tb/zh_CN.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: wesnoth-1.16\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
 "POT-Creation-Date: 2023-08-20 01:56 UTC\n"
-"PO-Revision-Date: 2024-06-28 12:16+0800\n"
+"PO-Revision-Date: 2025-05-26 18:17+0800\n"
 "Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #. [campaign]: id=Two_Brothers
 #: data/campaigns/Two_Brothers/_main.cfg:13
@@ -34,7 +34,7 @@ msgstr "AToTB"
 #. [campaign]: id=Two_Brothers
 #: data/campaigns/Two_Brothers/_main.cfg:18
 msgid "Beginner"
-msgstr "初心者"
+msgstr "初学者"
 
 #. [campaign]: id=Two_Brothers
 #: data/campaigns/Two_Brothers/_main.cfg:18
@@ -59,7 +59,7 @@ msgid ""
 "as planned. Can you help?\n"
 "\n"
 msgstr ""
-"一个邪恶的法师威胁着玛格雷小村和它的居民们。村里的法师向他的武士哥哥求助，但"
+"一个邪恶的法师威胁着玛格雷小村和它的居民们。村里的法师向他的骑士哥哥求助，但"
 "事态的发展并不如所料。你能帮忙吗？\n"
 "\n"
 
@@ -116,7 +116,7 @@ msgid ""
 msgstr ""
 "韦诺王国西面的偏远乐土玛格雷曾经是一个和平的地方，它的居民们很少会注意到外面"
 "世界的风云变幻。战争，或是战争的传闻一直与他们无关。即使是商人也很少出现，尽"
-"管艾尔德里尔和丹·冬克之间的商队可能会在烽火台召唤时派出一辆马车。"
+"管艾迪尔和丹·冬克之间的商队可能会在烽火台召唤时派出一辆马车。"
 
 #. [part]
 #: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:57
@@ -134,9 +134,9 @@ msgstr ""
 "然后有一天，一位黑暗法师在该地区定居下来，并开始为他的集会寻找祭品。\n"
 "\n"
 "骷髅和僵尸杀死牲畜，烧毁田园。<b>“畏服法师魔达克吧！”</b>他们边行丑恶之事，边"
-"以邪恶之音喊叫。人们从孤立的农场里消失。男人和女人都开始害怕夜晚，而他们的孩"
-"子甚至在白天也担惊受怕。但是到最近领主的居所，骑马需要走一天多，派去请他帮忙"
-"的信使都没有回来。"
+"以邪恶之音喊叫。在偏远地区的农舍里，村民突然失踪。男人和女人都开始害怕夜晚，"
+"而他们的孩子甚至在白天也担惊受怕。但是到最近领主的居所，骑马需要走一天多，派"
+"去请他帮忙的信使都没有回来。"
 
 #. [part]
 #: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:63
@@ -184,13 +184,13 @@ msgstr ""
 "韦元363年5月12日\n"
 "摘自玛格雷的巴兰的日记\n"
 "\n"
-"要是我能面对这个‘魔达克’就好了！我想我的魔法也许比他的强。但是他藏身在丘陵"
+"要是我能面对这个“魔达克”就好了！我想我的魔法也许比他的强。但是他藏身在丘陵"
 "里，被仆人们层层保护着，而我只能召集这些担惊受怕的农夫用刀棍去对付他的奴"
 "仆。\n"
 "\n"
 "我需要我哥哥；在作战方面，他向来比我有头脑。只是自从在托恩·卡里克的该死的那天"
-"以来，我们就再也没有交谈过了。就算他不会为我而来，但也许他会回来拯救我们这个"
-"急需救助的村子吧。"
+"以来，我们就再也没有交谈过了。就算他不为我而来，或许也会回来为我们的村庄解救"
+"燃眉之急吧。"
 
 #. [part]
 #: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:81
@@ -609,7 +609,7 @@ msgstr "我们在战场上击杀了死灵法师！我亲自了结了他。"
 msgid ""
 "We killed the necromancer on the battlefield! I saw the killing blow with my "
 "own eyes."
-msgstr "我们在战场上击杀了司令法师！我亲眼看到了最后一击。"
+msgstr "我们在战场上击杀了死灵法师！我亲眼看到了最后一击。"
 
 #. [message]: speaker=Nil-Galion
 #: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:392
@@ -626,7 +626,10 @@ msgstr ""
 "三天之前，我们听到了战斗的声响，但那囚人从我们身边经过时散发的邪恶死气，我们"
 "可是不会搞错的。如果你的弟弟确实就是那囚人，那他同时也是一名死灵法师。如我们"
 "大家所愿，记住你弟弟曾经的样子吧，你得知道，那囚人的命运将被你所能想到的最可"
-"怕的复仇所淹没。"
+"怕的复仇所淹没。\n"
+"\n"
+"无论如何，你们闯入我们的森林都不会有任何好处。不准再前进了，因为我们要保卫我"
+"们的土地。"
 
 #. [message]: speaker=Arvith
 #: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:399
@@ -643,8 +646,8 @@ msgid ""
 "will have us at a disadvantage; our horses will not maneuver well in the "
 "trees."
 msgstr ""
-"我真高兴至少我们不用面对幽灵。不过相比那些精灵，我们处于劣势；我们的马匹不能"
-"很好地在树林里机动。"
+"我真高兴我们不是真的见鬼。不过相比那些精灵，我们处于劣势；我们的马匹不能很好"
+"地在树林里机动。"
 
 #. [message]: speaker=Arvith
 #: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:409
@@ -1192,7 +1195,7 @@ msgstr "死在你手上还是泰拉奇手上都一样，终究难逃一死……
 #. [message]: speaker=Arvith
 #: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:705
 msgid "‘Tairach’? Who or what is Tairach?"
-msgstr "‘泰拉奇’？泰拉奇是什么人？还是什么东西？"
+msgstr "“泰拉奇”？泰拉奇是什么人？还是什么东西？"
 
 #. [message]: speaker=second_unit
 #: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:710
@@ -1224,7 +1227,7 @@ msgid ""
 "(neutral time of day). Place your units carefully, as your troops will be "
 "weaker and enemy units stronger."
 msgstr ""
-"此城堡一直处于<b>混沌</b>的时段（相当于永久的夜晚），除了与被照亮的石墙紧邻的"
+"此城堡一直处于<b>混沌</b>的时段（相当于永久的夜晚），除了与有照明的石墙紧邻的"
 "被照亮的六角格（相当于中性时段）。小心地放置你的单位，因为你的部队会变弱，而"
 "敌方单位会变强。"
 
@@ -1305,7 +1308,7 @@ msgstr "不是那样。也许我就该烂死在这。我辜负了你。我又一
 msgid ""
 "That is as may be. But you are my brother still. And... I never doubted you "
 "would have come for me."
-msgstr "大概吧。不过你终究是我弟弟。还有……我从不怀疑你会来救我的。"
+msgstr "大概吧。不过你终究是我弟弟。还有……我从不怀疑你也会为我冒险。"
 
 #. [message]: speaker=Arvith
 #: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:964
@@ -1545,7 +1548,7 @@ msgid ""
 "I have already paid with the lives of my men at Toen Caric. It is time I "
 "righted that mistake and finished this once and for all."
 msgstr ""
-"在托恩·卡里克，我的部下付出了生命的代价。是时候一劳永逸地纠正这个错误了。"
+"在托恩·卡里克，我的部下付出了生命的代价。是时候一劳永逸地纠正我的失误了。"
 
 #. [message]: speaker=Arvith
 #: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:355
@@ -1609,9 +1612,9 @@ msgstr ""
 "玛格雷比我上次看到它时好多了。巴兰在两年内创造了奇迹。村庄已经重建了，而周围"
 "的农田也恢复了生产。尽管我弟弟很担心，但我们的人民在那段时间里也没有遇到新的"
 "威胁。\n"
-"过去两年不回村子更不容易了，不过我有我的事业，而巴兰有他的事业，我们也很少有"
-"机会再见面。不过我的弟兄和我正跟随一位新主顾穿过王国的这一地区， 我向他请假去"
-"探望我弟弟，而他准许了。"
+"这两年我们心中很难再保持距离了，不过我有我的事业，而巴兰有他的事业，我们也很"
+"少有机会再见面。不过我的弟兄和我正跟随一位新主顾穿过王国的这一地区， 我向他请"
+"假去探望我弟弟，而他准许了。"
 
 #. [part]
 #: data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg:27

--- a/translations/wesnoth/po/wesnoth-tutorial/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-tutorial/zh_CN.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: wesnoth-1.18\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
 "POT-Creation-Date: 2024-05-26 02:28 UTC\n"
-"PO-Revision-Date: 2024-05-21 18:27+0800\n"
+"PO-Revision-Date: 2025-05-26 15:31+0800\n"
 "Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #. [campaign]: id=Tutorial
 #: data/campaigns/tutorial/_main.cfg:11
@@ -252,7 +252,7 @@ msgstr "早上好，德法多！现在是不是该找点东西来揍揍了？"
 #. [message]: speaker=Delfador
 #: data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg:400
 msgid "Um, well..."
-msgstr "恩，好吧……"
+msgstr "嗯，好吧……"
 
 #. [message]: speaker=student
 #: data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg:405
@@ -899,9 +899,8 @@ msgid ""
 "to the next scenario in the campaign."
 msgstr ""
 "在你的胜利提示之后，地图会变为灰色，以表示本场景已经结束；这称为<b>逗留模式</"
-"b>。但你将仍然可以查看你的部队以及所有存活的敌人的最终位置和状态。这称为<b>逗"
-"留模式</b>。当你结束查看时，点击<b>结束场景</b>按钮，以进入战役中的下一幕场"
-"景。"
+"b>。但你将仍然可以查看你的部队以及所有存活的敌人的最终位置和状态。当你结束查"
+"看时，点击<b>结束场景</b>按钮，以进入战役中的下一幕场景。"
 
 #. [scenario]: id=2_Tutorial
 #: data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg:5
@@ -1619,7 +1618,7 @@ msgid ""
 "prevent stronger enemies from reaching key locations, such as villages, even "
 "if you have limited manpower."
 msgstr ""
-"紧邻一个单位的六个六角格组成了它的<b>控制区域<b>。当敌方单位进入那些六角格"
+"紧邻一个单位的六个六角格组成了它的<b>控制区域</b>。当敌方单位进入那些六角格"
 "时，他们在该回合将无法继续移动。（有一个例外，拥有<b>散兵</b>能力的单位不受控"
 "制区域的影响。）这可以用于封锁强敌的行动，让他们不能接近诸如村庄一类的关键位"
 "置，哪怕你人手不足也是如此。"
@@ -1696,7 +1695,7 @@ msgid ""
 "without wading through the water, and you will be securely on a terrain with "
 "good defense."
 msgstr ""
-"干得好！岛上的村庄是我们的了。你可以靠树林组成针对兽人的封锁；他们若不淌水，"
+"干得好！岛上的村庄是我们的了。你可以靠树林组成针对兽人的封锁；他们若不蹚水，"
 "那只能挨个过桥，而你则会处于能够良好防御的地形之上，十分安全。"
 
 #. [then]
@@ -2171,8 +2170,7 @@ msgstr ""
 msgid ""
 "You can also refer to the in-game help browser if you ever need to refresh "
 "your memory on gameplay mechanics."
-msgstr ""
-"如果你需要刷新一下有关游戏机制的记忆，你也可以随时参看游戏内的帮助浏览器。"
+msgstr "如果你需要回顾游戏机制，也可以随时参看游戏内的帮助浏览器。"
 
 #. [unit_type]: id=Fighter, race=human
 #: data/campaigns/tutorial/units/Fighter.cfg:4


### PR DESCRIPTION
改正了教程和”兄弟传说“战役里的一些翻译错误和疏漏。尤其是教程里的”非法的Pango标记“，我从1.16看到1.18，直到我前几天给一位朋友介绍这个游戏时他也看到了😂。
有一些感觉不通顺的地方按照我自己的理解来修改了，如有不妥，敬请斧正。