### PR TITLE
master版本的wesnoth-lib、low、nr翻译更新

### DIFF
--- a/translations/wesnoth/po/wesnoth-lib/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-lib/zh_CN.po
@@ -1,5 +1,5 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
@@ -7,21 +7,22 @@
 # sylecn <sylecn@yahoo.com.cn>, 2009.
 # CloudiDust <cloudidust@gmail.com>, 2010.
 # Yifan <yyf1992@mail.ustc.edu.cn>, 2015.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.18\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2026-04-19 22:19-0500\n"
-"PO-Revision-Date: 2026-05-03 11:15+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-08-18 10:18-0500\n"
+"PO-Revision-Date: 2026-08-26 21:26+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.8\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [ai]: id=ai_default_rca
 #: data/ai/ais/ai_default_rca.cfg:9
@@ -61,7 +62,7 @@ msgstr "篱笆"
 #. [terrain_type]: id=deep_water_tropical
 #. [terrain_type]: id=deep_water
 #: data/core/terrain.cfg:23 data/core/terrain.cfg:34 data/core/terrain.cfg:45
-#: data/core/terrain.cfg:3376 data/core/terrain.cfg:3377
+#: data/core/terrain.cfg:3374 data/core/terrain.cfg:3375
 msgid "Deep Water"
 msgstr "深水"
 
@@ -85,7 +86,7 @@ msgstr "热带深水"
 #. [terrain_type]: id=tropical_water
 #. [terrain_type]: id=shallow_water
 #: data/core/terrain.cfg:56 data/core/terrain.cfg:67 data/core/terrain.cfg:78
-#: data/core/terrain.cfg:3335 data/core/terrain.cfg:3336
+#: data/core/terrain.cfg:3333 data/core/terrain.cfg:3334
 msgid "Shallow Water"
 msgstr "浅水"
 
@@ -128,8 +129,8 @@ msgstr ""
 #. [terrain_type]: id=tropical_reef
 #. [terrain_type]: id=reef
 #: data/core/terrain.cfg:101 data/core/terrain.cfg:112
-#: data/core/terrain.cfg:123 data/core/terrain.cfg:3291
-#: data/core/terrain.cfg:3292
+#: data/core/terrain.cfg:123 data/core/terrain.cfg:3289
+#: data/core/terrain.cfg:3290
 msgid "Coastal Reef"
 msgstr "礁石"
 
@@ -153,8 +154,8 @@ msgstr "热带礁石"
 #. [terrain_type]: id=quagmire
 #. [terrain_type]: id=swamp_water
 #: data/core/terrain.cfg:134 data/core/terrain.cfg:149
-#: data/core/terrain.cfg:160 data/core/terrain.cfg:3319
-#: data/core/terrain.cfg:3320
+#: data/core/terrain.cfg:160 data/core/terrain.cfg:3317
+#: data/core/terrain.cfg:3318
 msgid "Swamp"
 msgstr "沼泽"
 
@@ -259,10 +260,8 @@ msgstr ""
 msgid "Clean Gray Cobbles"
 msgstr "干净的灰色卵石"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=road_desert
 #: data/core/terrain.cfg:274
-#, fuzzy
 msgid "Gravel"
 msgstr "碎石"
 
@@ -308,8 +307,8 @@ msgstr ""
 
 #. [terrain_type]: id=sand_beach
 #. [terrain_type]: id=sand
-#: data/core/terrain.cfg:340 data/core/terrain.cfg:3278
-#: data/core/terrain.cfg:3279
+#: data/core/terrain.cfg:340 data/core/terrain.cfg:3276
+#: data/core/terrain.cfg:3277
 msgid "Sand"
 msgstr "沙地"
 
@@ -320,7 +319,7 @@ msgstr "海滩沙砾"
 
 #. [terrain_type]: id=sand_beach
 #. [terrain_type]: id=sand
-#: data/core/terrain.cfg:345 data/core/terrain.cfg:3282
+#: data/core/terrain.cfg:345 data/core/terrain.cfg:3280
 msgid ""
 "The instability of <italic>text='sand'</italic> makes it harder for most "
 "units to cross, and leaves them wide open to attack. In contrast, the wide "
@@ -522,8 +521,8 @@ msgstr "已死的参天橡树"
 #: data/core/terrain.cfg:758 data/core/terrain.cfg:770
 #: data/core/terrain.cfg:782 data/core/terrain.cfg:794
 #: data/core/terrain.cfg:806 data/core/terrain.cfg:818
-#: data/core/terrain.cfg:830 data/core/terrain.cfg:3402
-#: data/core/terrain.cfg:3403
+#: data/core/terrain.cfg:830 data/core/terrain.cfg:3400
+#: data/core/terrain.cfg:3401
 msgid "Forest"
 msgstr "森林"
 
@@ -607,8 +606,8 @@ msgstr "雪地混交林"
 #. [terrain_type]: id=snow_hills
 #. [terrain_type]: id=hills
 #: data/core/terrain.cfg:846 data/core/terrain.cfg:856
-#: data/core/terrain.cfg:876 data/core/terrain.cfg:3306
-#: data/core/terrain.cfg:3307
+#: data/core/terrain.cfg:876 data/core/terrain.cfg:3304
+#: data/core/terrain.cfg:3305
 msgid "Hills"
 msgstr "丘陵"
 
@@ -645,7 +644,7 @@ msgstr "雪丘"
 #: data/core/terrain.cfg:911 data/core/terrain.cfg:922
 #: data/core/terrain.cfg:1347 data/core/terrain.cfg:1357
 #: data/core/terrain.cfg:1368 data/core/terrain.cfg:1378
-#: data/core/terrain.cfg:3362 data/core/terrain.cfg:3363
+#: data/core/terrain.cfg:3360 data/core/terrain.cfg:3361
 msgid "Mountains"
 msgstr "山岭"
 
@@ -674,7 +673,7 @@ msgstr "沙漠山岭"
 #. [terrain_type]: id=regular_stone_floor_deprecated
 #. [terrain_type]: id=ancient_stone_floor_deprecated
 #: data/core/terrain.cfg:934 data/core/terrain.cfg:944
-#: data/core/terrain.cfg:3473 data/core/terrain.cfg:3484
+#: data/core/terrain.cfg:3471 data/core/terrain.cfg:3482
 msgid "Stone Floor"
 msgstr "石地板"
 
@@ -694,8 +693,8 @@ msgstr "古老石地板"
 #. [terrain_type]: id=rug_floor_deprecated
 #. [terrain_type]: id=rug2_floor_deprecated
 #: data/core/terrain.cfg:954 data/core/terrain.cfg:964
-#: data/core/terrain.cfg:974 data/core/terrain.cfg:3495
-#: data/core/terrain.cfg:3506
+#: data/core/terrain.cfg:974 data/core/terrain.cfg:3493
+#: data/core/terrain.cfg:3504
 msgid "Rug"
 msgstr "地毯"
 
@@ -727,7 +726,7 @@ msgstr "基本木地板"
 #. [terrain_type]: id=old_wood_floor
 #. [terrain_type]: id=old_wood_floor_deprecated
 #: data/core/terrain.cfg:994 data/core/terrain.cfg:997
-#: data/core/terrain.cfg:3517
+#: data/core/terrain.cfg:3515
 msgid "Old Wooden Floor"
 msgstr "老旧木地板"
 
@@ -745,7 +744,7 @@ msgstr "光束"
 #. [terrain_type]: id=cave_earthy
 #. [terrain_type]: id=cave
 #: data/core/terrain.cfg:1021 data/core/terrain.cfg:1031
-#: data/core/terrain.cfg:3263 data/core/terrain.cfg:3264
+#: data/core/terrain.cfg:3261 data/core/terrain.cfg:3262
 msgid "Cave"
 msgstr "洞穴"
 
@@ -801,8 +800,8 @@ msgstr ""
 "覆盖层”^Uf“和”^Ufi“现已废弃。原因是，虽然其图形显示的是一个覆盖层，其下有另一"
 "种地形，但其移动和防御数值均是纯真菌地形的，而完全忽略了下层地形。推荐"
 "用”^Tf“和”^Tfi“来替代，它们看上去和原来一样，但其数值与其图形所暗示的数值一"
-"致。如果需要在格中使用纯真菌地形，那么“^Tb”是蘑菇基础地形，在使用时，其上可以"
-"覆盖也可以不覆盖“^Tf”。"
+"致。如果需要在格中使用纯真菌地形的数值，那么“^Tb”是蘑菇基础地形，在使用时，其"
+"上可以覆盖也可以不覆盖“^Tf”。"
 
 #. [terrain_type]: id=fungus_grove_old
 #. [terrain_type]: id=fungus_beam_old
@@ -881,38 +880,30 @@ msgstr "多土岩石洞穴"
 msgid "Mine Rail"
 msgstr "矿中铁轨"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=high_border
 #: data/core/terrain.cfg:1214
-#, fuzzy
 msgid "Bluff"
-msgstr "虚张声势"
+msgstr "悬崖"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=high_canyon
 #: data/core/terrain.cfg:1224
-#, fuzzy
 msgid "Gulch"
-msgstr "沟壑"
+msgstr "峡谷"
 
 #. [terrain_type]: id=high_canyon_obst
 #: data/core/terrain.cfg:1235
 msgid "Unwalkable Ravine"
 msgstr "不可行走的峡谷"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=high_border_woods
 #: data/core/terrain.cfg:1249
-#, fuzzy
 msgid "Wooded Bluffs"
-msgstr "伍德德布拉夫斯"
+msgstr "树木覆盖的悬崖"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=high_canyon_woods
 #: data/core/terrain.cfg:1259
-#, fuzzy
 msgid "Wooded Gulch"
-msgstr "伍德德沟"
+msgstr "树木覆盖的峡谷"
 
 #. [terrain_type]: id=canyon
 #. [terrain_type]: id=chasm_earthy
@@ -1163,13 +1154,13 @@ msgid "Impassable Overlay"
 msgstr "不可通过地形覆盖层"
 
 #. [terrain_type]: id=unwalkable_overlay
-#: data/core/terrain.cfg:1756
+#: data/core/terrain.cfg:1754
 msgid "Unwalkable Overlay"
 msgstr "不可行走地形覆盖层"
 
 #. [terrain_type]: id=void
 #. [terrain_type]: id=off_map
-#: data/core/terrain.cfg:1768 data/core/terrain.cfg:3181
+#: data/core/terrain.cfg:1766 data/core/terrain.cfg:3179
 msgid "Void"
 msgstr "空"
 
@@ -1205,178 +1196,178 @@ msgstr "空"
 #. [terrain_type]: id=mermen-village
 #. [terrain_type]: id=village_overlay
 #. [terrain_type]: id=village
-#: data/core/terrain.cfg:1784 data/core/terrain.cfg:1797
-#: data/core/terrain.cfg:1810 data/core/terrain.cfg:1823
-#: data/core/terrain.cfg:1838 data/core/terrain.cfg:1851
-#: data/core/terrain.cfg:1866 data/core/terrain.cfg:1879
-#: data/core/terrain.cfg:1894 data/core/terrain.cfg:1907
-#: data/core/terrain.cfg:1920 data/core/terrain.cfg:1933
-#: data/core/terrain.cfg:1946 data/core/terrain.cfg:1959
-#: data/core/terrain.cfg:1972 data/core/terrain.cfg:1985
-#: data/core/terrain.cfg:1998 data/core/terrain.cfg:2011
-#: data/core/terrain.cfg:2024 data/core/terrain.cfg:2037
-#: data/core/terrain.cfg:2050 data/core/terrain.cfg:2065
-#: data/core/terrain.cfg:2078 data/core/terrain.cfg:2091
-#: data/core/terrain.cfg:2104 data/core/terrain.cfg:2117
-#: data/core/terrain.cfg:2130 data/core/terrain.cfg:2143
-#: data/core/terrain.cfg:2158 data/core/terrain.cfg:2171
-#: data/core/terrain.cfg:2189 data/core/terrain.cfg:3427
-#: data/core/terrain.cfg:3428
+#: data/core/terrain.cfg:1782 data/core/terrain.cfg:1795
+#: data/core/terrain.cfg:1808 data/core/terrain.cfg:1821
+#: data/core/terrain.cfg:1836 data/core/terrain.cfg:1849
+#: data/core/terrain.cfg:1864 data/core/terrain.cfg:1877
+#: data/core/terrain.cfg:1892 data/core/terrain.cfg:1905
+#: data/core/terrain.cfg:1918 data/core/terrain.cfg:1931
+#: data/core/terrain.cfg:1944 data/core/terrain.cfg:1957
+#: data/core/terrain.cfg:1970 data/core/terrain.cfg:1983
+#: data/core/terrain.cfg:1996 data/core/terrain.cfg:2009
+#: data/core/terrain.cfg:2022 data/core/terrain.cfg:2035
+#: data/core/terrain.cfg:2048 data/core/terrain.cfg:2063
+#: data/core/terrain.cfg:2076 data/core/terrain.cfg:2089
+#: data/core/terrain.cfg:2102 data/core/terrain.cfg:2115
+#: data/core/terrain.cfg:2128 data/core/terrain.cfg:2141
+#: data/core/terrain.cfg:2156 data/core/terrain.cfg:2169
+#: data/core/terrain.cfg:2187 data/core/terrain.cfg:3425
+#: data/core/terrain.cfg:3426
 msgid "Village"
 msgstr "村庄"
 
 #. [terrain_type]: id=desert_village
-#: data/core/terrain.cfg:1785
+#: data/core/terrain.cfg:1783
 msgid "Adobe Village"
 msgstr "泥砖村庄"
 
 #. [terrain_type]: id=desert_village_ruin
-#: data/core/terrain.cfg:1798
+#: data/core/terrain.cfg:1796
 msgid "Ruined Adobe Village"
 msgstr "毁坏的泥砖村庄"
 
 #. [terrain_type]: id=desert_village_tent
-#: data/core/terrain.cfg:1811
+#: data/core/terrain.cfg:1809
 msgid "Desert Tent Village"
 msgstr "沙漠帐篷村庄"
 
 #. [terrain_type]: id=camp_village
-#: data/core/terrain.cfg:1824
+#: data/core/terrain.cfg:1822
 msgid "Tent Village"
 msgstr "帐篷村庄"
 
 #. [terrain_type]: id=orcish_village
-#: data/core/terrain.cfg:1839
+#: data/core/terrain.cfg:1837
 msgid "Orcish Village"
 msgstr "兽人村庄"
 
 #. [terrain_type]: id=orcish_snow_village
-#: data/core/terrain.cfg:1852
+#: data/core/terrain.cfg:1850
 msgid "Snowy Orcish Village"
 msgstr "雪中兽人村庄"
 
 #. [terrain_type]: id=elven_snow_village
-#: data/core/terrain.cfg:1867
+#: data/core/terrain.cfg:1865
 msgid "Snowy Elven Village"
 msgstr "雪中精灵村庄"
 
 #. [terrain_type]: id=elven_village
-#: data/core/terrain.cfg:1880
+#: data/core/terrain.cfg:1878
 msgid "Elven Village"
 msgstr "精灵村庄"
 
 #. [terrain_type]: id=human_village
-#: data/core/terrain.cfg:1895
+#: data/core/terrain.cfg:1893
 msgid "Cottage"
 msgstr "小农舍"
 
 #. [terrain_type]: id=snow_village
-#: data/core/terrain.cfg:1908
+#: data/core/terrain.cfg:1906
 msgid "Snowy Cottage"
 msgstr "雪中小农舍"
 
 #. [terrain_type]: id=human_village_ruin
-#: data/core/terrain.cfg:1921
+#: data/core/terrain.cfg:1919
 msgid "Ruined Cottage"
 msgstr "毁坏的小农舍"
 
 #. [terrain_type]: id=city_village
-#: data/core/terrain.cfg:1934
+#: data/core/terrain.cfg:1932
 msgid "Human City"
 msgstr "人类城市"
 
 #. [terrain_type]: id=windmill_village
-#: data/core/terrain.cfg:1947
+#: data/core/terrain.cfg:1945
 msgid "Windmill Village"
 msgstr "风车村庄"
 
 #. [terrain_type]: id=city_village_wno
-#: data/core/terrain.cfg:1960
+#: data/core/terrain.cfg:1958
 msgid "Snowy Human City"
 msgstr "雪中人类城市"
 
 #. [terrain_type]: id=city_village_ruin
-#: data/core/terrain.cfg:1973
+#: data/core/terrain.cfg:1971
 msgid "Ruined Human City"
 msgstr "毁坏的人类城市"
 
 #. [terrain_type]: id=hill_village
-#: data/core/terrain.cfg:1986
+#: data/core/terrain.cfg:1984
 msgid "Hill Stone Village"
 msgstr "山石村庄"
 
 #. [terrain_type]: id=snow-hill_village
-#: data/core/terrain.cfg:1999
+#: data/core/terrain.cfg:1997
 msgid "Snowy Hill Stone Village"
 msgstr "雪中山石村庄"
 
 #. [terrain_type]: id=hill_village_ruin
-#: data/core/terrain.cfg:2012
+#: data/core/terrain.cfg:2010
 msgid "Ruined Hill Stone Village"
 msgstr "毁坏的山石村庄"
 
 #. [terrain_type]: id=tropical_forest_village
-#: data/core/terrain.cfg:2025
+#: data/core/terrain.cfg:2023
 msgid "Tropical Village"
 msgstr "热带村庄"
 
 #. [terrain_type]: id=drake_village
-#: data/core/terrain.cfg:2038
+#: data/core/terrain.cfg:2036
 msgid "Drake Village"
 msgstr "龙人村庄"
 
 #. [terrain_type]: id=drake_snow_village
-#: data/core/terrain.cfg:2051
+#: data/core/terrain.cfg:2049
 msgid "Snowy Drake Village"
 msgstr "雪中龙人村庄"
 
 #. [terrain_type]: id=underground_village
-#: data/core/terrain.cfg:2066
+#: data/core/terrain.cfg:2064
 msgid "Cave Village"
 msgstr "洞穴村庄"
 
 #. [terrain_type]: id=dwarven_village
-#: data/core/terrain.cfg:2079
+#: data/core/terrain.cfg:2077
 msgid "Dwarven Village"
 msgstr "矮人村庄"
 
 #. [terrain_type]: id=hut_village
-#: data/core/terrain.cfg:2092
+#: data/core/terrain.cfg:2090
 msgid "Hut"
 msgstr "小屋"
 
 #. [terrain_type]: id=hut_snow_village
-#: data/core/terrain.cfg:2105
+#: data/core/terrain.cfg:2103
 msgid "Snowy Hut"
 msgstr "雪中小屋"
 
 #. [terrain_type]: id=logcabin_village
-#: data/core/terrain.cfg:2118
+#: data/core/terrain.cfg:2116
 msgid "Log Cabin"
 msgstr "小木屋"
 
 #. [terrain_type]: id=logcabin_snow_village
-#: data/core/terrain.cfg:2131
+#: data/core/terrain.cfg:2129
 msgid "Snowy Log Cabin"
 msgstr "雪中小木屋"
 
 #. [terrain_type]: id=igloo
-#: data/core/terrain.cfg:2144
+#: data/core/terrain.cfg:2142
 msgid "Igloo"
 msgstr "圆顶屋"
 
 #. [terrain_type]: id=swamp_village
-#: data/core/terrain.cfg:2159
+#: data/core/terrain.cfg:2157
 msgid "Swamp Village"
 msgstr "沼泽村庄"
 
 #. [terrain_type]: id=mermen-village
-#: data/core/terrain.cfg:2172
+#: data/core/terrain.cfg:2170
 msgid "Merfolk Village"
 msgstr "人鱼村庄"
 
 #. [terrain_type]: id=mermen-village
-#: data/core/terrain.cfg:2173
+#: data/core/terrain.cfg:2171
 msgid ""
 "<italic>text='Submerged villages'</italic> are the homes of merfolk and "
 "nagas. While water-dwelling creatures are at home here, land-dwellers have a "
@@ -1396,7 +1387,7 @@ msgstr ""
 "人鱼和娜迦在水下村庄中拥有60%的防御率，但是陆地单位在其中的防御率通常比较低。"
 
 #. [terrain_type]: id=village_overlay
-#: data/core/terrain.cfg:2190
+#: data/core/terrain.cfg:2188
 msgid "Village Overlay"
 msgstr "村庄覆盖层"
 
@@ -1405,19 +1396,19 @@ msgstr "村庄覆盖层"
 #. [terrain_type]: id=encampment_snow
 #. [terrain_type]: id=troll_encampment
 #. [terrain_type]: id=aquatic_camp
-#: data/core/terrain.cfg:2206 data/core/terrain.cfg:2207
-#: data/core/terrain.cfg:2218 data/core/terrain.cfg:2230
-#: data/core/terrain.cfg:2435 data/core/terrain.cfg:2447
+#: data/core/terrain.cfg:2204 data/core/terrain.cfg:2205
+#: data/core/terrain.cfg:2216 data/core/terrain.cfg:2228
+#: data/core/terrain.cfg:2433 data/core/terrain.cfg:2445
 msgid "Encampment"
 msgstr "营地"
 
 #. [terrain_type]: id=encampment_ruin
-#: data/core/terrain.cfg:2219
+#: data/core/terrain.cfg:2217
 msgid "Ruined Encampment"
 msgstr "毁坏的营地"
 
 #. [terrain_type]: id=encampment_snow
-#: data/core/terrain.cfg:2231
+#: data/core/terrain.cfg:2229
 msgid "Snowy Encampment"
 msgstr "雪中营地"
 
@@ -1436,69 +1427,69 @@ msgstr "雪中营地"
 #. [terrain_type]: id=aquatic_castle
 #. [terrain_type]: id=castle_overlay
 #. [terrain_type]: id=castle
-#: data/core/terrain.cfg:2242 data/core/terrain.cfg:2254
-#: data/core/terrain.cfg:2266 data/core/terrain.cfg:2278
-#: data/core/terrain.cfg:2289 data/core/terrain.cfg:2301
-#: data/core/terrain.cfg:2313 data/core/terrain.cfg:2325
-#: data/core/terrain.cfg:2337 data/core/terrain.cfg:2349
-#: data/core/terrain.cfg:2361 data/core/terrain.cfg:2411
-#: data/core/terrain.cfg:2460 data/core/terrain.cfg:2776
-#: data/core/terrain.cfg:3346 data/core/terrain.cfg:3347
+#: data/core/terrain.cfg:2240 data/core/terrain.cfg:2252
+#: data/core/terrain.cfg:2264 data/core/terrain.cfg:2276
+#: data/core/terrain.cfg:2287 data/core/terrain.cfg:2299
+#: data/core/terrain.cfg:2311 data/core/terrain.cfg:2323
+#: data/core/terrain.cfg:2335 data/core/terrain.cfg:2347
+#: data/core/terrain.cfg:2359 data/core/terrain.cfg:2409
+#: data/core/terrain.cfg:2458 data/core/terrain.cfg:2774
+#: data/core/terrain.cfg:3344 data/core/terrain.cfg:3345
 msgid "Castle"
 msgstr "城堡"
 
 #. [terrain_type]: id=orcish_fort
-#: data/core/terrain.cfg:2243
+#: data/core/terrain.cfg:2241
 msgid "Orcish Castle"
 msgstr "兽人城堡"
 
 #. [terrain_type]: id=snow_orcish_fort
-#: data/core/terrain.cfg:2255
+#: data/core/terrain.cfg:2253
 msgid "Snowy Orcish Castle"
 msgstr "雪中兽人城堡"
 
 #. [terrain_type]: id=human_castle
-#: data/core/terrain.cfg:2267
+#: data/core/terrain.cfg:2265
 msgid "Human Castle"
 msgstr "人类城堡"
 
 #. [terrain_type]: id=snow_castle
-#: data/core/terrain.cfg:2279
+#: data/core/terrain.cfg:2277
 msgid "Snowy Human Castle"
 msgstr "雪中人类城堡"
 
 #. [terrain_type]: id=elven_castle
-#: data/core/terrain.cfg:2290
+#: data/core/terrain.cfg:2288
 msgid "Elven Castle"
 msgstr "精灵城堡"
 
 #. [terrain_type]: id=elven_castle_ruin
-#: data/core/terrain.cfg:2302
+#: data/core/terrain.cfg:2300
 msgid "Elven Castle Ruin"
 msgstr "精灵城堡废墟"
 
 #. [terrain_type]: id=elven_castle_winter
-#: data/core/terrain.cfg:2314
+#: data/core/terrain.cfg:2312
 msgid "Winter Elven Castle"
 msgstr "冬季精灵城堡"
 
 #. [terrain_type]: id=dwarven_castle
-#: data/core/terrain.cfg:2326
+#: data/core/terrain.cfg:2324
 msgid "Dwarven Underground Castle"
 msgstr "矮人地下城堡"
 
 #. [terrain_type]: id=dwarven_castle2
-#: data/core/terrain.cfg:2338
+#: data/core/terrain.cfg:2336
 msgid "Dwarven Castle"
 msgstr "矮人城堡"
 
 #. [terrain_type]: id=dwarven_castle_ruin
-#: data/core/terrain.cfg:2350
+#: data/core/terrain.cfg:2348
 msgid "Dwarven Castle Ruins"
 msgstr "矮人城堡废墟"
 
 #. [terrain_type]: id=dwarven_castle_winter
-#: data/core/terrain.cfg:2362
+#: data/core/terrain.cfg:2360
 msgid "Winter Dwarven Castle"
 msgstr "冬季矮人城堡"
 
@@ -1506,48 +1497,48 @@ msgstr "冬季矮人城堡"
 #. [terrain_type]: id=sunkenruin
 #. [terrain_type]: id=swampruin
 #. [terrain_type]: id=sand_castle_ruin
-#: data/core/terrain.cfg:2373 data/core/terrain.cfg:2385
-#: data/core/terrain.cfg:2398 data/core/terrain.cfg:2423
+#: data/core/terrain.cfg:2371 data/core/terrain.cfg:2383
+#: data/core/terrain.cfg:2396 data/core/terrain.cfg:2421
 msgid "Ruined Castle"
 msgstr "毁坏的城堡"
 
 #. [terrain_type]: id=ruin
-#: data/core/terrain.cfg:2374
+#: data/core/terrain.cfg:2372
 msgid "Ruined Human Castle"
 msgstr "毁坏的人类城堡"
 
 #. [terrain_type]: id=sunkenruin
-#: data/core/terrain.cfg:2386
+#: data/core/terrain.cfg:2384
 msgid "Sunken Human Ruin"
 msgstr "沉陷的人类废墟"
 
 #. [terrain_type]: id=swampruin
-#: data/core/terrain.cfg:2399
+#: data/core/terrain.cfg:2397
 msgid "Swamp Human Ruin"
 msgstr "沼泽中的人类废墟"
 
 #. [terrain_type]: id=sand_castle
-#: data/core/terrain.cfg:2412
+#: data/core/terrain.cfg:2410
 msgid "Desert Castle"
 msgstr "沙漠城堡"
 
 #. [terrain_type]: id=sand_castle_ruin
-#: data/core/terrain.cfg:2424
+#: data/core/terrain.cfg:2422
 msgid "Ruined Desert Castle"
 msgstr "毁坏的沙漠城堡"
 
 #. [terrain_type]: id=troll_encampment
-#: data/core/terrain.cfg:2436
+#: data/core/terrain.cfg:2434
 msgid "Troll Encampment"
 msgstr "巨魔营地"
 
 #. [terrain_type]: id=aquatic_camp
-#: data/core/terrain.cfg:2448
+#: data/core/terrain.cfg:2446
 msgid "Aquatic Encampment"
 msgstr "水中营地"
 
 #. [terrain_type]: id=aquatic_castle
-#: data/core/terrain.cfg:2461
+#: data/core/terrain.cfg:2459
 msgid "Aquatic Castle"
 msgstr "水中城堡"
 
@@ -1556,24 +1547,24 @@ msgstr "水中城堡"
 #. [terrain_type]: id=encampment_snow_keep
 #. [terrain_type]: id=merman_campkeep
 #. [terrain_type]: id=troll_campkeep
-#: data/core/terrain.cfg:2477 data/core/terrain.cfg:2501
-#: data/core/terrain.cfg:2514 data/core/terrain.cfg:2735
-#: data/core/terrain.cfg:2748
+#: data/core/terrain.cfg:2475 data/core/terrain.cfg:2499
+#: data/core/terrain.cfg:2512 data/core/terrain.cfg:2733
+#: data/core/terrain.cfg:2746
 msgid "Encampment Keep"
 msgstr "营地主楼"
 
 #. [terrain_type]: id=encampment_ruin_keep
-#: data/core/terrain.cfg:2489
+#: data/core/terrain.cfg:2487
 msgid "Ruined Encampment Keep"
 msgstr "毁坏的营地主楼"
 
 #. [terrain_type]: id=encampment_keep_tall
-#: data/core/terrain.cfg:2502
+#: data/core/terrain.cfg:2500
 msgid "Tall Encampment Keep"
 msgstr "高耸的营地主楼"
 
 #. [terrain_type]: id=encampment_snow_keep
-#: data/core/terrain.cfg:2515
+#: data/core/terrain.cfg:2513
 msgid "Snowy Encampment Keep"
 msgstr "雪中营地主楼"
 
@@ -1592,69 +1583,69 @@ msgstr "雪中营地主楼"
 #. [terrain_type]: id=desert_keep
 #. [terrain_type]: id=merman_castlekeep
 #. [terrain_type]: id=keep_overlay
-#: data/core/terrain.cfg:2527 data/core/terrain.cfg:2540
-#: data/core/terrain.cfg:2553 data/core/terrain.cfg:2566
-#: data/core/terrain.cfg:2579 data/core/terrain.cfg:2592
-#: data/core/terrain.cfg:2605 data/core/terrain.cfg:2618
-#: data/core/terrain.cfg:2631 data/core/terrain.cfg:2644
-#: data/core/terrain.cfg:2657 data/core/terrain.cfg:2709
-#: data/core/terrain.cfg:2761 data/core/terrain.cfg:2789
+#: data/core/terrain.cfg:2525 data/core/terrain.cfg:2538
+#: data/core/terrain.cfg:2551 data/core/terrain.cfg:2564
+#: data/core/terrain.cfg:2577 data/core/terrain.cfg:2590
+#: data/core/terrain.cfg:2603 data/core/terrain.cfg:2616
+#: data/core/terrain.cfg:2629 data/core/terrain.cfg:2642
+#: data/core/terrain.cfg:2655 data/core/terrain.cfg:2707
+#: data/core/terrain.cfg:2759 data/core/terrain.cfg:2787
 msgid "Keep"
 msgstr "主楼"
 
 # i'd like to translate it as城堡主楼
 #. [terrain_type]: id=orcish_keep
-#: data/core/terrain.cfg:2528
+#: data/core/terrain.cfg:2526
 msgid "Orcish Keep"
 msgstr "兽人主楼"
 
 #. [terrain_type]: id=snow_orcish_keep
-#: data/core/terrain.cfg:2541
+#: data/core/terrain.cfg:2539
 msgid "Snowy Orcish Keep"
 msgstr "雪中兽人主楼"
 
 #. [terrain_type]: id=human_keep
-#: data/core/terrain.cfg:2554
+#: data/core/terrain.cfg:2552
 msgid "Human Castle Keep"
 msgstr "人类城堡主楼"
 
 #. [terrain_type]: id=snow_keep
-#: data/core/terrain.cfg:2567
+#: data/core/terrain.cfg:2565
 msgid "Snowy Human Castle Keep"
 msgstr "雪中人类城堡主楼"
 
 #. [terrain_type]: id=elven_keep
-#: data/core/terrain.cfg:2580
+#: data/core/terrain.cfg:2578
 msgid "Elven Castle Keep"
 msgstr "精灵城堡主楼"
 
 #. [terrain_type]: id=elven_keep_ruin
-#: data/core/terrain.cfg:2593
+#: data/core/terrain.cfg:2591
 msgid "Elven Keep Ruin"
 msgstr "精灵主楼废墟"
 
 #. [terrain_type]: id=elven_keep_winter
-#: data/core/terrain.cfg:2606
+#: data/core/terrain.cfg:2604
 msgid "Winter Elven Keep"
 msgstr "冬季精灵主楼"
 
 #. [terrain_type]: id=dwarven_keep
-#: data/core/terrain.cfg:2619
+#: data/core/terrain.cfg:2617
 msgid "Dwarven Underground Keep"
 msgstr "矮人地下城堡主楼"
 
 #. [terrain_type]: id=dwarven_keep2
-#: data/core/terrain.cfg:2632
+#: data/core/terrain.cfg:2630
 msgid "Dwarven Castle Keep"
 msgstr "矮人城堡主楼"
 
 #. [terrain_type]: id=dwarven_keep_ruin
-#: data/core/terrain.cfg:2645
+#: data/core/terrain.cfg:2643
 msgid "Dwarven Ruin Keep"
 msgstr "矮人废墟主楼"
 
 #. [terrain_type]: id=dwarven_keep_winter
-#: data/core/terrain.cfg:2658
+#: data/core/terrain.cfg:2656
 msgid "Winter Dwarven Keep"
 msgstr "冬季矮人主楼"
 
@@ -1662,58 +1653,58 @@ msgstr "冬季矮人主楼"
 #. [terrain_type]: id=sunken_keep
 #. [terrain_type]: id=swamp_keep
 #. [terrain_type]: id=desert_keep_ruined
-#: data/core/terrain.cfg:2670 data/core/terrain.cfg:2683
-#: data/core/terrain.cfg:2696 data/core/terrain.cfg:2722
+#: data/core/terrain.cfg:2668 data/core/terrain.cfg:2681
+#: data/core/terrain.cfg:2694 data/core/terrain.cfg:2720
 msgid "Ruined Keep"
 msgstr "荒废的主楼"
 
 #. [terrain_type]: id=ruined_keep
-#: data/core/terrain.cfg:2671
+#: data/core/terrain.cfg:2669
 msgid "Ruined Human Castle Keep"
 msgstr "荒废的人类城堡主楼"
 
 #. [terrain_type]: id=sunken_keep
-#: data/core/terrain.cfg:2684
+#: data/core/terrain.cfg:2682
 msgid "Sunken Human Castle Keep"
 msgstr "沉陷的人类城堡主楼"
 
 #. [terrain_type]: id=swamp_keep
-#: data/core/terrain.cfg:2697
+#: data/core/terrain.cfg:2695
 msgid "Swamp Human Castle Keep"
 msgstr "沼泽中的人类城堡主楼"
 
 #. [terrain_type]: id=desert_keep
-#: data/core/terrain.cfg:2710
+#: data/core/terrain.cfg:2708
 msgid "Desert Keep"
 msgstr "沙漠主楼"
 
 #. [terrain_type]: id=desert_keep_ruined
-#: data/core/terrain.cfg:2723
+#: data/core/terrain.cfg:2721
 msgid "Ruined Desert Keep"
 msgstr "荒废的沙漠主楼"
 
 #. [terrain_type]: id=merman_campkeep
-#: data/core/terrain.cfg:2736
+#: data/core/terrain.cfg:2734
 msgid "Aquatic Encampment Keep"
 msgstr "水中营地主楼"
 
 #. [terrain_type]: id=troll_campkeep
-#: data/core/terrain.cfg:2749
+#: data/core/terrain.cfg:2747
 msgid "Troll Encampment Keep"
 msgstr "巨魔营地主楼"
 
 #. [terrain_type]: id=merman_castlekeep
-#: data/core/terrain.cfg:2762
+#: data/core/terrain.cfg:2760
 msgid "Aquatic Keep"
 msgstr "水中主楼"
 
 #. [terrain_type]: id=castle_overlay
-#: data/core/terrain.cfg:2777
+#: data/core/terrain.cfg:2775
 msgid "Castle Overlay"
 msgstr "城堡覆盖层"
 
 #. [terrain_type]: id=keep_overlay
-#: data/core/terrain.cfg:2790
+#: data/core/terrain.cfg:2788
 msgid "Keep Overlay"
 msgstr "主楼覆盖层"
 
@@ -1741,31 +1732,31 @@ msgstr "主楼覆盖层"
 #. [terrain_type]: id=plankbridgediag1
 #. [terrain_type]: id=plankbridgediag2
 #. [terrain_type]: id=plankbridge
-#: data/core/terrain.cfg:2808 data/core/terrain.cfg:2823
-#: data/core/terrain.cfg:2836 data/core/terrain.cfg:2849
-#: data/core/terrain.cfg:2861 data/core/terrain.cfg:2874
-#: data/core/terrain.cfg:2889 data/core/terrain.cfg:2901
-#: data/core/terrain.cfg:2914 data/core/terrain.cfg:2929
-#: data/core/terrain.cfg:2941 data/core/terrain.cfg:2954
-#: data/core/terrain.cfg:2969 data/core/terrain.cfg:2981
-#: data/core/terrain.cfg:2995 data/core/terrain.cfg:3012
-#: data/core/terrain.cfg:3026 data/core/terrain.cfg:3040
-#: data/core/terrain.cfg:3054 data/core/terrain.cfg:3068
-#: data/core/terrain.cfg:3082 data/core/terrain.cfg:3096
-#: data/core/terrain.cfg:3110 data/core/terrain.cfg:3124
+#: data/core/terrain.cfg:2806 data/core/terrain.cfg:2821
+#: data/core/terrain.cfg:2834 data/core/terrain.cfg:2847
+#: data/core/terrain.cfg:2859 data/core/terrain.cfg:2872
+#: data/core/terrain.cfg:2887 data/core/terrain.cfg:2899
+#: data/core/terrain.cfg:2912 data/core/terrain.cfg:2927
+#: data/core/terrain.cfg:2939 data/core/terrain.cfg:2952
+#: data/core/terrain.cfg:2967 data/core/terrain.cfg:2979
+#: data/core/terrain.cfg:2993 data/core/terrain.cfg:3010
+#: data/core/terrain.cfg:3024 data/core/terrain.cfg:3038
+#: data/core/terrain.cfg:3052 data/core/terrain.cfg:3066
+#: data/core/terrain.cfg:3080 data/core/terrain.cfg:3094
+#: data/core/terrain.cfg:3108 data/core/terrain.cfg:3122
 msgid "Bridge"
 msgstr "桥梁"
 
 #. [terrain_type]: id=bridge
 #. [terrain_type]: id=bridgediag1
 #. [terrain_type]: id=bridgediag2
-#: data/core/terrain.cfg:2809 data/core/terrain.cfg:2824
-#: data/core/terrain.cfg:2837
+#: data/core/terrain.cfg:2807 data/core/terrain.cfg:2822
+#: data/core/terrain.cfg:2835
 msgid "Wooden Bridge"
 msgstr "木桥"
 
 #. [terrain_type]: id=bridge
-#: data/core/terrain.cfg:2815
+#: data/core/terrain.cfg:2813
 msgid ""
 "To those capable of building one, the ability to lay a "
 "<italic>text='bridge'</italic> offers a liberation from the fickle nature of "
@@ -1790,106 +1781,98 @@ msgstr ""
 #. [terrain_type]: id=rotbridge
 #. [terrain_type]: id=rotbridgediag1
 #. [terrain_type]: id=rotbridgediag2
-#: data/core/terrain.cfg:2850 data/core/terrain.cfg:2862
-#: data/core/terrain.cfg:2875
+#: data/core/terrain.cfg:2848 data/core/terrain.cfg:2860
+#: data/core/terrain.cfg:2873
 msgid "Rotting Bridge"
 msgstr "腐坏中的村庄"
 
 #. [terrain_type]: id=stone_bridge
 #. [terrain_type]: id=stone_bridgediag1
 #. [terrain_type]: id=stone_bridgediag2
-#: data/core/terrain.cfg:2890 data/core/terrain.cfg:2902
-#: data/core/terrain.cfg:2915
+#: data/core/terrain.cfg:2888 data/core/terrain.cfg:2900
+#: data/core/terrain.cfg:2913
 msgid "Basic Stone Bridge"
 msgstr "基本石桥"
 
 #. [terrain_type]: id=snow_stone_bridge
 #. [terrain_type]: id=snow_stone_bridgediag1
 #. [terrain_type]: id=snow_stone_bridgediag2
-#: data/core/terrain.cfg:2930 data/core/terrain.cfg:2942
-#: data/core/terrain.cfg:2955
+#: data/core/terrain.cfg:2928 data/core/terrain.cfg:2940
+#: data/core/terrain.cfg:2953
 msgid "Snowy Stone Bridge"
 msgstr "雪中石桥"
 
 #. [terrain_type]: id=bridgechasm
 #. [terrain_type]: id=bridgechasmdiag1
 #. [terrain_type]: id=bridgechasmdiag2
-#: data/core/terrain.cfg:2970 data/core/terrain.cfg:2982
-#: data/core/terrain.cfg:2996
+#: data/core/terrain.cfg:2968 data/core/terrain.cfg:2980
+#: data/core/terrain.cfg:2994
 msgid "Cave Chasm Bridge"
 msgstr "洞穴裂隙上的桥"
 
 #. [terrain_type]: id=hangingbridgediag1
 #. [terrain_type]: id=hangingbridgediag2
 #. [terrain_type]: id=hangingbridge
-#: data/core/terrain.cfg:3013 data/core/terrain.cfg:3027
-#: data/core/terrain.cfg:3041
+#: data/core/terrain.cfg:3011 data/core/terrain.cfg:3025
+#: data/core/terrain.cfg:3039
 msgid "Hanging Bridge"
 msgstr "吊桥"
 
 #. [terrain_type]: id=stonechasmbridgediag1
 #. [terrain_type]: id=stonechasmbridgediag2
 #. [terrain_type]: id=stonechasmbridge
-#: data/core/terrain.cfg:3055 data/core/terrain.cfg:3069
-#: data/core/terrain.cfg:3083
+#: data/core/terrain.cfg:3053 data/core/terrain.cfg:3067
+#: data/core/terrain.cfg:3081
 msgid "Stone Chasm Bridge"
 msgstr "石头裂隙上的桥"
 
 #. [terrain_type]: id=plankbridgediag1
 #. [terrain_type]: id=plankbridgediag2
 #. [terrain_type]: id=plankbridge
-#: data/core/terrain.cfg:3097 data/core/terrain.cfg:3111
-#: data/core/terrain.cfg:3125
+#: data/core/terrain.cfg:3095 data/core/terrain.cfg:3109
+#: data/core/terrain.cfg:3123
 msgid "Plank Bridge"
 msgstr "平板桥"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=mark_high
-#: data/core/terrain.cfg:3140
-#, fuzzy
+#: data/core/terrain.cfg:3138
 msgid "Marker High"
-msgstr "马克高"
+msgstr "高点标记"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=mark_high2
-#: data/core/terrain.cfg:3150
-#, fuzzy
+#: data/core/terrain.cfg:3148
 msgid "Marker High 2"
-msgstr "马克高2"
+msgstr "高点标记 2"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=mark_low
-#: data/core/terrain.cfg:3160
-#, fuzzy
+#: data/core/terrain.cfg:3158
 msgid "Marker Low"
-msgstr "标记位为低"
+msgstr "低点标记"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [terrain_type]: id=mark_low2
-#: data/core/terrain.cfg:3170
-#, fuzzy
+#: data/core/terrain.cfg:3168
 msgid "Marker Low 2"
-msgstr "标记低2"
+msgstr "低点标记 2"
 
 #. [terrain_type]: id=off_map
-#: data/core/terrain.cfg:3182
+#: data/core/terrain.cfg:3180
 msgid "Off Map"
 msgstr "地图外"
 
 #. [terrain_type]: id=off_map2
-#: data/core/terrain.cfg:3192
+#: data/core/terrain.cfg:3190
 msgid "Fake Map Border"
 msgstr "伪地图边缘"
 
 #. [terrain_type]: id=overlay_artplaceholder
-#: data/core/terrain.cfg:3202
+#: data/core/terrain.cfg:3200
 msgid "Art Placeholder"
-msgstr "艺术占位符"
+msgstr "素材占位标记"
 
 #. [terrain_type]: id=shroud
 #. [toggle_button]: id=shroud
 #. [toggle_button]: id=sort_7
-#: data/core/terrain.cfg:3214
+#: data/core/terrain.cfg:3212
 #: data/gui/themes/default/dialogs/editor_edit_side.cfg:206
 #: data/gui/themes/default/dialogs/game_stats.cfg:384
 #: data/gui/themes/default/dialogs/mp_create_game.cfg:390
@@ -1897,24 +1880,24 @@ msgid "Shroud"
 msgstr "战场黑幕"
 
 #. [terrain_type]: id=fake_shroud_overlay
-#: data/core/terrain.cfg:3225
+#: data/core/terrain.cfg:3223
 msgid "Fake Shroud"
 msgstr "虚假黑幕"
 
 #. [terrain_type]: id=fog
 #. [toggle_button]: id=sort_6
-#: data/core/terrain.cfg:3236
+#: data/core/terrain.cfg:3234
 #: data/gui/themes/default/dialogs/game_stats.cfg:370
 msgid "Fog"
 msgstr "战争迷雾"
 
 #. [terrain_type]: id=fungus
-#: data/core/terrain.cfg:3251 data/core/terrain.cfg:3252
+#: data/core/terrain.cfg:3249 data/core/terrain.cfg:3250
 msgid "Fungus"
 msgstr "真菌"
 
 #. [terrain_type]: id=fungus
-#: data/core/terrain.cfg:3255
+#: data/core/terrain.cfg:3253
 msgid ""
 "<italic>text='Mushroom groves'</italic> are vast underground forests of "
 "giant mushrooms, which thrive in the damp darkness. Most units have trouble "
@@ -1934,7 +1917,7 @@ msgstr ""
 "大多数单位在蘑菇林中获得50%到60%的防御率，而骑兵只能获得20%。"
 
 #. [terrain_type]: id=cave
-#: data/core/terrain.cfg:3266
+#: data/core/terrain.cfg:3264
 msgid ""
 "<italic>text='Cave'</italic> terrain represents any underground cavern with "
 "enough room for a unit to pass.\n"
@@ -1966,7 +1949,7 @@ msgstr ""
 "大多数单位在洞穴中可获得20%到40%的防御率，而矮人则拥有50%。"
 
 #. [terrain_type]: id=reef
-#: data/core/terrain.cfg:3296
+#: data/core/terrain.cfg:3294
 msgid ""
 "<italic>text='Coastal reefs'</italic> are shallows formed by stone, coral "
 "and sand.\n"
@@ -1983,7 +1966,7 @@ msgstr ""
 "人鱼和娜迦在礁石上都能获得70%的防御率。"
 
 #. [terrain_type]: id=hills
-#: data/core/terrain.cfg:3310
+#: data/core/terrain.cfg:3308
 msgid ""
 "<italic>text='Hills'</italic> represent any reasonably rough terrain, with "
 "enough dips and rises in the ground to provide some cover. Hills are "
@@ -2004,7 +1987,7 @@ msgstr ""
 "的防御率。"
 
 #. [terrain_type]: id=swamp_water
-#: data/core/terrain.cfg:3324
+#: data/core/terrain.cfg:3322
 msgid ""
 "<italic>text='Swamps'</italic> represent any sort of wetlands.\n"
 "Swamps slow down nearly everyone, and inhibit their ability to defend "
@@ -2025,7 +2008,7 @@ msgstr ""
 "率。"
 
 #. [terrain_type]: id=shallow_water
-#: data/core/terrain.cfg:3337
+#: data/core/terrain.cfg:3335
 msgid ""
 "<italic>text='Shallow water'</italic> represents any body of water deep "
 "enough to come up to roughly a man’s waist. This is enough to slow down "
@@ -2047,7 +2030,7 @@ msgstr ""
 "大多数单位在浅水中只拥有20%到30%的防御率，而人鱼和娜迦都可以享有60%。"
 
 #. [terrain_type]: id=castle
-#: data/core/terrain.cfg:3352
+#: data/core/terrain.cfg:3350
 msgid ""
 "<italic>text='Castles'</italic> are any sort of permanent fortification.\n"
 "Nearly all units receive a considerable bonus to their defense by being "
@@ -2066,7 +2049,7 @@ msgstr ""
 "大多数单位在城堡中拥有大约60%的防御率。"
 
 #. [terrain_type]: id=mountains
-#: data/core/terrain.cfg:3366
+#: data/core/terrain.cfg:3364
 msgid ""
 "<italic>text='Mountains'</italic> are steep enough that units often have to "
 "climb over obstacles to move.\n"
@@ -2090,7 +2073,7 @@ msgstr ""
 "大多数单位在山岭中拥有60%的防御率，而矮人则享受到70%。"
 
 #. [terrain_type]: id=deep_water
-#: data/core/terrain.cfg:3378
+#: data/core/terrain.cfg:3376
 msgid ""
 "<italic>text='Deep water'</italic> represents any body of water deep enough "
 "to cover a man’s head.\n"
@@ -2105,12 +2088,12 @@ msgstr ""
 "人鱼和娜迦在深水中都能获得50%的防御率，并且能够全速移动。"
 
 #. [terrain_type]: id=flat
-#: data/core/terrain.cfg:3389 data/core/terrain.cfg:3390
+#: data/core/terrain.cfg:3387 data/core/terrain.cfg:3388
 msgid "Flat"
 msgstr "平原"
 
 #. [terrain_type]: id=flat
-#: data/core/terrain.cfg:3391
+#: data/core/terrain.cfg:3389
 msgid ""
 "<italic>text='Grassland'</italic> represents open plains, whether "
 "cultivated, cut back for grazing, or wild.\n"
@@ -2129,7 +2112,7 @@ msgstr ""
 "大多数单位在草原上拥有30%到40%的防御率。"
 
 #. [terrain_type]: id=forest
-#: data/core/terrain.cfg:3404
+#: data/core/terrain.cfg:3402
 msgid ""
 "<italic>text='Forests'</italic> represent any woodland with significant "
 "undergrowth, enough to hinder passage. Though they slow nearly everyone "
@@ -2158,12 +2141,12 @@ msgstr ""
 "御率。"
 
 #. [terrain_type]: id=frozen
-#: data/core/terrain.cfg:3414 data/core/terrain.cfg:3415
+#: data/core/terrain.cfg:3412 data/core/terrain.cfg:3413
 msgid "Frozen"
 msgstr "冻原"
 
 #. [terrain_type]: id=frozen
-#: data/core/terrain.cfg:3417
+#: data/core/terrain.cfg:3415
 msgid ""
 "<italic>text='Frozen'</italic> terrain represents any flat area that is "
 "covered by snow or ice.\n"
@@ -2180,7 +2163,7 @@ msgstr ""
 "大多数单位在冻原上拥有20%到40%的防御率。"
 
 #. [terrain_type]: id=village
-#: data/core/terrain.cfg:3430
+#: data/core/terrain.cfg:3428
 msgid ""
 "<italic>text='Villages'</italic> represent any group of buildings, human or "
 "otherwise.\n"
@@ -2201,12 +2184,12 @@ msgstr ""
 "大多数单位在村庄里拥有50%或者60%的防御率，但是骑兵只能获得40%。"
 
 #. [terrain_type]: id=impassable
-#: data/core/terrain.cfg:3440 data/core/terrain.cfg:3441
+#: data/core/terrain.cfg:3438 data/core/terrain.cfg:3439
 msgid "Impassable"
 msgstr "不可通过地形"
 
 #. [terrain_type]: id=impassable
-#: data/core/terrain.cfg:3443
+#: data/core/terrain.cfg:3441
 msgid ""
 "Obstacles that not even the most determined traveler may overcome include "
 "solid walls of stone and mountains so tall and steep that they are "
@@ -2219,12 +2202,12 @@ msgstr ""
 "魔也无法砸开。"
 
 #. [terrain_type]: id=unwalkable
-#: data/core/terrain.cfg:3450 data/core/terrain.cfg:3451
+#: data/core/terrain.cfg:3448 data/core/terrain.cfg:3449
 msgid "Unwalkable"
 msgstr "不可步行地形"
 
 #. [terrain_type]: id=unwalkable
-#: data/core/terrain.cfg:3453
+#: data/core/terrain.cfg:3451
 msgid ""
 "<italic>text='Unwalkable terrain'</italic> covers any chasm or gorge which, "
 "as the name implies, cannot be crossed simply by walking. Chasms are noted "
@@ -2236,12 +2219,12 @@ msgstr ""
 "逻辑而言，只有能够飞行的单位才能够通过此地形。"
 
 #. [terrain_type]: id=rails
-#: data/core/terrain.cfg:3460 data/core/terrain.cfg:3461
+#: data/core/terrain.cfg:3458 data/core/terrain.cfg:3459
 msgid "Rails"
 msgstr "轨道"
 
 #. [terrain_type]: id=rails
-#: data/core/terrain.cfg:3463
+#: data/core/terrain.cfg:3461
 msgid ""
 "<italic>text='Rails'</italic> are used to transport ore, mostly by dwarves."
 msgstr "<bold>text='轨道'</bold> 用于运输矿石，大多数时候是矮人在使用。"
@@ -2251,9 +2234,9 @@ msgstr "<bold>text='轨道'</bold> 用于运输矿石，大多数时候是矮人
 #. [terrain_type]: id=rug_floor_deprecated
 #. [terrain_type]: id=rug2_floor_deprecated
 #. [terrain_type]: id=old_wood_floor_deprecated
-#: data/core/terrain.cfg:3476 data/core/terrain.cfg:3487
-#: data/core/terrain.cfg:3498 data/core/terrain.cfg:3509
-#: data/core/terrain.cfg:3520
+#: data/core/terrain.cfg:3474 data/core/terrain.cfg:3485
+#: data/core/terrain.cfg:3496 data/core/terrain.cfg:3507
+#: data/core/terrain.cfg:3518
 msgid "Deprecated"
 msgstr "已弃用"
 
@@ -2293,7 +2276,7 @@ msgid "Players"
 msgstr "玩家"
 
 #. [settings]
-#: data/gui/themes/celes/_main.cfg:25 data/gui/themes/default/_main.cfg:23
+#: data/gui/themes/celes/_main.cfg:27 data/gui/themes/default/_main.cfg:25
 msgid " (Press ‘$hotkey’ for more information)"
 msgstr "（按”$hotkey|”以查看更多信息）"
 
@@ -2347,7 +2330,7 @@ msgstr "关于"
 #: data/gui/themes/celes/dialogs/title_screen.cfg:230
 #: data/gui/themes/default/dialogs/title_screen.cfg:473
 msgid "General information about Battle for Wesnoth"
-msgstr "关于韦诺之战的通用信息"
+msgstr "韦诺之战的基本信息"
 
 #. [button]: id=language
 #. [label]
@@ -2401,7 +2384,7 @@ msgstr "玩多人游戏（热座、局域网或因特网游戏），或者玩与
 #. [button]: id=load_movetype
 #. [button]: id=ok
 #: data/gui/themes/celes/dialogs/title_screen.cfg:288
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:894
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:900
 #: data/gui/themes/default/dialogs/game_load.cfg:638
 #: data/gui/themes/default/dialogs/title_screen.cfg:258
 msgid "Load"
@@ -2455,7 +2438,7 @@ msgstr "启动地图编辑器"
 #. [grid]
 #. [tab]
 #: data/gui/themes/celes/dialogs/title_screen.cfg:295
-#: data/gui/themes/default/dialogs/game_version.cfg:903
+#: data/gui/themes/default/dialogs/game_version.cfg:911
 #: data/gui/themes/default/dialogs/title_screen.cfg:262
 msgid "Community"
 msgstr "社区"
@@ -2494,7 +2477,7 @@ msgstr "帮助"
 #. [grid]
 #: data/gui/themes/celes/dialogs/title_screen.cfg:297
 msgid "Visit the in-game help"
-msgstr "访问游戏中的帮助"
+msgstr "浏览游戏内帮助"
 
 #. [grid]
 #. [button]: id=cancel
@@ -2528,7 +2511,7 @@ msgstr "复制"
 #. The heavy checkmark character is available in the DejaVu Sans font, but not in the default Lato font
 #: data/gui/themes/celes/widgets/button_success.cfg:269
 msgid "page^<b><span font_family='DejaVu Sans'>✔</span> Copied</b>"
-msgstr "page^<b><span font_family='DejaVu Sans'>✔</span> 已复制</b>"
+msgstr "<b><span font_family='DejaVu Sans'>✔</span> 已复制</b>"
 
 #. [button]: id=click_dismiss
 #. [button]: id=ok
@@ -2536,12 +2519,12 @@ msgstr "page^<b><span font_family='DejaVu Sans'>✔</span> 已复制</b>"
 #. [button]: id=close_window
 #: data/gui/themes/celes/widgets/window_default.cfg:57
 #: data/gui/themes/default/dialogs/achievements_dialog.cfg:307
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:302
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:306
 #: data/gui/themes/default/dialogs/chat_log.cfg:201
 #: data/gui/themes/default/dialogs/end_credits.cfg:145
 #: data/gui/themes/default/dialogs/game_cache_options.cfg:247
 #: data/gui/themes/default/dialogs/game_stats.cfg:843
-#: data/gui/themes/default/dialogs/game_version.cfg:991
+#: data/gui/themes/default/dialogs/game_version.cfg:999
 #: data/gui/themes/default/dialogs/gamestate_inspector.cfg:398
 #: data/gui/themes/default/dialogs/generator_settings.cfg:190
 #: data/gui/themes/default/dialogs/help_browser.cfg:295
@@ -2591,7 +2574,7 @@ msgstr "在本地保存密码（明文）"
 #. [button]: id=ok
 #: data/gui/themes/default/dialogs/addon_auth.cfg:159
 #: data/gui/themes/default/dialogs/addon_server_info.cfg:168
-#: data/gui/themes/default/dialogs/custom_tod.cfg:511
+#: data/gui/themes/default/dialogs/custom_tod.cfg:521
 #: data/gui/themes/default/dialogs/depcheck_select_new.cfg:151
 #: data/gui/themes/default/dialogs/edit_label.cfg:139
 #: data/gui/themes/default/dialogs/edit_text.cfg:116
@@ -2600,7 +2583,7 @@ msgstr "在本地保存密码（明文）"
 #: data/gui/themes/default/dialogs/editor_edit_pbl_translation.cfg:125
 #: data/gui/themes/default/dialogs/editor_edit_scenario.cfg:287
 #: data/gui/themes/default/dialogs/editor_edit_side.cfg:469
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1245
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1251
 #: data/gui/themes/default/dialogs/file_dialog.cfg:504
 #: data/gui/themes/default/dialogs/folder_create.cfg:119
 #: data/gui/themes/default/dialogs/label_settings.cfg:137
@@ -2634,10 +2617,10 @@ msgstr "确定"
 #: data/gui/themes/default/dialogs/addon_connect.cfg:206
 #: data/gui/themes/default/dialogs/addon_license_prompt.cfg:113
 #: data/gui/themes/default/dialogs/addon_uninstall_list.cfg:170
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:624
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:626
 #: data/gui/themes/default/dialogs/campaign_difficulty.cfg:234
 #: data/gui/themes/default/dialogs/core_dialog.cfg:241
-#: data/gui/themes/default/dialogs/custom_tod.cfg:524
+#: data/gui/themes/default/dialogs/custom_tod.cfg:534
 #: data/gui/themes/default/dialogs/depcheck_select_new.cfg:165
 #: data/gui/themes/default/dialogs/edit_label.cfg:153
 #: data/gui/themes/default/dialogs/edit_text.cfg:130
@@ -2647,7 +2630,7 @@ msgstr "确定"
 #: data/gui/themes/default/dialogs/editor_edit_pbl_translation.cfg:137
 #: data/gui/themes/default/dialogs/editor_edit_scenario.cfg:301
 #: data/gui/themes/default/dialogs/editor_edit_side.cfg:481
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1258
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1264
 #: data/gui/themes/default/dialogs/editor_generate_map.cfg:214
 #: data/gui/themes/default/dialogs/editor_new_map.cfg:126
 #: data/gui/themes/default/dialogs/editor_resize_map.cfg:282
@@ -2744,7 +2727,7 @@ msgstr "游戏与服务器之间的通信是加密的"
 #: data/gui/themes/default/dialogs/addon_manager.cfg:162
 #: data/gui/themes/default/dialogs/addon_manager.cfg:817
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:210
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:708
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:714
 msgid "Type:"
 msgstr "类型："
 
@@ -2926,22 +2909,20 @@ msgstr "退出"
 msgid "Add-on download count by version"
 msgstr "按版本划分的附加组件下载量"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [button]: id=addon_count_by_forum_auth
 #: data/gui/themes/default/dialogs/addon_server_info.cfg:77
-#, fuzzy
 msgid "Count of add-ons using forum_auth"
-msgstr "使用forum_auth的插件数量"
+msgstr "使用forum_auth的附加组件数量"
 
 #. [button]: id=admin_delete_addon
 #: data/gui/themes/default/dialogs/addon_server_info.cfg:95
 msgid "Delete selected add-on (admin)"
-msgstr "删除选定的附加组件（管理员）"
+msgstr "删除选中的附加组件（管理员）"
 
 #. [button]: id=admin_hide_addon
 #: data/gui/themes/default/dialogs/addon_server_info.cfg:113
 msgid "Hide selected add-on (admin)"
-msgstr "隐藏选定的附加组件（管理员）"
+msgstr "隐藏选中的附加组件（管理员）"
 
 #. [button]: id=admin_unhide_addon
 #: data/gui/themes/default/dialogs/addon_server_info.cfg:131
@@ -2966,69 +2947,69 @@ msgid "Remove"
 msgstr "移除"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:82
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:86
 msgid "Base damage"
 msgstr "基础伤害"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:84
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:88
 msgid "Time of day modifier"
 msgstr "时段修正"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:85
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:89
 msgid "Leadership bonus"
 msgstr "领导力加成"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:86
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:90
 msgid "Slowed penalty"
 msgstr "减速惩罚"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:90
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:94
 msgid "Total damage"
 msgstr "总伤害"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:94
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:98
 msgid "Chance to hit"
 msgstr "命中率"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:95
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:99
 msgid "Chance of being unscathed"
 msgstr "毫发无伤率"
 
 #. [label]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:184
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:188
 msgid "Expected Battle Result (HP)"
 msgstr "期望战斗结果（HP）"
 
 #. [label]: id=title
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:247
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:251
 msgid "Damage Calculations"
 msgstr "伤害计算"
 
 #. [column]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:270
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:274
 msgid "Attacker"
 msgstr "进攻方"
 
 #. [column]
-#: data/gui/themes/default/dialogs/attack_predictions.cfg:280
+#: data/gui/themes/default/dialogs/attack_predictions.cfg:284
 msgid "Defender"
 msgstr "防守方"
 
 #. [label]
 #. The campaign_landing^ strings are shown in the right-hand panel when the campaign menu is opened.
 #. This one is the page title, shown in bold.
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:205
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:207
 msgid "campaign_landing^Welcome to Wesnoth v1.20"
-msgstr "campaign_landing^欢迎来到韦诺之战 v1.20"
+msgstr "欢迎来到韦诺之战v1.20"
 
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:207
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:209
 msgid ""
 "campaign_landing^<b>If you’re new to Wesnoth</b>, the opening story arc "
 "starts with <span color='#e1e119' style='italic'>The South Guard</span> and "
@@ -3037,40 +3018,32 @@ msgid ""
 "style='italic'>Heir to the Throne</span>. The intended way to learn both the "
 "story and the game mechanics is to play the campaigns in that order."
 msgstr ""
-"campaign_landing^<b>如果你是韦诺新手</b>，游戏的开场故事线从<span "
-"color='#e1e119' style='italic'>南疆卫队</span>开始，随后按照左侧列出的顺序依"
-"次进行各项战役任务，最终在半个世纪后以<span color='#e1e119' style='italic'>王"
-"座继承人</span>作为结局。建议按照这个顺序来体验这些战役，以学习故事与游戏机"
-"制。"
+"<b>如果你是韦诺新手</b>，游戏的开场故事线从<span color='#e1e119' "
+"style='bold'>南疆卫队</span>开始，随后按照左侧列出的战役顺序发展，最终在半个"
+"世纪后以<span color='#e1e119' style='bold'>王座继承人</span>为结局。建议按照"
+"这个顺序来体验这些战役，以了解故事与游戏机制。"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:209
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:211
 msgid ""
 "campaign_landing^<b>If you’re a returning player</b>, you’ll notice a number "
 "of changes since v1.18:"
-msgstr ""
-"campaign_landing^<b>如果你是回归玩家</b>，会发现从v1.18版本之后有很多变化："
+msgstr "<b>如果你是回归玩家</b>，会发现在v1.18之后有一些变化："
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:211
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:213
 msgid ""
 "campaign_landing^<span color='#e1e119' style='italic'>Heir to the Throne</"
 "span> now features an open world with 33 branching scenarios, each awarding "
 "Konrad unique recruits, companions, or items. The original campaign is still "
 "available as <i>Heir to the Throne, Classic</i>."
 msgstr ""
-"《王位继承者》现在拥有一个开放世界，其中包含33条分支剧情线，每条剧情线都会为"
-"康拉德提供不同的新成员、同伴或物品。原版剧情仍以《王位继承者：经典版》的形式"
-"提供。"
+"<span color='#e1e119' style='bold'>王座继承人</span>现在拥有一个开放世界，其"
+"中包含33个分支场景，每个分支场景都会为科纳德提供不同的征募选项、同伴或物品。"
+"原版战役则以<b>王座继承人经典版</b>的名义继续提供。"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:213
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:215
 msgid ""
 "campaign_landing^<span color='#e1e119' style='italic'>The Deceiver’s Gambit</"
 "span> replaces <i>Delfador’s Memoirs</i>. Follow a young mage from the "
@@ -3078,38 +3051,35 @@ msgid ""
 "orcs of the north. Choose between 23 magic spells as you bear witness to the "
 "rise of a tyrant."
 msgstr ""
-"活动名称为<span color='#e1e119' style='italic'>骗子的阴谋</span>，它将取代游"
-"戏中的<i>德尔法多的回忆录</i>。跟随这位年轻的法师，从阿尔杜因的海岸出发，一路"
-"进入国王的宫殿，共同对抗北方那些凶残的兽人。在见证一个暴君崛起的过程中，你可"
-"以从23种魔法咒语中选择使用。"
+"<span color='#e1e119' style='bold'>欺诈师的赌局</span>取代了游戏中的<b>德法多"
+"回忆录</b>。跟随一位年轻的法师，从安度云的海岸出发，一路进入国王的宫殿，共同"
+"对抗北方那些凶残的兽人。在见证暴君崛起的过程中，你可以从23种魔法咒语中选择使"
+"用。"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:215
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:217
 msgid ""
 "campaign_landing^<span color='#e1e119' style='italic'>Dusk of Dawn</span> is "
 "our first troll campaign. Lead the Golden Flame Tribe out from the bowels of "
 "Irdya and up to the surface world — but beware what awaits you there."
 msgstr ""
-"“黎明黄昏”战役是我们首次推出的巨魔题材战役。带领金焰部落从伊尔迪亚的深处走向"
-"地表世界吧——但请务必提防那里等待你们的危险。"
+"<span color='#e1e119' style='bold'>破晓之暮</span>是我们首个巨魔战役。带领金"
+"焰部落从伊迪亚的深处走上地表世界吧——但请务必提防在地表等待你们的东西。"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:217
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:219
 msgid ""
 "campaign_landing^<span color='#e1e119' style='italic'>Of Pearls and Pirates</"
 "span> is a new beginner-oriented campaign set in a sleepy fishing town on "
 "the Bay of Pearls. When corsairs strike, the villagers must join forces with "
 "the local merfolk and take the fight to the pirates."
 msgstr ""
-"“珍珠与海盗”的新手导向战役设定在珍珠湾一个宁静的渔镇。当海盗来袭时，村民们必"
-"须与当地的海洋生物联手，共同对抗这些掠夺者。"
+"<span color='#e1e119' style='bold'>珍珠与海盗</span>是新的新手导向战役，设定"
+"在珍珠湾上一个宁静的渔镇。当海盗来袭时，村民们必须与当地的海洋生物联手，共同"
+"对抗这些掠夺者。"
 
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:219
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:221
 msgid ""
 "campaign_landing^<span color='#e1e119' style='italic'>The South Guard</span> "
 "has been significantly revised, and now replaces the classic <i>Battle "
@@ -3117,26 +3087,24 @@ msgid ""
 "original tutorial is still available as part of <i>Heir to the Throne, "
 "Classic</i>."
 msgstr ""
-"campaign_landing^<span color='#e1e119' style='italic'>南疆卫队</span>已经进行"
-"了大幅修改，现在取代了传统<i>战斗训练</i>教程。对于那些怀念德法多指导的玩家来"
-"说，原始教程仍然以<i>王座继承人（经典版）</i>的一部分存在。"
+"<span color='#e1e119' style='bold'>南疆卫队</span>已大幅修改，现已取代了经典"
+"的<b>战斗训练</b>教程。对于那些怀念德法多指导的玩家来说，原始教程仍然作为<b>"
+"王座继承人经典版</b>的一部分存在。"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:221
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:223
 msgid ""
 "campaign_landing^<span color='#e1e119' style='italic'>The Hammer of "
 "Thursagan</span> has been enhanced with story adjustments, improved enemy "
 "AI, a new Thunderer advancement, a redesign of <i>High Pass</i>, and the re-"
 "addition of the formerly removed <i>Mages and Drakes</i>."
 msgstr ""
-"campaign_landing^<span color='#e1e119' style='italic'>索萨根之锤</span>经过了"
-"剧情调整、敌人AI的优化、新增的雷霆者升级系统、<i>高岭通道</i>的重设计，以及被"
-"移除后又重新加入的<i>法师与巨龙</i>内容，从而得到了全面升级。"
+"<span color='#e1e119' style='bold'>瑟萨冈之锤</span>有以下增强：剧情调整、敌"
+"方AI优化、新增一种雷霆卫士升级、<b>高岭通道</b>重新设计，以及被移除后又重新加"
+"入的<b>法师与龙人</b>。"
 
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:223
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:225
 msgid ""
 "campaign_landing^<span color='#e1e119' style='italic'>Winds of Fate</span> "
 "has been rebalanced with much lower recall costs, redesigned wildlife "
@@ -3144,24 +3112,21 @@ msgid ""
 "and dialogue sequences were changed for better continuity with other "
 "campaigns."
 msgstr ""
-"campaign_landing^<span color='#e1e119' style='italic'>命运之风</span>已进行了"
-"平衡性调整：召回成本大幅降低，野生动物生成机制及 AI 也得到了重新设计，还有更"
-"大的战役中期战斗规模。此外，部分角色设定与对话内容也进行了调整，以便与其他战"
-"役保持更好的连贯性。"
+"<span color='#e1e119' style='bold'>命运之风</span>已调整了平衡性：召回成本大"
+"幅降低，野生动物生成机制及AI也已重新设计，战役中期战斗规模则变得更大。部分角"
+"色与对话内容也进行了调整，以便与其他战役保持更好的连贯性。"
 
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:225
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:227
 msgid ""
 "campaign_landing^For a full list of changes, consult our official changelog "
 "at https://www.wesnoth.org/start/1.20/"
 msgstr ""
-"campaign_landing^如需查看完整的变更列表，请访问我们的官方变更日志：https://"
-"www.wesnoth.org/start/1.20/"
+"如需查看完整的变更列表，请访问我们的官方变更日志：https://www.wesnoth.org/"
+"start/1.20/"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:246
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:248
 msgid ""
 "In addition to the mainline campaigns, Wesnoth also has an ever-growing list "
 "of add-on content created by other players available via the Add-ons server, "
@@ -3169,14 +3134,14 @@ msgid ""
 "multiplayer maps, additional media and various other content! Be sure to "
 "give it a try!"
 msgstr ""
-"除了主线剧情外，Wesnoth还提供了越来越多由其他玩家创作的附加内容，这些内容可以"
-"通过附加内容服务器获取，其中包括但不仅限于更多的单人及多人剧情模式、多人游戏"
-"地图、额外媒体资料以及各种其他类型的内容！一定要试试看哦！"
+"除了主线剧情外，由其他玩家创作的韦诺附加内容也在不断增加，这些内容可以通过附"
+"加组件服务器获取，其中包括且不限于更多的单人及多人战役、多人游戏地图、额外多"
+"媒体资源以及各种其他类型的内容！一定要试试看！"
 
 #. [label]
 #. "more than 15" gives a little leeway to add or remove one without changing the translatable text.
 #. It's already ambiguous, 1.18 has 19 campaigns, if you include the tutorial and multiplayer-only World Conquest.
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:263
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:265
 msgid ""
 "Wesnoth normally includes more than 15 mainline campaigns, even before "
 "installing any from the add-ons server. If you’ve installed the game via a "
@@ -3192,7 +3157,7 @@ msgstr ""
 #. [label]: id=name
 #. [label]
 #. [toggle_button]: id=unit_name
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:303
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:305
 #: data/gui/themes/default/dialogs/game_load.cfg:170
 #: data/gui/themes/default/dialogs/mp_connect.cfg:159
 #: data/gui/themes/default/dialogs/mp_faction_select.cfg:33
@@ -3203,117 +3168,113 @@ msgid "Name"
 msgstr "名字"
 
 #. [toggle_button]: id=sort_name
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:304
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:306
 msgid "Sort by full campaign name in alphabetical order"
 msgstr "按照战役全名的字母顺序排序"
 
 #. [toggle_button]: id=sort_time
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:315
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:317
 msgid "Timeline"
 msgstr "时间线"
 
 #. [toggle_button]: id=sort_time
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:316
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:318
 msgid "Sort in approximate chronological order of story events"
 msgstr "按照故事事件的大略时间顺序排序"
 
 #. [multimenu_button]: id=filter_completion
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:326
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:328
 msgid "Filter by campaign completion status"
 msgstr "按战役完成状态筛选"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:329
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:331
 msgid "Not Completed"
 msgstr "未完成"
 
 #. [option]
 #. campaigns which the player hasn't beaten, rather than campaigns which the author hasn't finished writing
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:331
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:333
 msgid "Show campaigns not completed by player"
 msgstr "显示玩家尚未完成的战役"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:335
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:337
 msgid "Completed: Bronze"
-msgstr "已完成：铜牌"
+msgstr "已完成：青铜"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:336
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:338
 msgid "Show campaigns completed at easiest difficulty"
 msgstr "显示在最简单难度完成的战役"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:340
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:342
 msgid "Completed: Silver"
-msgstr "已完成：银牌"
+msgstr "已完成：白银"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:341
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:343
 msgid "Show campaigns completed at intermediate difficulties"
 msgstr "显示在中等难度完成的战役"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:345
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:347
 msgid "Completed: Gold"
-msgstr "已完成：金牌"
+msgstr "已完成：黄金"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:346
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:348
 msgid "Show campaigns completed at hardest difficulty"
 msgstr "显示在最高难度完成的战役"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:350
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:352
 msgid "Completed: All"
 msgstr "已完成：全部"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:351
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:353
 msgid "Show completed campaigns"
 msgstr "显示已完成的战役"
 
 #. [label]
 #. [label]: id=mods_header
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:402
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:404
 #: data/gui/themes/default/dialogs/mp_create_game.cfg:209
 msgid "Modifications:"
 msgstr "模组："
 
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:427
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:429
 msgid "Combat:"
 msgstr "战斗："
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:442
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:444
 msgid "Default RNG"
 msgstr "默认的随机数生成器"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:443
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:445
 msgid ""
 "Pure, unbiased randomness; the way Wesnoth is intended to be played.\n"
 "\n"
 "Example: if you strike twice with 50% accuracy, you’re most likely to hit "
 "once and miss once, but might also hit twice or miss twice."
 msgstr ""
-"纯粹的、无偏见的随机性——这正是韦斯诺斯这款游戏应有的玩法方式。  \n"
+"纯粹的、无偏见的随机性——这正是我们希望你游玩韦诺的方式。  \n"
 "\n"
 "例如：如果你以50%的命中率进行两次攻击，那么你很可能会一次命中、一次未命中，但"
 "也有可能两次都命中或两次都未命中。"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:448
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:450
 msgid "Predictable RNG"
 msgstr "可预测的随机数生成器"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:449
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:451
 msgid ""
 "Identical to Default RNG, except loading a saved game will not change the "
 "outcome of an attack.\n"
@@ -3321,23 +3282,18 @@ msgid ""
 "Example: you strike twice and get lucky, hitting both strikes. You then load "
 "an earlier save and make the same attack again. Both strikes will still hit."
 msgstr ""
-"与默认的随机数生成机制完全相同，只不过加载已保存的游戏并不会改变攻击的结"
-"果。\n"
+"与默认的随机数生成器完全相同，只不过加载已保存的游戏并不会改变攻击的结果。\n"
 "\n"
 "例如：你连续发动两次攻击，并且运气很好，两次都命中了目标。之后你加载了一个之"
 "前的保存文件，再次进行同样的攻击，结果两次仍然都会命中目标。"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:454
-#, fuzzy
-#| msgid "Predictable RNG"
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:456
 msgid "Reduced RNG"
-msgstr "可预测的随机数生成器"
+msgstr "随机性降低的随机数生成器"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:455
-#, fuzzy
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:457
 msgid ""
 "Hits and misses are much more consistent. This tends to make small-scale "
 "engagements easier to plan.\n"
@@ -3345,41 +3301,41 @@ msgid ""
 "Example: if you strike three times with 50% accuracy, you will always hit at "
 "least once and miss at least once."
 msgstr ""
-"命中与未命中的情况会更为稳定。这样一来，小型交战就更容易进行规划了。\n"
+"命中与未命中会明显更为稳定。这样一来，小型交战就更容易进行规划了。\n"
 "\n"
 "例如：如果你以50%的命中率发动三次攻击，那么你总会至少命中一次，同时也至少会有"
 "一次未命中。"
 
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:472
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:474
 msgid "Difficulty:"
 msgstr "难度："
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:486
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:488
 msgid "Easy"
 msgstr "简单"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:489
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:491
 msgid "Normal"
 msgstr "普通"
 
 #. [option]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:492
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:494
 msgid "Hard"
 msgstr "困难"
 
 #. [label]
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:549
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:551
 msgid "Play a Campaign"
 msgstr "玩一场战役"
 
 #. [button]: id=proceed
 #. [button]: id=ok
-#: data/gui/themes/default/dialogs/campaign_dialog.cfg:613
+#: data/gui/themes/default/dialogs/campaign_dialog.cfg:615
 #: data/gui/themes/default/dialogs/campaign_difficulty.cfg:221
-#: src/gui/dialogs/campaign_selection.cpp:82
+#: src/gui/dialogs/campaign_selection.cpp:85
 msgid "game^Play"
 msgstr "开始游玩"
 
@@ -3387,7 +3343,7 @@ msgstr "开始游玩"
 #. [slider]: id=enemey_gold_factor
 #. [slider]: id=enemy_gold_factor
 #: data/gui/themes/default/dialogs/campaign_difficulty.cfg:53
-#: data/multiplayer/scenarios/2p_Dark_Forecast.cfg:249
+#: data/multiplayer/scenarios/2p_Dark_Forecast.cfg:248
 #: data/multiplayer/scenarios/2p_Isle_of_Mists.cfg:295
 #: src/gui/dialogs/editor/edit_pbl.cpp:198
 msgid "Difficulty"
@@ -3448,68 +3404,68 @@ msgstr "读取核心"
 #: data/gui/themes/default/dialogs/language_selection.cfg:293
 #: src/gui/dialogs/editor/custom_tod.cpp:172
 #: src/gui/dialogs/editor/edit_unit.cpp:296
-#: src/preferences/preferences.cpp:1342
+#: src/preferences/preferences.cpp:1291
 msgid "Select"
 msgstr "选择"
 
 #. [button]: id=copy_
 #. [button]: id=copy
-#: data/gui/themes/default/dialogs/custom_tod.cfg:53
+#: data/gui/themes/default/dialogs/custom_tod.cfg:57
 #: data/gui/themes/default/dialogs/game_cache_options.cfg:110
-#: data/gui/themes/default/dialogs/game_version.cfg:48
+#: data/gui/themes/default/dialogs/game_version.cfg:54
 #: data/gui/themes/default/dialogs/screenshot_notification.cfg:33
 msgid "filesystem^Copy"
 msgstr "复制"
 
 #. [button]: id=copy_
 #. [button]: id=copy
-#: data/gui/themes/default/dialogs/custom_tod.cfg:54
+#: data/gui/themes/default/dialogs/custom_tod.cfg:58
 #: data/gui/themes/default/dialogs/game_cache_options.cfg:111
-#: data/gui/themes/default/dialogs/game_version.cfg:49
+#: data/gui/themes/default/dialogs/game_version.cfg:55
 #: data/gui/themes/default/dialogs/screenshot_notification.cfg:34
 msgid "Copy this path to clipboard"
 msgstr "将路径复制到剪贴板"
 
 #. [button]: id=browse_
 #. [button]: id=browse
-#: data/gui/themes/default/dialogs/custom_tod.cfg:69
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:112
+#: data/gui/themes/default/dialogs/custom_tod.cfg:75
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:118
 #: data/gui/themes/default/dialogs/game_cache_options.cfg:126
-#: data/gui/themes/default/dialogs/game_version.cfg:64
+#: data/gui/themes/default/dialogs/game_version.cfg:72
 msgid "filesystem^Browse"
 msgstr "浏览"
 
 #. [button]: id=browse_
 #. [button]: id=browse
-#: data/gui/themes/default/dialogs/custom_tod.cfg:70
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:113
+#: data/gui/themes/default/dialogs/custom_tod.cfg:76
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:119
 #: data/gui/themes/default/dialogs/game_cache_options.cfg:127
-#: data/gui/themes/default/dialogs/game_version.cfg:65
+#: data/gui/themes/default/dialogs/game_version.cfg:73
 msgid "Browse this location using a file manager"
 msgstr "使用文件管理器浏览此位置"
 
 #. [button]: id=preview_
-#: data/gui/themes/default/dialogs/custom_tod.cfg:90
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:98
+#: data/gui/themes/default/dialogs/custom_tod.cfg:98
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:102
 msgid "Preview image"
 msgstr "预览图像"
 
 #. [button]: id=preview_
-#: data/gui/themes/default/dialogs/custom_tod.cfg:108
+#: data/gui/themes/default/dialogs/custom_tod.cfg:118
 msgid "Play sound"
 msgstr "播放声音"
 
 #. [label]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:186
+#: data/gui/themes/default/dialogs/custom_tod.cfg:196
 msgid "Edit Time Schedule"
 msgstr "编辑日程表"
 
 #. [label]
 #. [label]: id=id_label
-#: data/gui/themes/default/dialogs/custom_tod.cfg:216
+#: data/gui/themes/default/dialogs/custom_tod.cfg:226
 #: data/gui/themes/default/dialogs/editor_edit_scenario.cfg:106
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:191
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:645
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:197
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:651
 #: data/gui/themes/default/dialogs/folder_create.cfg:72
 #: data/gui/themes/default/dialogs/game_save.cfg:72
 #: data/gui/themes/default/dialogs/game_save_message.cfg:92
@@ -3523,70 +3479,70 @@ msgstr "名字："
 
 #. [label]
 #. [grid]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:244
+#: data/gui/themes/default/dialogs/custom_tod.cfg:254
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:151
 #: data/gui/themes/default/dialogs/editor_edit_pbl_translation.cfg:99
 #: data/gui/themes/default/dialogs/editor_edit_scenario.cfg:140
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:322
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:328
 msgid "Description:"
 msgstr "描述："
 
 #. [label]
 #. [label]: id=id_label
-#: data/gui/themes/default/dialogs/custom_tod.cfg:271
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:144
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:619
+#: data/gui/themes/default/dialogs/custom_tod.cfg:281
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:150
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:625
 #: data/gui/themes/default/dialogs/tod_new_schedule.cfg:46
 msgid "ID:"
 msgstr "ID："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:352
+#: data/gui/themes/default/dialogs/custom_tod.cfg:362
 msgid "Image:"
 msgstr "图片："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:353
+#: data/gui/themes/default/dialogs/custom_tod.cfg:363
 msgid "Mask:"
 msgstr "遮罩："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:354
+#: data/gui/themes/default/dialogs/custom_tod.cfg:364
 msgid "Sound:"
 msgstr "声音："
 
 #. [label]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:383
+#: data/gui/themes/default/dialogs/custom_tod.cfg:393
 msgid "Lawful Bonus:"
 msgstr "守序加成："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:406
+#: data/gui/themes/default/dialogs/custom_tod.cfg:416
 msgid "Red:"
 msgstr "红："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:407
+#: data/gui/themes/default/dialogs/custom_tod.cfg:417
 msgid "Green:"
 msgstr "绿："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/custom_tod.cfg:408
+#: data/gui/themes/default/dialogs/custom_tod.cfg:418
 msgid "Blue:"
 msgstr "蓝："
 
 #. [button]: id=new
-#: data/gui/themes/default/dialogs/custom_tod.cfg:472
+#: data/gui/themes/default/dialogs/custom_tod.cfg:482
 msgid "New ToD"
 msgstr "新建时段"
 
 #. [button]: id=delete
-#: data/gui/themes/default/dialogs/custom_tod.cfg:485
+#: data/gui/themes/default/dialogs/custom_tod.cfg:495
 msgid "Delete ToD"
 msgstr "删除时段"
 
 #. [button]: id=preview_color
-#: data/gui/themes/default/dialogs/custom_tod.cfg:498
+#: data/gui/themes/default/dialogs/custom_tod.cfg:508
 msgid "Preview color changes on map"
 msgstr "预览地图上的颜色更改"
 
@@ -3659,17 +3615,15 @@ msgstr "仅用于团队"
 msgid "Add-on Selection"
 msgstr "附加组件选择"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
 #: data/gui/themes/default/dialogs/editor_choose_addon.cfg:64
-#, fuzzy
 msgid ""
 "Choose an add-on to be associated with the current editor session. If the "
 "New Add-on option is chosen, its ID can be changed via the Change Add-on ID "
 "option."
 msgstr ""
-"选择一个附加组件来关联当前的编辑会话。如果选择了“新建附加组件”选项，可以通过"
-"“更改附加组件ID”选项来修改其ID。"
+"选择一个要与当前编辑器会话关联的附加组件。如果选择了“新建附加组件”选项，则可"
+"以通过“更改附加组件ID”选项修改其ID。"
 
 #. [label]
 #: data/gui/themes/default/dialogs/editor_choose_addon.cfg:162
@@ -3711,12 +3665,10 @@ msgstr "迷雾中可见"
 msgid "Visible in shroud"
 msgstr "黑幕中可见"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]: id=title
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:84
-#, fuzzy
 msgid "Add-on Publishing Setup"
-msgstr "插件发布设置"
+msgstr "附加组件发布设置"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:150
@@ -3728,17 +3680,15 @@ msgstr "游戏中显示的附加组件名称。"
 msgid "Title:"
 msgstr "标题："
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:151
-#, fuzzy
 msgid "The description of the add-on to display in the add-ons manager."
-msgstr "该插件在插件管理器中的显示描述。"
+msgstr "在附加组件管理器中显示的附加组件描述。"
 
 #. [label]: id=icon_label
 #. [grid]: id=grid_atk
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:162
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:661
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:667
 msgid "Icon:"
 msgstr "图标："
 
@@ -3747,14 +3697,12 @@ msgstr "图标："
 msgid "Select an icon file"
 msgstr "选择一个图标文件"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [text_box]: id=icon
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:195
-#, fuzzy
 msgid ""
 "The path to the icon image to display in the add-ons manager. Must be an "
 "image from mainline."
-msgstr "这是用于在插件管理器中显示的图标图像的路径。该图像必须来自主线版本。"
+msgstr "要在附加组件管理器中显示的图标图片路径。该图片必须来自主线。"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:206
@@ -3773,31 +3721,27 @@ msgstr "此附加组件的作者。如果使用了论坛身份认证，这就是
 msgid "The add-on’s current version. This should be of the form X.Y.Z."
 msgstr "附加组件的当前版本。它的形式应当为 X.Y.Z."
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:208
-#, fuzzy
 msgid ""
 "A comma delimited list of the IDs of any other add-ons that this add-on "
 "depends on. The add-on ID is the folder name in your operating system’s file "
 "manager, not the add-on’s name."
 msgstr ""
-"以逗号分隔的列表，列出了该插件所依赖的其他插件的ID。这里的插件ID指的是您操作"
-"系统文件管理器中对应的文件夹名称，而非插件的名称本身。"
+"以逗号分隔的列表，其中包含该附加组件所依赖的其他附加组件的ID。附加组件ID是指"
+"您操作系统文件管理器中的文件夹名称，而非附加组件的名称。"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:211
 msgid "Forum thread:"
 msgstr "论坛帖子："
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:211
-#, fuzzy
 msgid ""
 "The numeric topic ID of a thread on the Wesnoth forums where players can "
 "post feedback."
-msgstr "这是Wesnoth论坛上一个供玩家发布反馈的帖子的数字主题ID。"
+msgstr "韦诺论坛上一个帖子的主题ID（为一个数字），玩家可以在该帖子下发表反馈。"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:212
@@ -3814,69 +3758,58 @@ msgstr "论坛上你的反馈帖子的完整 URL."
 msgid "Forum Authentication:"
 msgstr "论坛身份认证："
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:213
-#, fuzzy
 msgid ""
 "Whether to use your forum username and password when uploading or to store "
 "your password and email address in the add-on’s _server.pbl."
 msgstr ""
-"在上传文件时是否使用你的论坛用户名和密码，或者将密码和电子邮件地址保存在插件"
-"的 `_server.pbl` 文件中。"
+"上传时是使用论坛用户名和密码，还是将密码和电子邮件地址存储在插件的_server.pbl"
+"文件中。"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:214
-#, fuzzy
 msgid ""
 "Comma delimited list of forum usernames of other people who are allowed to "
 "upload updates for this add-on or delete this add-on."
 msgstr ""
-"以逗号分隔的列表，列出了被允许为该插件上传更新或删除该插件的其他用户的论坛用"
-"户名。"
+"以逗号分隔的论坛用户名列表，包含此附加组件作者以外的其他用户，他们被允许上传"
+"此附加组件的更新，或删除此附加组件。"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:214
 msgid "Primary Authors:"
 msgstr "主要作者："
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:215
-#, fuzzy
 msgid ""
 "Comma delimited list of forum usernames of other people who are allowed to "
 "upload updates for this add-on."
-msgstr "以逗号分隔的列表，列出了被允许为该插件上传更新的其他用户的论坛用户名。"
+msgstr "论坛用户名列表，包含允许为该附加组件上传更新的其他用户，以逗号分隔。"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:215
 msgid "Secondary Authors:"
 msgstr "第二作者："
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:216
-#, fuzzy
 msgid ""
 "An email address you can be contacted at in case of issues with your add-on."
-msgstr "这是一个电子邮件地址，在您的插件出现问题时，可以通过这个地址联系到您。"
+msgstr "一个可供联系的电子邮箱地址，当你的插件出现问题时，可以此联系你。"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:216
 msgid "Email:"
 msgstr "Email:"
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:217
-#, fuzzy
 msgid ""
 "The add-on’s current password. Using forum authentication is recommended "
 "instead since this password is not stored securely."
-msgstr ""
-"该附加组件的当前密码。建议使用论坛认证方式，因为这个密码并未得到安全存储。"
+msgstr "附加组件的当前密码。建议改用论坛认证，因为此密码并未以安全的方式存储。"
 
 #. [label]: id=translations_title
 #: data/gui/themes/default/dialogs/editor_edit_pbl.cfg:275
@@ -3928,7 +3861,7 @@ msgstr "翻译"
 #. [label]
 #: data/gui/themes/default/dialogs/editor_edit_pbl_translation.cfg:84
 msgid "* Required"
-msgstr "* 必填项"
+msgstr "* 必需"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/editor_edit_pbl_translation.cfg:97
@@ -4094,196 +4027,179 @@ msgid "vision^None"
 msgstr "无"
 
 #. [button]: id=load_unit_type
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:174
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:180
 msgid "Load Unit Type"
 msgstr "加载单位类型"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:208
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:214
 msgid "Unit Image:"
-msgstr "单位图片："
+msgstr "单位图像："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:210
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:216
 msgid "Portrait:"
 msgstr "肖像："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:221
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:227
 msgid "Level:"
 msgstr "等级："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:246
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:252
 #: data/gui/themes/default/dialogs/mp_join_game.cfg:197
 #: data/gui/themes/default/dialogs/mp_staging.cfg:200
 msgid "Gender:"
 msgstr "性别："
 
 #. [row]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:254
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:260
 msgid "gender^Male"
-msgstr "gender^男"
+msgstr "男"
 
 #. [row]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:255
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:261
 msgid "gender^Female"
-msgstr "gender^女"
+msgstr "女"
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:270
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:276
 msgid "Advances to:"
-msgstr "升级至："
+msgstr "升级为："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:296
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:302
 msgid "Race:"
 msgstr "种族："
 
-# Translated by openai with model hy-mt1.5-7b.
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:349
-#, fuzzy
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:355
 msgid "Alignment:"
-msgstr "对齐方式："
+msgstr "立场："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:375
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:381
 msgid "HP:"
 msgstr "生命："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:405
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:411
 msgid "XP:"
 msgstr "经验："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:435
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:441
 msgid "Cost:"
 msgstr "价格："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:465
-#, fuzzy
-#| msgid "Movement Costs:"
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:471
 msgid "Movement:"
-msgstr "移动花费："
+msgstr "移动："
 
 #. [label]: id=title
 #. [tab]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:524
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1208
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:530
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1214
 #: src/gui/widgets/unit_preview_pane.cpp:216
 msgid "Attacks"
 msgstr "攻击手段"
 
 #. [button]: id=atk_new
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:589
-#, fuzzy
-#| msgid "Attack"
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:595
 msgid "New Attack"
-msgstr "攻击"
+msgstr "新攻击"
 
 #. [button]: id=atk_delete
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:602
-#, fuzzy
-#| msgid "Select/Move/Attack"
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:608
 msgid "Delete Attack"
-msgstr "选择/移动/攻击"
+msgstr "删除攻击"
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:672
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:678
 msgid "Range:"
 msgstr "范围："
 
 #. [option]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:687
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:693
 msgid "range^Melee"
-msgstr "range^近战"
+msgstr "近战"
 
 #. [option]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:692
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:698
 msgid "range^Ranged"
-msgstr "range^远程"
+msgstr "远程"
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:733
-#, fuzzy
-#| msgid "Damage"
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:739
 msgid "Damage:"
-msgstr "伤害"
+msgstr "伤害："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:760
-#, fuzzy
-#| msgid "Hits"
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:766
 msgid "Hits:"
-msgstr "命中数"
+msgstr "命中数："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:788
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:794
 msgid "Specials:"
 msgstr "特攻："
 
 #. [grid]: id=grid_adv
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:830
-#, fuzzy
-#| msgid "Profile"
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:836
 msgid "Small Profile"
-msgstr "档案"
+msgstr "小档案"
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:841
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:847
 msgid "Abilities:"
 msgstr "能力："
 
 #. [label]: id=movetype_label
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:867
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:873
 msgid "Movetype:"
 msgstr "移动类型："
 
 #. [label]: id=movement_costs_label
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:910
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:916
 #: src/gui/widgets/unit_preview_pane.cpp:150
 msgid "Movement Costs:"
 msgstr "移动花费："
 
 #. [label]: id=defense_label
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:963
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:969
 msgid "Defense:"
-msgstr "防守："
+msgstr "防御："
 
 #. [label]: id=resistance_label
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1016
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1022
 msgid "Resistances:"
 msgstr "抗性："
 
 #. [label]: id=usage_label
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1069
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1075
 msgid "AI Usage:"
-msgstr "AI 使用："
+msgstr "AI使用："
 
 #. [label]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1172
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1178
 msgid "Unit Type Editor"
 msgstr "单位类型编辑器"
 
 #. [tab]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1194
-#: data/gui/themes/default/dialogs/preferences/01_general.cfg:226
-#, fuzzy
-#| msgid "Game Stats"
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1200
 msgid "Main Stats"
-msgstr "游戏统计"
+msgstr "主要统计"
 
 #. [tab]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1201
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1207
 #: data/gui/themes/default/dialogs/preferences/06_advanced.cfg:148
 msgid "Advanced"
 msgstr "高级"
 
 #. [tab]
-#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1215
+#: data/gui/themes/default/dialogs/editor_edit_unit.cfg:1221
 msgid "WML View"
 msgstr "WML 视图"
 
@@ -4411,12 +4327,12 @@ msgstr "移除当前书签"
 #. [button]: id=open_ext
 #: data/gui/themes/default/dialogs/file_dialog.cfg:319
 msgid "Open External"
-msgstr ""
+msgstr "用外部应用打开"
 
 #. [button]: id=open_ext
 #: data/gui/themes/default/dialogs/file_dialog.cfg:320
 msgid "Open selected using platform’s default applications"
-msgstr ""
+msgstr "用平台的默认应用打开选定的文件"
 
 #. [button]: id=new_dir
 #. [label]: id=title
@@ -4727,185 +4643,186 @@ msgid "Scroll To"
 msgstr "滚屏至"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:122
+#: data/gui/themes/default/dialogs/game_version.cfg:130
 msgid "<span font_family='DejaVu Sans'>✦</span> <b>Version:</b>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>✦</span> <b>版本：</b>"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:150
+#: data/gui/themes/default/dialogs/game_version.cfg:158
 msgid "<span font_family='DejaVu Sans'>✦</span> <b>Running on:</b>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>✦</span> <b>运行于：</b>"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:179
+#: data/gui/themes/default/dialogs/game_version.cfg:187
 msgid "<span font_family='DejaVu Sans'>✦</span> <b>Architecture:</b>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>✦</span> <b>架构：</b>"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:207
+#: data/gui/themes/default/dialogs/game_version.cfg:215
 msgid "<span font_family='DejaVu Sans'>✦</span> <b>Homepage:</b>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>✦</span> <b>主页：</b>"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:239
+#: data/gui/themes/default/dialogs/game_version.cfg:247
 msgid "<span font_family='DejaVu Sans'>✦</span> <b>Wiki:</b>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>✦</span> <b>维基：</b>"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:279
+#: data/gui/themes/default/dialogs/game_version.cfg:287
 msgid ""
 "<i><span font_family='DejaVu Sans'>➤</span> Copy a full report here:</i>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>➤</span> 从此处复制完整报告："
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:299
+#: data/gui/themes/default/dialogs/game_version.cfg:307
 msgid ""
 "<i><span font_family='DejaVu Sans'>➤</span> Report an issue or request a "
 "feature:</i>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>➤</span> 报告问题或请求实现新特性："
 
 #. [button]: id=issue
-#: data/gui/themes/default/dialogs/game_version.cfg:312
+#: data/gui/themes/default/dialogs/game_version.cfg:320
 msgid "Report Issue"
-msgstr ""
+msgstr "报告问题"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:321
+#: data/gui/themes/default/dialogs/game_version.cfg:329
 msgid "<i><span font_family='DejaVu Sans'>➤</span> View Game Manual:</i>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>➤</span> 查看游戏手册："
 
 #. [button]: id=view_manual
 #. button to open the game manual in the platform's browser.
-#: data/gui/themes/default/dialogs/game_version.cfg:334
+#: data/gui/themes/default/dialogs/game_version.cfg:342
 msgid "View Manual"
-msgstr ""
+msgstr "查看手册"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:342
+#: data/gui/themes/default/dialogs/game_version.cfg:350
 msgid ""
 "<i><span font_family='DejaVu Sans'>➤</span> Re-open the version migrator "
 "dialog:</i>"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>➤</span> 重新打开版本迁移器对话框："
 
 #. [button]: id=run_migrator
 #. button to open the version migration dialog manually to re-migrate add-ons and the preferences file
-#: data/gui/themes/default/dialogs/game_version.cfg:355
+#: data/gui/themes/default/dialogs/game_version.cfg:363
 msgid "Migrate"
 msgstr "迁移"
 
 #. [grid]
-#: data/gui/themes/default/dialogs/game_version.cfg:392
+#: data/gui/themes/default/dialogs/game_version.cfg:400
 msgid "Game data:"
 msgstr "游戏数据："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/game_version.cfg:394
+#: data/gui/themes/default/dialogs/game_version.cfg:402
 msgid "User data:"
 msgstr "用户数据："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/game_version.cfg:396
+#: data/gui/themes/default/dialogs/game_version.cfg:404
 msgid "Saved games:"
 msgstr "保存的游戏："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/game_version.cfg:398
+#: data/gui/themes/default/dialogs/game_version.cfg:406
 msgid "Add-ons:"
 msgstr "附加组件："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/game_version.cfg:400
+#: data/gui/themes/default/dialogs/game_version.cfg:408
 msgid "Cache:"
 msgstr "缓存："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/game_version.cfg:402
+#: data/gui/themes/default/dialogs/game_version.cfg:410
 msgid "Logs:"
 msgstr "日志："
 
 #. [grid]
-#: data/gui/themes/default/dialogs/game_version.cfg:404
+#: data/gui/themes/default/dialogs/game_version.cfg:412
 msgid "Screenshots:"
 msgstr "截图："
 
 #. [button]: id=open_stderr
-#: data/gui/themes/default/dialogs/game_version.cfg:438
+#: data/gui/themes/default/dialogs/game_version.cfg:446
 msgid "Log File"
 msgstr "日志文件"
 
 #. [button]: id=open_stderr
-#: data/gui/themes/default/dialogs/game_version.cfg:439
+#: data/gui/themes/default/dialogs/game_version.cfg:447
 msgid ""
 "Opens the log file pertaining to the current session, which may contain "
 "useful debug information"
 msgstr "打开与当前会话有关的日志文件，其中可能包含有用的调试信息"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:469
+#: data/gui/themes/default/dialogs/game_version.cfg:477
 msgid "library^Name"
 msgstr "名称"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:480
+#: data/gui/themes/default/dialogs/game_version.cfg:488
 msgid "library^Build version"
 msgstr "构建版本"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:492
+#: data/gui/themes/default/dialogs/game_version.cfg:500
 msgid "library^Runtime version"
 msgstr "运行时版本"
 
 #. [label]
-#: data/gui/themes/default/dialogs/game_version.cfg:573
+#: data/gui/themes/default/dialogs/game_version.cfg:581
 msgid ""
 "The following features were selected when building this version of Wesnoth:"
 msgstr "构建此版韦诺时，选择了以下特性："
 
 #. [button]: id=forums
 #. this is on a button that opens the Wesnoth forums webpage
-#: data/gui/themes/default/dialogs/game_version.cfg:653
+#: data/gui/themes/default/dialogs/game_version.cfg:661
 msgid "Forums"
 msgstr "论坛"
 
 #. [button]: id=discord
 #. this is on a button that opens the Wesnoth Discord server webpage
-#: data/gui/themes/default/dialogs/game_version.cfg:672
+#: data/gui/themes/default/dialogs/game_version.cfg:680
 msgid "Discord"
 msgstr "Discord"
 
 #. [button]: id=irc
 #. this is on a button that opens the Wesnoth IRC webpage. IRC is an acronym for Internet Relay Chat
-#: data/gui/themes/default/dialogs/game_version.cfg:691
+#: data/gui/themes/default/dialogs/game_version.cfg:699
 msgid "IRC"
 msgstr "IRC"
 
 #. [button]: id=steam
 #. this is on a button that opens the Wesnoth Steam forums webpage
-#: data/gui/themes/default/dialogs/game_version.cfg:710
+#: data/gui/themes/default/dialogs/game_version.cfg:718
 msgid "Steam"
 msgstr "Steam"
 
 #. [button]: id=reddit
 #. this is on a button that opens the Wesnoth Reddit webpage
-#: data/gui/themes/default/dialogs/game_version.cfg:729
+#: data/gui/themes/default/dialogs/game_version.cfg:737
 msgid "Reddit"
 msgstr "Reddit"
 
 #. [button]: id=donate
 #. this is on a button that opens the Wesnoth SPI webpage for sending donations
-#: data/gui/themes/default/dialogs/game_version.cfg:748
+#: data/gui/themes/default/dialogs/game_version.cfg:756
 msgid "Donate"
 msgstr "捐款"
 
 #. [label]: id=description
-#: data/gui/themes/default/dialogs/game_version.cfg:844
+#: data/gui/themes/default/dialogs/game_version.cfg:852
 msgid "An open source, turn-based strategy game with a high fantasy theme."
-msgstr ""
+msgstr "高幻想主题的开源回合制策略游戏。"
 
 #. [tab]
 #. [widget]: id=tab_label
-#: data/gui/themes/default/dialogs/game_version.cfg:879
+#: data/gui/themes/default/dialogs/game_version.cfg:887
 #: data/gui/themes/default/dialogs/mp_create_game.cfg:564
+#: data/gui/themes/default/dialogs/preferences/01_general.cfg:226
 #: data/gui/themes/default/dialogs/preferences/05_multiplayer.cfg:405
 #: data/gui/themes/default/dialogs/server_info.cfg:181
 #: src/hotkey/hotkey_command.cpp:51
@@ -4913,27 +4830,27 @@ msgid "General"
 msgstr "通用"
 
 #. [tab]
-#: data/gui/themes/default/dialogs/game_version.cfg:885
+#: data/gui/themes/default/dialogs/game_version.cfg:893
 msgid "Paths"
 msgstr "路径"
 
 #. [tab]
-#: data/gui/themes/default/dialogs/game_version.cfg:891
+#: data/gui/themes/default/dialogs/game_version.cfg:899
 msgid "Libraries"
 msgstr "库"
 
 #. [tab]
-#: data/gui/themes/default/dialogs/game_version.cfg:897
+#: data/gui/themes/default/dialogs/game_version.cfg:905
 msgid "Features"
 msgstr "特性"
 
 #. [button]: id=credits
-#: data/gui/themes/default/dialogs/game_version.cfg:957
+#: data/gui/themes/default/dialogs/game_version.cfg:965
 msgid "Credits"
 msgstr "制作者"
 
 #. [button]: id=license
-#: data/gui/themes/default/dialogs/game_version.cfg:972
+#: data/gui/themes/default/dialogs/game_version.cfg:980
 msgid "License"
 msgstr "许可证"
 
@@ -5018,7 +4935,7 @@ msgstr "显示主题"
 #. [text_box]: id=filter_box
 #: data/gui/themes/default/dialogs/help_browser.cfg:163
 msgid "Search help topic names"
-msgstr ""
+msgstr "查找帮助主题名称"
 
 #. [label]
 #: data/gui/themes/default/dialogs/hotkey_bind.cfg:35
@@ -5037,6 +4954,8 @@ msgid ""
 "including translation. Translations may drift behind or even become "
 "abandoned."
 msgstr ""
+"<b>韦诺之战</b>的开发工作，包括翻译工作在内，均依赖志愿者。因此，翻译工作可能"
+"会滞后，甚至被搁置。"
 
 #. [label]
 #. Beneath the label widget displaying this text there is a widget displaying
@@ -5047,6 +4966,8 @@ msgid ""
 "interface and in-game help only. More complete stats, including details for "
 "each campaign, are available at the following page:"
 msgstr ""
+"<b>注意：</b>所示的翻译百分比仅适用于核心游戏界面和游戏内帮助。更完整的统计数"
+"据（包括每个战役的详细信息）可在以下页面查看："
 
 #. [label]
 #. Beneath the label widget displaying this text there is a widget displaying
@@ -5063,30 +4984,28 @@ msgid "Show in-progress or abandoned translations"
 msgstr "显示正在进行或弃用的翻译"
 
 #. [label]: id=status
-#: data/gui/themes/default/dialogs/loadscreen.cfg:183
+#: data/gui/themes/default/dialogs/loadscreen.cfg:185
 msgid "Loading..."
 msgstr "正在载入……"
 
 #. [widget]: id=tab_label
 #: data/gui/themes/default/dialogs/lobby_main.cfg:75
-#, fuzzy
-#| msgid "General"
 msgid "General Lobby"
-msgstr "通用"
+msgstr "通用大厅"
 
 #. [widget]: id=tab_label
 #. Games which were created by a bot, there's discussion about the meaning and
 #. possibly better names in https://github.com/wesnoth/wesnoth/issues/8148
 #: data/gui/themes/default/dialogs/lobby_main.cfg:88
 msgid "Matchmaking"
-msgstr ""
+msgstr "匹配"
 
 #. [widget]: id=tab_label
 #. saved settings to start a game with, such as era, map, fog, etc
 #: data/gui/themes/default/dialogs/lobby_main.cfg:102
 #: src/gui/dialogs/multiplayer/mp_create_game.cpp:129
 msgid "Presets"
-msgstr ""
+msgstr "预设"
 
 #. [label]: id=map
 #: data/gui/themes/default/dialogs/lobby_main.cfg:153
@@ -5101,7 +5020,7 @@ msgstr "需要密码才能加入游戏"
 #. [button]: id=delete_preset
 #: data/gui/themes/default/dialogs/lobby_main.cfg:305
 msgid "Delete this preset"
-msgstr "删除这个预设"
+msgstr "删除此预设"
 
 #. [toggle_button]: id=filter_vacant_slots
 #: data/gui/themes/default/dialogs/lobby_main.cfg:477
@@ -5222,14 +5141,12 @@ msgstr "直到获得某一阵营的控制权之前，不显示地图"
 #. [button]: id=join_queue
 #: data/gui/themes/default/dialogs/lobby_main.cfg:728
 msgid "Join Queue"
-msgstr ""
+msgstr "加入队列"
 
 #. [button]: id=leave_queue
 #: data/gui/themes/default/dialogs/lobby_main.cfg:738
-#, fuzzy
-#| msgid "Leave"
 msgid "Leave Queue"
-msgstr "离开"
+msgstr "离开队列"
 
 #. [label]
 #: data/gui/themes/default/dialogs/lobby_main.cfg:844
@@ -5860,7 +5777,7 @@ msgstr "选择此阵营的派系和首领"
 #: data/gui/themes/default/dialogs/mp_join_game.cfg:155
 #: data/gui/themes/default/dialogs/mp_staging.cfg:157
 msgid "Faction:"
-msgstr "阵营："
+msgstr "派系："
 
 #. [label]: id=status_label
 #: data/gui/themes/default/dialogs/mp_join_game.cfg:364
@@ -5990,12 +5907,12 @@ msgstr "作为主机建立游戏（将启动专属服务器）"
 
 #. [widget]: id=name
 #: data/gui/themes/default/dialogs/mp_method_selection.cfg:301
-#, fuzzy
-#| msgid "Host Networked Game"
 msgid ""
 "Host Networked\n"
 "Game"
-msgstr "主建联机游戏"
+msgstr ""
+"主建联机\n"
+"游戏"
 
 #. [column]
 #: data/gui/themes/default/dialogs/mp_method_selection.cfg:312
@@ -6010,17 +5927,17 @@ msgstr "本地游戏"
 #. [label]
 #: data/gui/themes/default/dialogs/mp_report.cfg:50
 msgid "* Player being reported:"
-msgstr ""
+msgstr "* 被举报的玩家："
 
 #. [label]
 #: data/gui/themes/default/dialogs/mp_report.cfg:82
 msgid "* Reason for report:"
-msgstr "* 报告原因："
+msgstr "* 举报原因："
 
 #. [label]
 #: data/gui/themes/default/dialogs/mp_report.cfg:114
 msgid "Location of occurrence:"
-msgstr ""
+msgstr "发生位置："
 
 #. [label]
 #: data/gui/themes/default/dialogs/mp_report.cfg:146
@@ -6122,14 +6039,12 @@ msgstr "不允许回合开始时的自动移动"
 #. [toggle_button]: id=show_turn_dialog
 #: data/gui/themes/default/dialogs/preferences/01_general.cfg:114
 msgid "Turn prompt"
-msgstr ""
+msgstr "回合提示"
 
 #. [toggle_button]: id=show_turn_dialog
 #: data/gui/themes/default/dialogs/preferences/01_general.cfg:115
-#, fuzzy
-#| msgid "Display a dialog at the beginning of your turn"
 msgid "Display a prompt at the beginning of your turn"
-msgstr "在你的回合开始时显示提示对话框"
+msgstr "在你的回合开始时显示提示"
 
 #. [toggle_button]: id=whiteboard_on_start
 #: data/gui/themes/default/dialogs/preferences/01_general.cfg:128
@@ -6235,7 +6150,7 @@ msgstr "快捷键"
 #. [toggle_button]: id=sort_2
 #. Translate G as the initial letter for Game
 #: data/gui/themes/default/dialogs/preferences/02_hotkeys.cfg:130
-#: src/gui/dialogs/preferences_dialog.cpp:885
+#: src/gui/dialogs/preferences_dialog.cpp:881
 msgid "game_hotkeys^G"
 msgstr "G"
 
@@ -6247,7 +6162,7 @@ msgstr "游戏中可用"
 #. [toggle_button]: id=sort_3
 #. Translate E as the initial letter for Editor
 #: data/gui/themes/default/dialogs/preferences/02_hotkeys.cfg:145
-#: src/gui/dialogs/preferences_dialog.cpp:886
+#: src/gui/dialogs/preferences_dialog.cpp:882
 msgid "editor_hotkeys^E"
 msgstr "E"
 
@@ -6259,7 +6174,7 @@ msgstr "编辑器中可用"
 #. [toggle_button]: id=sort_4
 #. Translate M as the initial letter for Main Menu
 #: data/gui/themes/default/dialogs/preferences/02_hotkeys.cfg:160
-#: src/gui/dialogs/preferences_dialog.cpp:887
+#: src/gui/dialogs/preferences_dialog.cpp:883
 msgid "mainmenu_hotkeys^M"
 msgstr "M"
 
@@ -6286,7 +6201,7 @@ msgstr "窗口大小："
 #. [label]: id=help_text
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:39
 msgid "Pixel scale multiplier:"
-msgstr ""
+msgstr "像素缩放系数："
 
 #. [menu_button]: id=resolution_set
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:73
@@ -6298,7 +6213,7 @@ msgstr "改变游戏窗口大小"
 msgid ""
 "Set the global pixel scale multiplier. A pixel scale multiplier of 2 will "
 "make everything look twice as large."
-msgstr ""
+msgstr "设置全局像素缩放系数。例如缩放系数为2，那么所有东西看上去都是两倍大。"
 
 #. [toggle_button]: id=fullscreen
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:102
@@ -6313,24 +6228,24 @@ msgstr "在全屏和窗口模式之间切换"
 #. [toggle_button]: id=auto_pixel_scale
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:114
 msgid "pixel_scale_multiplier^Automatic scale"
-msgstr ""
+msgstr "自动缩放"
 
 #. [toggle_button]: id=auto_pixel_scale
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:115
 msgid "Choose pixel scale multiplier automatically based on current resolution"
-msgstr ""
+msgstr "根据当前分辨率，自动选择像素缩放系数"
 
 #. [toggle_button]: id=vsync
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:129
 msgid "VSync"
-msgstr "VSync"
+msgstr "垂直同步"
 
 #. [toggle_button]: id=vsync
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:130
 msgid ""
 "Reduces tearing by synchronizing rendering with the screen refresh rate "
 "(requires restart to take effect)"
-msgstr ""
+msgstr "通过将渲染与屏幕刷新率同步来减少画面撕裂（需要重启才能生效）"
 
 #. [label]
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:152
@@ -6342,19 +6257,19 @@ msgstr "游戏内主题："
 msgid ""
 "Change the in-game interface theme. Additional themes may be provided by "
 "community-made add-ons"
-msgstr ""
+msgstr "更改游戏内界面主题。更多主题可由社区制作的附加组件提供"
 
 #. [label]
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:176
 msgid "UI theme:"
-msgstr "用户界面主题："
+msgstr "界面主题："
 
 #. [menu_button]: id=choose_gui2_theme
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:192
 msgid ""
 "Change the UI (GUI2) theme. Additional themes may be provided by community-"
 "made add-ons"
-msgstr ""
+msgstr "变更界面（GUI2）主题。更多主题由社区制作的附加组件提供"
 
 #. [button]: id=apply
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:201
@@ -6363,27 +6278,23 @@ msgstr "应用"
 
 #. [toggle_button]: id=show_tips
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:224
-#, fuzzy
-#| msgid "Show next tip of the day"
 msgid "Show gameplay tips on the main menu"
-msgstr "显示后一条每日提示"
+msgstr "在主菜单处显示玩法提示"
 
 #. [toggle_button]: id=show_floating_labels
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:236
 msgid "Combat damage indicators"
-msgstr ""
+msgstr "战斗伤害标识"
 
 #. [toggle_button]: id=show_floating_labels
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:237
-#, fuzzy
-#| msgid "Show damage and healing amounts above a unit"
 msgid "Show amount of damage inflicted or healed as fading labels above units"
-msgstr "在单位上方显示伤害和治疗数字"
+msgstr "用会淡出的标签，在单位上方显示伤害和治疗量"
 
 #. [toggle_button]: id=show_ellipses
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:250
 msgid "Team color indicators"
-msgstr ""
+msgstr "团队颜色标识"
 
 #. [toggle_button]: id=show_ellipses
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:251
@@ -6395,7 +6306,7 @@ msgstr "在单位脚底周围显示彩色圆环以显示其所属阵营"
 #. [toggle_button]: id=show_grid
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:264
 msgid "Grid overlay"
-msgstr ""
+msgstr "网格覆盖层"
 
 #. [toggle_button]: id=show_grid
 #: data/gui/themes/default/dialogs/preferences/03_display.cfg:265
@@ -6645,30 +6556,28 @@ msgstr "你并没有将任何其他玩家加为好友或拉黑。"
 
 #. [label]
 #: data/gui/themes/default/dialogs/reachmap_options.cfg:101
-#, fuzzy
-#| msgid "Random map options: "
 msgid "Reach Map Options"
-msgstr "随机地图选项："
+msgstr "接触地图选项："
 
 #. [label]
 #: data/gui/themes/default/dialogs/reachmap_options.cfg:112
 msgid "Highlight Color"
-msgstr ""
+msgstr "高亮颜色"
 
 #. [label]
 #: data/gui/themes/default/dialogs/reachmap_options.cfg:130
 msgid "Enemy Highlight Color"
-msgstr ""
+msgstr "敌方高亮颜色"
 
 #. [grid]
 #: data/gui/themes/default/dialogs/reachmap_options.cfg:142
 msgid "Border Opacity:"
-msgstr ""
+msgstr "边框不透明度："
 
 #. [grid]
 #: data/gui/themes/default/dialogs/reachmap_options.cfg:144
 msgid "Tint Opacity:"
-msgstr ""
+msgstr "色调不透明度："
 
 #. [button]: id=open
 #: data/gui/themes/default/dialogs/screenshot_notification.cfg:49
@@ -6940,7 +6849,7 @@ msgstr "攻击敌人"
 #: data/gui/themes/default/dialogs/units_dialog.cfg:24
 #: data/gui/themes/default/dialogs/units_dialog.cfg:573
 msgid "★"
-msgstr ""
+msgstr "★"
 
 #. [toggle_button]: id=unit_details
 #. [toggle_button]: id=sort_4
@@ -6999,11 +6908,11 @@ msgstr "重命名"
 #. [button]: id=mark_favorite
 #: data/gui/themes/default/dialogs/units_dialog.cfg:574
 msgid "Mark/unmark the selected unit as favorite"
-msgstr ""
+msgstr "将选中的单位标记为收藏/取消收藏"
 
 #. [label]
 #: data/gui/themes/default/dialogs/wml_error.cfg:40
-#: src/gui/dialogs/message.cpp:206 src/gui/dialogs/preferences_dialog.cpp:265
+#: src/gui/dialogs/message.cpp:206 src/gui/dialogs/preferences_dialog.cpp:249
 #: src/gui/dialogs/transient_message.cpp:77
 msgid "Error"
 msgstr "错误"
@@ -7039,7 +6948,7 @@ msgstr "下载数"
 #. The heavy checkmark character is available in the DejaVu Sans font, but not in the default Lato font
 #: data/gui/themes/default/widgets/button_success.cfg:250
 msgid "page^<span font_family='DejaVu Sans'>✔</span> Copied"
-msgstr ""
+msgstr "<span font_family='DejaVu Sans'>✔</span> 已复制"
 
 #. [image]: id=pending_messages
 #: data/gui/themes/default/widgets/chatbox.cfg:40
@@ -7050,7 +6959,7 @@ msgstr "消息等待中"
 #: data/internal/Urban_Jungle/terrain.cfg:8
 #: data/internal/Urban_Jungle/terrain.cfg:9
 msgid "Urban"
-msgstr ""
+msgstr "城市"
 
 #. [terrain_type]: id=urbanjungle
 #: data/internal/Urban_Jungle/terrain.cfg:10
@@ -7059,6 +6968,8 @@ msgid ""
 "villages, providing no income or healing. They are difficult to navigate "
 "quickly, but offer significant protection."
 msgstr ""
+"密集的建筑群比传统村庄更不适合驻军，不提供收入或治疗。虽然难以快速穿行，但能"
+"提供显著的防护。"
 
 #. [terrain_type]: id=urbanjungleA
 #. [terrain_type]: id=urbanjungle{ID}
@@ -7069,25 +6980,25 @@ msgstr ""
 #: data/internal/Urban_Jungle/terrain.cfg:33
 #: data/internal/Urban_Jungle/terrain.cfg:34
 msgid "Urban Jungle"
-msgstr ""
+msgstr "城市丛林"
 
-#: src/build_info.cpp:297
+#: src/build_info.cpp:281
 msgid "feature^Lua console completion"
 msgstr "Lua控制台补全"
 
-#: src/build_info.cpp:304
+#: src/build_info.cpp:288
 msgid "feature^D-Bus notifications back end"
 msgstr "D-Bus提醒后端"
 
-#: src/build_info.cpp:313
+#: src/build_info.cpp:297
 msgid "feature^Win32 notifications back end"
 msgstr "Win32提醒后端"
 
-#: src/build_info.cpp:319
+#: src/build_info.cpp:303
 msgid "feature^Cocoa notifications back end"
 msgstr "Cocoa提醒后端"
 
-#: src/build_info.cpp:358 src/desktop/version.cpp:129
+#: src/build_info.cpp:342 src/desktop/version.cpp:129
 msgid "cpu_architecture^<unknown>"
 msgstr "<未知>"
 
@@ -7133,7 +7044,7 @@ msgstr "<未知>"
 #. other's resources rather than duplicating them. For example,
 #. Swedish (sv) and Danish (da) are such, so Swedish translator could
 #. translate this message as "sv,da", while Danish as "da,sv".
-#: src/filesystem.cpp:1850
+#: src/filesystem.cpp:1845
 msgid "language code for localized resources^en_US"
 msgstr "zh_CN"
 
@@ -7178,20 +7089,16 @@ msgid "disjunct end^$prefix, or $last"
 msgstr "$prefix|或$last"
 
 #: src/gui/core/canvas.cpp:289
-#, fuzzy
-#| msgid "Image doesn't fit on canvas."
 msgid "Image doesn’t fit on canvas."
-msgstr "图片不适应画布大小。"
+msgstr "图像超出画布范围。"
 
 #: src/gui/core/widget_definition.cpp:29
 msgid "No draw section defined for state."
 msgstr "没有为状态定义的绘图区域。"
 
 #: src/gui/core/widget_definition.cpp:67 src/gui/core/window_builder.cpp:113
-#, fuzzy
-#| msgid "No resolution defined."
 msgid "No resolution defined for "
-msgstr "没有已定义的分辨率。"
+msgstr "没有为此定义分辨率："
 
 #: src/gui/core/window_builder.cpp:147 src/gui/widgets/addon_list.cpp:432
 #: src/gui/widgets/multi_page.cpp:181 src/gui/widgets/panel.cpp:131
@@ -7201,29 +7108,22 @@ msgid "No grid defined."
 msgstr "没有已定义的网格。"
 
 #: src/gui/core/window_builder.cpp:201
-#, fuzzy
-#| msgid "Grid '$grid' row $row must have at least one column."
 msgid "Grid ‘$grid’ row $row must have at least one column."
 msgstr "网格“$grid”的第$row|行至少要有一列。"
 
 #: src/gui/core/window_builder.cpp:213
-#, fuzzy
-#| msgid ""
-#| "Grid '$grid' row $row has a differing number of columns ($found found, "
-#| "$expected expected)"
 msgid ""
 "Grid ‘$grid’ row $row has a differing number of columns ($found found, "
 "$expected expected)"
-msgstr ""
-"网格“$grid”的第$row|行的列数与期望值不同（实际为$found|，期望为$expected|）"
+msgstr "网格“$grid”的第$row|行的列数不同（实际为$found|，期望为$expected|）"
 
 #: src/gui/dialogs/achievements_dialog.cpp:97
 msgid "$title ($count/$total)"
-msgstr ""
+msgstr "$title|（$count/$total）"
 
 #: src/gui/dialogs/achievements_dialog.cpp:138
 msgid "Completed $count/$total"
-msgstr ""
+msgstr "已完成 $count/$total"
 
 #: src/gui/dialogs/addon/addon_server_info.cpp:95
 #: src/gui/dialogs/addon/addon_server_info.cpp:120
@@ -7243,10 +7143,8 @@ msgstr "回复"
 #: src/gui/dialogs/addon/addon_server_info.cpp:115
 #: src/gui/dialogs/addon/addon_server_info.cpp:143
 #: src/gui/dialogs/addon/addon_server_info.cpp:167
-#, fuzzy
-#| msgid "Password Required"
 msgid "Password not provided"
-msgstr "需要输入密码"
+msgstr "没有提供密码"
 
 #: src/gui/dialogs/addon/manager.cpp:145
 msgid "addons_view^All Add-ons"
@@ -7309,10 +7207,8 @@ msgid "addons_of_type^Cores"
 msgstr "核心"
 
 #: src/gui/dialogs/addon/manager.cpp:163
-#, fuzzy
-#| msgid "addons_of_type^Cores"
 msgid "addons_of_type^Themes"
-msgstr "核心"
+msgstr "主题"
 
 #: src/gui/dialogs/addon/manager.cpp:164
 msgid "addons_of_type^Resources"
@@ -7526,7 +7422,7 @@ msgstr "此附加组件的远程版本与正在上传的版本相同，或比它
 
 #: src/gui/dialogs/addon/manager.cpp:997
 msgid "The passphrase attribute cannot be present when forum_auth is used."
-msgstr ""
+msgstr "使用forum_auth时，不能有passphrase属性。"
 
 #: src/gui/dialogs/addon/manager.cpp:1002
 msgid "Invalid icon path. Make sure the path points to a valid image."
@@ -7584,19 +7480,19 @@ msgstr "进攻方抗性 vs"
 msgid "Attacker vulnerability vs"
 msgstr "进攻方弱点 vs"
 
-#: src/gui/dialogs/campaign_selection.cpp:82
+#: src/gui/dialogs/campaign_selection.cpp:85
 msgid "game^Get Add-ons"
-msgstr "game^获取附加组件"
+msgstr "获取附加组件"
 
-#: src/gui/dialogs/campaign_selection.cpp:409
+#: src/gui/dialogs/campaign_selection.cpp:412
 msgid "More campaigns..."
 msgstr "更多战役……"
 
-#: src/gui/dialogs/campaign_selection.cpp:424
+#: src/gui/dialogs/campaign_selection.cpp:427
 msgid "Missing Campaigns"
 msgstr "缺失的战役"
 
-#: src/gui/dialogs/campaign_selection.cpp:458
+#: src/gui/dialogs/campaign_selection.cpp:461
 #: src/gui/dialogs/multiplayer/lobby.cpp:435
 msgid "active_modifications^None"
 msgstr "无"
@@ -7643,7 +7539,7 @@ msgstr "选择文件"
 msgid ""
 "This file is outside Wesnoth’s data dirs. Do you wish to copy it into your "
 "add-on?"
-msgstr ""
+msgstr "此文件位于韦诺的数据目录之外。是否希望将其复制到你的附加组件中？"
 
 #: src/gui/dialogs/editor/edit_pbl.cpp:178
 msgid "Core"
@@ -7720,7 +7616,7 @@ msgstr "地形改造"
 
 #: src/gui/dialogs/editor/edit_pbl.cpp:402
 msgid "The icon’s file size is too large"
-msgstr ""
+msgstr "图标的文件尺寸过大"
 
 #: src/gui/dialogs/editor/edit_pbl.cpp:404
 msgid "No validation errors"
@@ -7744,7 +7640,7 @@ msgstr "战士"
 
 #: src/gui/dialogs/editor/edit_unit.cpp:182
 msgid "archer"
-msgstr "弓箭手"
+msgstr "弓手"
 
 #: src/gui/dialogs/editor/edit_unit.cpp:183
 msgid "mixed fighter"
@@ -7752,11 +7648,11 @@ msgstr "混合战士"
 
 #: src/gui/dialogs/editor/edit_unit.cpp:184
 msgid "healer"
-msgstr ""
+msgstr "治疗师"
 
 #: src/gui/dialogs/editor/edit_unit.cpp:927
 msgid "Unsaved changes will be lost. Do you want to leave?"
-msgstr "未保存的修改会丢失。你要离开吗？"
+msgstr "未保存的变更将会丢失。你想要离开吗？"
 
 #: src/gui/dialogs/editor/edit_unit.cpp:946
 msgid "Unit type saved."
@@ -7764,7 +7660,7 @@ msgstr "单位类型已保存。"
 
 #: src/gui/dialogs/editor/generator_settings.cpp:38
 msgid "$count/1000 tiles"
-msgstr "$count/1000区块"
+msgstr "$count/1000图块"
 
 #: src/gui/dialogs/editor/generator_settings.cpp:43
 msgid "Coastal"
@@ -7788,7 +7684,7 @@ msgstr "输入文件名"
 
 #: src/gui/dialogs/file_dialog.cpp:201
 msgid "invalid extension (use $extensions)"
-msgstr ""
+msgstr "无效扩展名（使用$extensions）"
 
 #: src/gui/dialogs/file_dialog.cpp:208
 msgid "filename contains whitespace"
@@ -7799,10 +7695,8 @@ msgid "Open"
 msgstr "打开"
 
 #: src/gui/dialogs/file_dialog.cpp:313
-#, fuzzy
-#| msgid "Opening links is not supported, contact your packager"
 msgid "Opening files is not supported, contact your packager"
-msgstr "不支持打开链接，请联系你的打包者"
+msgstr "不支持打开文件，请联系你的打包者"
 
 #: src/gui/dialogs/file_dialog.cpp:370
 msgid "The file already exists. Do you wish to overwrite it?"
@@ -7971,7 +7865,7 @@ msgid "yes"
 msgstr "是"
 
 #: src/gui/dialogs/game_version_dialog.cpp:263
-#: src/gui/dialogs/game_version_dialog.cpp:277 src/gui/widgets/label.cpp:124
+#: src/gui/dialogs/game_version_dialog.cpp:269 src/gui/widgets/label.cpp:124
 msgid "Opening links is not supported, contact your packager"
 msgstr "不支持打开链接，请联系你的打包者"
 
@@ -8072,8 +7966,6 @@ msgid "Downloading lobby data"
 msgstr "正在下载大厅数据"
 
 #: src/gui/dialogs/lua_interpreter.cpp:628
-#, fuzzy
-#| msgid "The lua console can only be used in debug mode! (Run ':debug' first)"
 msgid "The lua console can only be used in debug mode! (Run ‘:debug’ first)"
 msgstr "Lua控制台只能用于调试模式中！（请先运行“:debug”）"
 
@@ -8089,7 +7981,7 @@ msgstr "未找到其他版本"
 msgid ""
 "This would import settings from a previous version of Wesnoth, but no other "
 "version was found on this device"
-msgstr ""
+msgstr "这将从先前版本的韦诺导入设置，但在此设备上未找到其他版本"
 
 #: src/gui/dialogs/multiplayer/faction_select.cpp:200
 #: src/gui/dialogs/multiplayer/mp_staging.cpp:498
@@ -8105,17 +7997,12 @@ msgid "Incompatible User-made Content"
 msgstr "不兼容的用户制作内容"
 
 #: src/gui/dialogs/multiplayer/lobby.cpp:175
-#, fuzzy
-#| msgid ""
-#| "This game cannot be joined because the host has out-of-date add-ons that "
-#| "are incompatible with your version. You might wish to suggest that the "
-#| "host's add-ons be updated."
 msgid ""
 "This game cannot be joined because the host has out-of-date add-ons that are "
 "incompatible with your version. You might wish to suggest that the host’s "
 "add-ons be updated."
 msgstr ""
-"此游戏不能加入，因为主机上有过时的附加组件，与你的版本不兼容。你也许希望建议"
+"不能加入此游戏，因为主机上有过时的附加组件，与你的版本不兼容。你也许可以建议"
 "主机更新自己的附加组件。"
 
 #: src/gui/dialogs/multiplayer/lobby.cpp:190
@@ -8184,12 +8071,9 @@ msgid "lobby"
 msgstr "大厅"
 
 #: src/gui/dialogs/multiplayer/lobby.cpp:962
-#, fuzzy
-#| msgid ""
-#| "This game doesn't allow observers. Observe using moderator rights anyway?"
 msgid ""
 "This game doesn’t allow observers. Observe using moderator rights anyway?"
-msgstr "此游戏不允许观察。仍然要使用管理员权限进行观察吗？"
+msgstr "此游戏不允许观察者加入。仍然要使用管理员权限进行观察吗？"
 
 #: src/gui/dialogs/multiplayer/lobby.cpp:973
 msgid ""
@@ -8314,11 +8198,11 @@ msgstr "游戏"
 
 #: src/gui/dialogs/multiplayer/mp_staging.cpp:81
 msgid "Hotkey(s): $bindings"
-msgstr ""
+msgstr "热键：$bindings"
 
 #: src/gui/dialogs/multiplayer/mp_staging.cpp:308
 msgid "Invalid Color"
-msgstr "无效的颜色"
+msgstr "无效颜色"
 
 #: src/gui/dialogs/multiplayer/mp_staging.cpp:515
 msgid "Waiting for players to choose factions..."
@@ -8328,33 +8212,33 @@ msgstr "正在等待玩家选择派系……"
 msgid "The End"
 msgstr "完结"
 
-#: src/gui/dialogs/preferences_dialog.cpp:192
+#: src/gui/dialogs/preferences_dialog.cpp:176
 msgid "friend"
 msgstr "好友"
 
-#: src/gui/dialogs/preferences_dialog.cpp:197
+#: src/gui/dialogs/preferences_dialog.cpp:181
 msgid "ignored"
 msgstr "忽略"
 
-#: src/gui/dialogs/preferences_dialog.cpp:250
-#: src/gui/dialogs/preferences_dialog.cpp:307
+#: src/gui/dialogs/preferences_dialog.cpp:234
+#: src/gui/dialogs/preferences_dialog.cpp:291
 msgid "No username specified"
 msgstr "未指定用户名"
 
-#: src/gui/dialogs/preferences_dialog.cpp:265
+#: src/gui/dialogs/preferences_dialog.cpp:249
 msgid "Invalid username"
 msgstr "无效用户名"
 
-#: src/gui/dialogs/preferences_dialog.cpp:312
+#: src/gui/dialogs/preferences_dialog.cpp:296
 msgid "Not on friends or ignore lists"
 msgstr "不在好友或忽略列表上"
 
-#: src/gui/dialogs/preferences_dialog.cpp:931
-#: src/gui/dialogs/preferences_dialog.cpp:995
+#: src/gui/dialogs/preferences_dialog.cpp:927
+#: src/gui/dialogs/preferences_dialog.cpp:993
 msgid "No hotkey selected"
 msgstr "未选定热键"
 
-#: src/gui/dialogs/preferences_dialog.cpp:959
+#: src/gui/dialogs/preferences_dialog.cpp:955
 msgid ""
 "“<b>$hotkey_sequence|</b>” is in use by “<b>$old_hotkey_action|</b>”.\n"
 "Do you wish to reassign it to “<b>$new_hotkey_action|</b>”?"
@@ -8362,15 +8246,15 @@ msgstr ""
 "“<b>$hotkey_sequence</b>”目前已用于“<b>$old_hotkey_action</b>”。\n"
 "你希望将该快捷键序列重新指定给“<b>$new_hotkey_action|</b>”吗？"
 
-#: src/gui/dialogs/preferences_dialog.cpp:965
+#: src/gui/dialogs/preferences_dialog.cpp:961
 msgid "Reassign Hotkey"
 msgstr "重新指定快捷键"
 
-#: src/gui/dialogs/preferences_dialog.cpp:982
+#: src/gui/dialogs/preferences_dialog.cpp:978
 msgid "All hotkeys have been reset to their default values."
 msgstr "所有快捷键都已被重置为默认值。"
 
-#: src/gui/dialogs/preferences_dialog.cpp:982
+#: src/gui/dialogs/preferences_dialog.cpp:978
 msgid "Hotkeys Reset"
 msgstr "重置快捷键"
 
@@ -8555,7 +8439,7 @@ msgstr "从服务器上删除附加组件"
 #. TRANSLATORS: This is the new chat text indicator
 #: src/gui/widgets/chatbox.cpp:95
 msgid "NEW"
-msgstr ""
+msgstr "新"
 
 #: src/gui/widgets/chatbox.cpp:298
 msgid "whisper to $receiver"
@@ -8574,10 +8458,8 @@ msgstr ""
 "ignore $name</b>"
 
 #: src/gui/widgets/helper.cpp:147
-#, fuzzy
-#| msgid "Mandatory widget '$id' hasn't been defined."
 msgid "Mandatory widget ‘$id’ hasn't been defined."
-msgstr "必须的界面构件“$id|”尚未定义。"
+msgstr "必须的构件“$id|”尚未定义。"
 
 #: src/gui/widgets/label.cpp:137 src/gui/widgets/multiline_text.cpp:429
 msgid "Open link?"
@@ -8588,9 +8470,6 @@ msgid "Copied link!"
 msgstr "已复制链接！"
 
 #: src/gui/widgets/listbox.cpp:696 src/gui/widgets/multi_page.cpp:224
-#, fuzzy
-#| msgid ""
-#| "'list_data' must have the same number of columns as the 'list_definition'."
 msgid ""
 "‘list_data’ must have the same number of columns as the ‘list_definition’."
 msgstr "“list_data”与“list_definition”中的列数必须一致。"
@@ -8600,22 +8479,18 @@ msgid "No list defined."
 msgstr "没有已定义的列表。"
 
 #: src/gui/widgets/listbox.cpp:736
-#, fuzzy
-#| msgid "A 'list_definition' should contain one row."
 msgid "A ‘list_definition’ should contain one row."
-msgstr "每个“list_definition”（列表定义）应该至少有一行。"
+msgstr "每个“list_definition”应该至少含有一行。"
 
 #: src/gui/widgets/multi_page.cpp:200
 msgid "No page defined."
 msgstr "没有已定义的页面。"
 
 #: src/gui/widgets/multiline_text.cpp:434
-#, fuzzy
-#| msgid "Opening links is not supported, contact your packager"
 msgid ""
 "Opening links is not supported, contact your packager. Link URL has been "
 "copied to the clipboard."
-msgstr "不支持打开链接，请联系你的打包者"
+msgstr "不支持打开链接，请联系你的打包者。链接URL已被复制到剪贴板。"
 
 #: src/gui/widgets/multimenu_button.cpp:171
 msgid "multimenu^All Selected"
@@ -8648,8 +8523,6 @@ msgid "No widget defined."
 msgstr "没有已定义的界面构件。"
 
 #: src/gui/widgets/slider.cpp:356
-#, fuzzy
-#| msgid "The number of value_labels and values don't match."
 msgid "The number of value_labels and values don’t match."
 msgstr "value_label的数量与值（value）的数量不匹配。"
 
@@ -8662,18 +8535,14 @@ msgid "Found a widget with a helptip and without a tooltip."
 msgstr "发现有帮助提示但却没有提示小标签的界面构件。"
 
 #: src/gui/widgets/tab_container.cpp:172
-#, fuzzy
-#| msgid "No nodes defined for a tree view."
 msgid "No grid defined for tab container control"
-msgstr "没有已定义的树状视图节点。"
+msgstr "页面容器控件的网格未定义"
 
 #: src/gui/widgets/tree_view.cpp:289
 msgid "No nodes defined for a tree view."
-msgstr "没有已定义的树状视图节点。"
+msgstr "树状视图的节点未定义。"
 
 #: src/gui/widgets/tree_view.cpp:319
-#, fuzzy
-#| msgid "[node]id 'root' is reserved for the implementation."
 msgid "[node]id ‘root’ is reserved for the implementation."
 msgstr "[节点]ID‘root’是保留给游戏实现专用的。"
 
@@ -8691,17 +8560,17 @@ msgstr "（攻/防）"
 
 #: src/gui/widgets/unit_preview_pane.cpp:220
 msgid "Remaining: $left/$max"
-msgstr ""
+msgstr "剩余：$left/$max"
 
 #: src/gui/widgets/unit_preview_pane.cpp:223
 msgid "This unit can attack multiple times per turn."
-msgstr ""
+msgstr "此单位每回合可以攻击多次。"
 
 #: src/gui/widgets/unit_preview_pane.cpp:275
 msgid "uses $num attack"
 msgid_plural "uses $num attacks"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "使用$num|次攻击"
+msgstr[1] "使用$num|次攻击"
 
 #: src/gui/widgets/unit_preview_pane.cpp:318
 #: src/gui/widgets/unit_preview_pane.cpp:349
@@ -8741,22 +8610,16 @@ msgid "Abilities"
 msgstr "能力"
 
 #: src/gui/widgets/window.cpp:287
-#, fuzzy
-#| msgid "Linked '$id' group has multiple definitions."
 msgid "Linked ‘$id’ group has multiple definitions."
 msgstr "连接的“$id|”组有多个定义。"
 
 #: src/gui/widgets/window.cpp:884
-#, fuzzy
-#| msgid "Click dismiss needs a 'click_dismiss' or 'ok' button."
 msgid "Click dismiss needs a ‘click_dismiss’ or ‘ok’ button."
 msgstr "单击“开除”需要一个“click_dismiss”或“ok”按钮。"
 
 #: src/gui/widgets/window.cpp:909 src/gui/widgets/window.cpp:945
-#, fuzzy
-#| msgid "Failed to show a dialog, which doesn't fit on the screen."
 msgid "Failed to show a dialog, which doesn’t fit on the screen."
-msgstr "无法显示对话框，对话框不适应屏幕大小。"
+msgstr "未能显示对话框，对话框超出屏幕大小。"
 
 #: src/hotkey/hotkey_command.cpp:52
 msgid "Saved Games"
@@ -8843,10 +8706,8 @@ msgid "Select/Move/Attack"
 msgstr "选择/移动/攻击"
 
 #: src/hotkey/hotkey_command.cpp:84
-#, fuzzy
-#| msgid "Touch"
 msgid "Touch Hex"
-msgstr "触击"
+msgstr "触击六角格"
 
 #: src/hotkey/hotkey_command.cpp:85
 msgid "Animate Map"
@@ -8925,10 +8786,8 @@ msgid "Save Map"
 msgstr "保存地图"
 
 #: src/hotkey/hotkey_command.cpp:110
-#, fuzzy
-#| msgid "Loading..."
 msgid "Load Turn..."
-msgstr "正在载入……"
+msgstr "载入回合……"
 
 #: src/hotkey/hotkey_command.cpp:112
 msgid "Repeat Recruit"
@@ -8980,10 +8839,8 @@ msgid "Kill Unit (Debug!)"
 msgstr "杀死单位（调试！）"
 
 #: src/hotkey/hotkey_command.cpp:126
-#, fuzzy
-#| msgid "Create Unit (Debug!)"
 msgid "Teleport Unit (Debug!)"
-msgstr "创建单位（调试！）"
+msgstr "传送单位（调试！）"
 
 #: src/hotkey/hotkey_command.cpp:128
 msgid "Objectives"
@@ -9122,7 +8979,7 @@ msgstr "指定本地时间"
 
 #: src/hotkey/hotkey_command.cpp:178
 msgid "New Unit Type"
-msgstr "新单位类型"
+msgstr "下一单位类型"
 
 #: src/hotkey/hotkey_command.cpp:180
 msgid "Time Schedule Editor"
@@ -9137,20 +8994,16 @@ msgid "New Scenario"
 msgstr "新建场景"
 
 #: src/hotkey/hotkey_command.cpp:184
-#, fuzzy
-#| msgid "Edit Scenario"
 msgid "Load Map/Scenario"
-msgstr "编辑场景"
+msgstr "载入地图/场景"
 
 #: src/hotkey/hotkey_command.cpp:186
 msgid "Save Map As"
 msgstr "地图另存为"
 
 #: src/hotkey/hotkey_command.cpp:187
-#, fuzzy
-#| msgid "Choose Test Scenario"
 msgid "Convert To Scenario"
-msgstr "选择测试场景"
+msgstr "转换为场景"
 
 #: src/hotkey/hotkey_command.cpp:188
 msgid "Save Scenario As"
@@ -9486,17 +9339,15 @@ msgstr "添加新的区域"
 
 #: src/hotkey/hotkey_command.cpp:277
 msgid "Add-on Publishing Editor"
-msgstr ""
+msgstr "附加组件发布编辑器"
 
 #: src/hotkey/hotkey_command.cpp:278
 msgid "Change Add-on ID"
 msgstr "修改附加组件ID"
 
 #: src/hotkey/hotkey_command.cpp:279
-#, fuzzy
-#| msgid "Select the add-on version"
 msgid "Select active Add-on"
-msgstr "选择附加组件版本"
+msgstr "选择活动附加组件"
 
 #: src/hotkey/hotkey_command.cpp:280
 msgid "Open Add-on folder"
@@ -9564,10 +9415,8 @@ msgid "Change Language"
 msgstr "改变语言"
 
 #: src/hotkey/hotkey_command.cpp:301
-#, fuzzy
-#| msgid "Starting game"
 msgid "Start Game (MP)"
-msgstr "正在开始游戏"
+msgstr "开始游戏（多人）"
 
 #: src/hotkey/hotkey_command.cpp:302
 msgid "Refresh WML"
@@ -9617,11 +9466,11 @@ msgstr "显示Lua控制台"
 msgid "Unrecognized Command"
 msgstr "未识别的命令"
 
-#: src/preferences/preferences.cpp:1299
+#: src/preferences/preferences.cpp:1248
 msgid "No known themes. Try changing from within an existing game."
 msgstr "无已知主题。请尝试在游戏中切换主题。"
 
-#: src/preferences/preferences.cpp:1336
+#: src/preferences/preferences.cpp:1285
 msgid ""
 "The <b>$filename</b> server application provides multiplayer server "
 "functionality and is required for hosting local network games. It will "
@@ -9630,15 +9479,15 @@ msgstr ""
 "<b>$filename</b>服务器应用提供了多人游戏服务器机能，在主建本地联机游戏时是必"
 "须的。通常可以在游戏可执行文件的同一个目录下找到它。"
 
-#: src/preferences/preferences.cpp:1340
+#: src/preferences/preferences.cpp:1289
 msgid "Find Server Application"
 msgstr "查找服务器应用"
 
-#: src/preferences/preferences.cpp:1822
+#: src/preferences/preferences.cpp:1771
 msgid "[%H:%M]"
 msgstr "[%H:%M]"
 
-#: src/preferences/preferences.cpp:1824
+#: src/preferences/preferences.cpp:1773
 msgid "[%I:%M %p]"
 msgstr "[%I:%M %p]"
 
@@ -9655,213 +9504,52 @@ msgid "When reporting the bug please include the following error message :"
 msgstr "报告BUG时请包含以下错误信息："
 
 #: src/wml_exception.cpp:89
-#, fuzzy
-#| msgid ""
-#| "In section '[$section|]' where '$primary_key| = $primary_value' the "
-#| "mandatory key '$key|' isn't set."
 msgid ""
 "In section ‘[$section|]’ where ‘$primary_key|’ = ‘$primary_value’ the "
 "mandatory key ‘$key|’ isn’t set."
 msgstr ""
-"在‘$primary_key| = $primary_value|’的小节‘[$section|]’中，必须设定的主"
-"键‘$key|’没有设定值。"
+"在‘$primary_key|’ = ‘$primary_value|’的‘[$section|]’小节中，必须设定的"
+"键‘$key|’没有设定。"
 
 #: src/wml_exception.cpp:92
-#, fuzzy
-#| msgid "In section '[$section|]' the mandatory key '$key|' isn't set."
 msgid "In section ‘[$section|]’ the mandatory key ‘$key|’ isn’t set."
-msgstr "在小节‘[$section|]’中，必须设定的主键‘$key|’没有设定值。"
+msgstr "在‘[$section|]’小节中，必须设定的键‘$key|’没有设定。"
 
 #: src/wml_exception.cpp:104
-#, fuzzy
-#| msgid "In section '[$section|]' the mandatory key '$key|' isn't set."
 msgid "In section ‘[$section|]’ the mandatory subtag ‘[$tag|]’ is missing."
-msgstr "在小节‘[$section|]’中，必须设定的主键‘$key|’没有设定值。"
+msgstr "在‘[$section|]’小节中，必须存在的子标签‘[$tag|]’不存在。"
 
-#~ msgid "Rocky Sands"
-#~ msgstr "岩石沙砾"
+msgid "Choose your preferred language:"
+msgstr "选择你偏好的语言："
 
-#~ msgid "Sands"
-#~ msgstr "沙地"
+msgid "By:"
+msgstr "作者："
 
-#~ msgid "Connected Players"
-#~ msgstr "已连接的玩家"
+msgid "Active Troops:"
+msgstr "出战部队数："
 
-#~ msgid "Reloading alters future combat outcomes"
-#~ msgstr "重新载入存档将改变未来的战斗结果"
+msgid "Reserve Troops:"
+msgstr "后备部队数："
 
-#~ msgid "Combat outcomes remain constant when reloading"
-#~ msgstr "战斗结果不受重新载入存档影响"
+msgid "Area to draw has negative size"
+msgstr "绘图区域的尺寸为负值"
 
-#~ msgid "Biased RNG (experimental)"
-#~ msgstr "偏心的随机数生成器（实验性）"
+msgid "Area to draw is larger than widget size"
+msgstr "绘图区域比部界面构件尺寸大"
 
-#~ msgid ""
-#~ "Combat outcomes are more in line with displayed probabilities and "
-#~ "unaffected by reloading"
-#~ msgstr ""
-#~ "战斗结果与显示的概率所产生的直觉结果更加一致，且不受重新载入存档影响"
+msgid ""
+"A terrain with a string with more than 4 characters has been found, the "
+"affected terrain is:"
+msgstr "找到一个具有长度超过4个字符的字符串的地形，受影响的地形是："
 
-#~ msgid "Add-on ID"
-#~ msgstr "附加组件ID"
+msgid ""
+"The key '$key' is deprecated and support will be removed in version "
+"$removal_version."
+msgstr "键‘$key|’已废弃，且对此主键的支持将在版本$removal_version|中移除。"
 
-#~ msgid "Configuration:"
-#~ msgstr "配置："
-
-#~ msgid "Copy the full report to clipboard"
-#~ msgstr "将完整的报告复制到剪贴板"
-
-#~ msgid "Battle For Wesnoth Help"
-#~ msgstr "韦诺之战帮助"
-
-#~ msgid "<b>Faction:</b>"
-#~ msgstr "<b>派系：</b>"
-
-#~ msgid "Turn dialog"
-#~ msgstr "回合对话框"
-
-#~ msgid "Limit FPS"
-#~ msgstr "限制FPS"
-
-#~ msgid ""
-#~ "Disabling this increases CPU usage, but may slightly improve performance "
-#~ "(requires restart to take effect)"
-#~ msgstr ""
-#~ "禁用此项将提高CPU使用率，但或许能够稍稍提升游戏性能（需要重启后才能生效）"
-
-#~ msgid "View the credits"
-#~ msgstr "查看制作者名单"
-
-#~ msgid "filesystem_path_game^User preferences"
-#~ msgstr "玩家首选项"
-
-#~ msgid "--userdata-dir=<relative path that doesn't start with a period>"
-#~ msgstr "--userdata-dir=<不以点号开头的相对路径>"
-
-#~ msgid ""
-#~ "Use an absolute path, or a relative path that starts with a period and a "
-#~ "backslash"
-#~ msgstr "使用绝对路径，或以点号及反斜杠开头的相对路径"
-
-#~ msgid "--userdata-dir=<relative path>"
-#~ msgstr "--userdata-dir=<相对路径>"
-
-#~ msgid ""
-#~ "Use absolute paths. Relative paths are deprecated because they are "
-#~ "interpreted relative to $HOME"
-#~ msgstr ""
-#~ "使用绝对路径。此处对相对路径的支持已经废弃，因为在解释相对路径时，是相对于"
-#~ "$HOME的"
-
-#~ msgid "The text contains invalid Pango markup: "
-#~ msgstr "文本中包含非法的Pango标记："
-
-#~ msgid "timespan^expired"
-#~ msgstr "过期"
-
-#~ msgid "timespan^$num year"
-#~ msgid_plural "timespan^$num years"
-#~ msgstr[0] "$num|年"
-#~ msgstr[1] "$num|年"
-
-#~ msgid "timespan^$num month"
-#~ msgid_plural "timespan^$num months"
-#~ msgstr[0] "$num|月"
-#~ msgstr[1] "$num|月"
-
-#~ msgid "timespan^$num week"
-#~ msgid_plural "timespan^$num weeks"
-#~ msgstr[0] "$num|周"
-#~ msgstr[1] "$num|周"
-
-#~ msgid "timespan^$num day"
-#~ msgid_plural "timespan^$num days"
-#~ msgstr[0] "$num|日"
-#~ msgstr[1] "$num|日"
-
-#~ msgid "timespan^$num hour"
-#~ msgid_plural "timespan^$num hours"
-#~ msgstr[0] "$num|时"
-#~ msgstr[1] "$num|时"
-
-#~ msgid "timespan^$num minute"
-#~ msgid_plural "timespan^$num minutes"
-#~ msgstr[0] "$num|分"
-#~ msgstr[1] "$num|分"
-
-#~ msgid "timespan^$num second"
-#~ msgid_plural "timespan^$num seconds"
-#~ msgstr[0] "$num|秒"
-#~ msgstr[1] "$num|秒"
-
-#~ msgid "Text has a font size of 0."
-#~ msgstr "字体大小是0。"
-
-#~ msgid "Clipboard support not found, contact your packager"
-#~ msgstr "未找到剪贴板支持，请联系你的打包者"
-
-#~ msgid "Running on $os"
-#~ msgstr "运行于$os之上"
-
-#~ msgid "Load Map"
-#~ msgstr "载入地图"
-
-#~ msgid "Choose your preferred language:"
-#~ msgstr "选择你偏好的语言："
-
-#~ msgid "No node defined."
-#~ msgstr "没有已定义的节点。"
-
-#~ msgid "By:"
-#~ msgstr "作者："
-
-#~ msgid "Gold Left:"
-#~ msgstr "剩余金币："
-
-#~ msgid "Active Troops:"
-#~ msgstr "出战部队数："
-
-#~ msgid "Reserve Troops:"
-#~ msgstr "后备部队数："
-
-#~ msgid "Resolution:"
-#~ msgstr "分辨率："
-
-#~ msgid "Show floating labels"
-#~ msgstr "显示浮动标签"
-
-#~ msgid "Show team colors"
-#~ msgstr "显示团队颜色"
-
-#~ msgid "Show grid"
-#~ msgstr "显示网格"
-
-#~ msgid "Area to draw has negative size"
-#~ msgstr "绘图区域的尺寸为负值"
-
-#~ msgid "Area to draw is larger than widget size"
-#~ msgstr "绘图区域比部界面构件尺寸大"
-
-#~ msgid "Selected Game"
-#~ msgstr "选中的游戏"
-
-#~ msgid "Start Test Scenario"
-#~ msgstr "开始测试场景"
-
-#~ msgid ""
-#~ "A terrain with a string with more than 4 characters has been found, the "
-#~ "affected terrain is:"
-#~ msgstr "找到一个具有长度超过4个字符的字符串的地形，受影响的地形是："
-
-#~ msgid ""
-#~ "The key '$key' is deprecated and support will be removed in version "
-#~ "$removal_version."
-#~ msgstr ""
-#~ "主键‘$key|’已废弃，且对此主键的支持将在版本$removal_version|中移除。"
-
-#~ msgid ""
-#~ "The key '$deprecated_key' has been renamed to '$key'. Support for "
-#~ "'$deprecated_key' will be removed in version $removal_version."
-#~ msgstr ""
-#~ "主键‘$deprecated_key|’已重命名为‘$key’。对‘$deprecated_key|’的支持将在版本"
-#~ "$removal_version|中移除。"
+msgid ""
+"The key '$deprecated_key' has been renamed to '$key'. Support for "
+"'$deprecated_key' will be removed in version $removal_version."
+msgstr ""
+"键‘$deprecated_key|’已重命名为‘$key’。对‘$deprecated_key|’的支持将在版本"
+"$removal_version|中移除。"

--- a/translations/wesnoth/po/wesnoth-lib/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-lib/zh_CN.po
@@ -9518,38 +9518,3 @@ msgstr "在‘[$section|]’小节中，必须设定的键‘$key|’没有设�
 #: src/wml_exception.cpp:104
 msgid "In section ‘[$section|]’ the mandatory subtag ‘[$tag|]’ is missing."
 msgstr "在‘[$section|]’小节中，必须存在的子标签‘[$tag|]’不存在。"
-
-msgid "Choose your preferred language:"
-msgstr "选择你偏好的语言："
-
-msgid "By:"
-msgstr "作者："
-
-msgid "Active Troops:"
-msgstr "出战部队数："
-
-msgid "Reserve Troops:"
-msgstr "后备部队数："
-
-msgid "Area to draw has negative size"
-msgstr "绘图区域的尺寸为负值"
-
-msgid "Area to draw is larger than widget size"
-msgstr "绘图区域比部界面构件尺寸大"
-
-msgid ""
-"A terrain with a string with more than 4 characters has been found, the "
-"affected terrain is:"
-msgstr "找到一个具有长度超过4个字符的字符串的地形，受影响的地形是："
-
-msgid ""
-"The key '$key' is deprecated and support will be removed in version "
-"$removal_version."
-msgstr "键‘$key|’已废弃，且对此主键的支持将在版本$removal_version|中移除。"
-
-msgid ""
-"The key '$deprecated_key' has been renamed to '$key'. Support for "
-"'$deprecated_key' will be removed in version $removal_version."
-msgstr ""
-"键‘$deprecated_key|’已重命名为‘$key’。对‘$deprecated_key|’的支持将在版本"
-"$removal_version|中移除。"

--- a/translations/wesnoth/po/wesnoth-low/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-low/zh_CN.po
@@ -1,39 +1,40 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
 # wind <everywherewind@gmail.com>, 2011.
 # CloudiDust <cloudidust@gmail.com>, 2017.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.16\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-09-18 02:19 UTC\n"
-"PO-Revision-Date: 2024-06-28 13:51+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-06-23 03:16 UTC\n"
+"PO-Revision-Date: 2026-08-26 21:51+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:44
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:45
 msgid "LoW"
 msgstr "LoW"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:45
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:46
 msgid "Legend of Wesmere"
 msgstr "韦弥尔传奇"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:47
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:51
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:48
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:52
 msgid ""
 "The tale of Kalenz, the High Lord who rallied his people after the second "
 "orcish invasion of the Great Continent and became the most renowned hero in "
@@ -45,88 +46,88 @@ msgstr ""
 "\n"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:49
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:50
 msgid "(Hard level, 17 scenarios.)"
 msgstr "（困难级别，17幕场景。）"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:53
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:54
 msgid "(Hard level, 18 scenarios.)"
 msgstr "（困难级别，18幕场景。）"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:57
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:58
 msgid "Normal"
 msgstr "普通"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:57
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:58
 msgid "Soldier"
 msgstr "士兵"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:58
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:59
 msgid "Challenging"
 msgstr "挑战"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:58
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:59
 msgid "Lord"
 msgstr "领主"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:59
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:60
 msgid "Difficult"
 msgstr "困难"
 
 #. [campaign]: id=LOW, type=hybrid
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:59
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:60
 msgid "High Lord"
 msgstr "高阶领主"
 
 #. [about]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:62
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:63
 msgid "Creator and Lead Designer"
 msgstr "制作者与主要设计者"
 
 #. [entry]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:64
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:77
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:65
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:78
 msgid "Spiros, George and Alexander Alexiou (Santi/fnaek)"
 msgstr "Spiros，George，以及Alexander Alexiou（Santi/fnaek）"
 
 #. [about]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:71
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:72
 msgid "Campaign Maintenance"
 msgstr "战役维护"
 
 #. [about]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:81
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:82
 msgid "Prose-doctoring and adaptation for mainline"
 msgstr "故事修订与主线改编"
 
 #. [about]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:91
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:92
 msgid "WML Assistance"
 msgstr "WML协助"
 
 #. [about]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:106
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:107
 msgid "Artificial Intelligence"
 msgstr "人工智能"
 
 #. [about]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:113
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:114
 msgid "Graphics"
 msgstr "图像"
 
 #. [about]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:129
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:130
 msgid "Additional thanks to"
 msgstr "鸣谢"
 
 #. [entry]
-#: data/campaigns/Legend_of_Wesmere/_main.cfg:187
+#: data/campaigns/Legend_of_Wesmere/_main.cfg:188
 msgid ""
 "And the rest of the Wesnoth community for feedback,\n"
 "criticism, help with WML code and graphics."
@@ -135,132 +136,132 @@ msgstr ""
 "评论，以及对WML代码和图像所提供的帮助。"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:15
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:11
 msgid "Essarn"
 msgstr "埃萨恩"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:24
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:20
 msgid "Valcathra"
 msgstr "瓦尔卡特"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:33
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:29
 msgid "River Telfar"
 msgstr "泰法河"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:42
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:38
 msgid "Telfar Green"
 msgstr "泰法绿林"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:51
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:47
 msgid "Erethean"
 msgstr "埃雷森"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:60
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:56
 msgid "Northern Shallows"
 msgstr "北方浅滩"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:69
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:65
 msgid "Arthen"
 msgstr "阿尔滕"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:78
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:74
 msgid "Dancer’s Green"
 msgstr "舞者绿林"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:87
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:83
 msgid "Illissa"
 msgstr "伊利撒"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:96
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:92
 msgid "Brightleaf Wood"
 msgstr "亮叶树林"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:105
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:101
 msgid "Viricon"
 msgstr "维里康"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:114
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:110
 msgid "Ford of Alyas"
 msgstr "阿亚斯浅滩"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:123
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:119
 msgid "Elendor"
 msgstr "埃伦德"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:132
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:128
 msgid "Telionath"
 msgstr "泰利奥纳特"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:141
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:137
 msgid "West Tower"
 msgstr "西塔"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:150
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:146
 msgid "North Bridge"
 msgstr "北桥"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:159
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:155
 msgid "North Tower"
 msgstr "北塔"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:168
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:164
 msgid "South Bastion"
 msgstr "南方堡垒"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:177
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:173
 msgid "Tireas"
 msgstr "特雷亚斯"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:186
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:182
 msgid "East Tower"
 msgstr "东塔"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:195
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:191
 msgid "Aelion"
 msgstr "阿埃利翁"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:204
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:200
 msgid "Ford of Tifranur"
 msgstr "迪弗兰努浅滩"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:213
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:209
 msgid "Karmarth Hills"
 msgstr "卡玛斯小山"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:222
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:218
 msgid "Arryn"
 msgstr "艾伦"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:231
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:227
 msgid "Westwind Wood"
 msgstr "西风树林"
 
 #. [label]
-#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:240
+#: data/campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg:236
 msgid "Southwind Wood"
 msgstr "南风树林"
 
@@ -365,22 +366,22 @@ msgstr ""
 "这是卡雷兹和兰达尔的故事，也是在人类刚来到韦诺的时代，精灵族的故事。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:123
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:117
 msgid "You trifled with the wrong elf!"
 msgstr "你居然敢玩弄精灵，找错对象了！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:133
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:127
 msgid "Take that, you orcish scum!"
 msgstr "接招吧，你们这群兽人混蛋！"
 
 #. [side]: id=Velon, type=Elvish Captain
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:165
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:158
 msgid "Velon"
 msgstr "维伦"
 
 #. [side]: id=Tbaran, type=Orcish Warrior
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:191
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:184
 msgid "T’baran"
 msgstr "特巴兰"
 
@@ -410,69 +411,69 @@ msgstr "特巴兰"
 #. [side]: type=Saurian Flanker, id=Hgyr
 #. [side]: type=Elvish Marshal, id=Crintil
 #. [side]: type=Elvish Captain, id=Oblil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:193
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:229
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:262
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:297
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:144
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:221
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:244
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:429
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:180
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:263
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:298
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:113
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:138
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:158
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:187
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:135
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:165
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:202
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:205
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:139
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:169
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:118
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:119
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:158
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:132
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:105
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:141
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:175
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:186
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:222
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:255
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:290
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:138
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:215
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:238
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:423
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:176
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:258
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:293
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:107
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:132
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:156
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:185
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:133
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:163
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:200
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:198
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:136
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:166
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:115
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:116
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:155
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:131
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:103
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:139
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:173
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg:129
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg:160
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:139
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:280
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:314
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:190
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:224
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:95
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:136
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:277
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:311
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:188
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:222
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:94
 msgid "Enemies"
 msgstr "敌人"
 
 #. [side]: id=Wrulf, type=Orcish Warrior
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:227
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:220
 msgid "Wrulf"
 msgstr "沃若夫"
 
 #. [side]: type=Orcish Warrior, id=Qumseh
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:267
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:260
 msgid "Qumseh"
 msgstr "库姆塞"
 
 #. [side]: type=Orcish Warrior, id=Graur-Tan
 #. [side]: type=Orcish Warlord, id=Graur-Tan
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:302
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:160
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:295
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:158
 msgid "Graur-Tan"
 msgstr "格兰努-坦"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:332
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:325
 msgid "Orcs are pressing on us from all directions! To arms!"
 msgstr "兽人正在从各个方向朝我们推进！拿起武器！"
 
 #. [message]: id=Velon
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:336
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:329
 msgid ""
 "Hold, Kalenz. The Ka’lian Council should discuss our response. Maybe we can "
 "reach an agreement with them!"
@@ -481,117 +482,117 @@ msgstr ""
 "议！"
 
 #. [message]: id=Qumseh
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:340
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:333
 msgid "Surrender or die, tree-shaggers!"
 msgstr "要么投降，要么死，树上长毛的家伙！"
 
 #. [message]: id=Velon
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:344
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:337
 msgid "They are too many. We have no choice but to submit!"
 msgstr "敌人太多了。我们只能投降了！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:348
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:341
 msgid ""
 "Elves must never surrender to these foul beasts! Who will fight them beside "
 "me?"
 msgstr "精灵们绝不向这群肮脏的野兽投降！有谁愿与我并肩作战？"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:356
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:349
 msgid "We will follow you, Kalenz — but where can we go?"
 msgstr "我们将追随你，卡雷兹——但我们又能去哪呢？"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:360
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:353
 msgid ""
 "We must reach the Elvish Council in Ka’lian and enlist their help to "
 "recapture our home."
 msgstr "我们必须到卡-利安的精灵评议会去，得到他们的帮助，夺回我们的家园。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:364
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:357
 msgid "We are surrounded!"
 msgstr "我们被包围了！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:368
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:361
 msgid ""
 "Then we must storm one of the orcs’ outposts to break the encirclement "
 "before more enemies arrive!"
 msgstr "我们必须在更多兽人到来之前，拔除一个前哨站，打破包围圈！"
 
 #. [message]: id=Anduilas
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:372
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:365
 msgid "Very well, Kalenz — lead us!"
 msgstr "太好了，卡雷兹——带领我们！"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:386
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:379
 msgid "Kill any of the orc leaders"
 msgstr "杀死任何一名兽人首领"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:391
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:384
 msgid "Keep Velon alive"
 msgstr "让维纶存活"
 
 #. [objective]: condition=lose
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:395
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:516
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:797
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:172
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:211
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:371
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:225
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:307
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:305
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:195
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:213
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:257
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:388
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:510
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:790
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:166
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:209
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:368
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:223
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:300
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:297
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:192
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:210
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:253
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:265
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:263
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:261
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg:220
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:370
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:282
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:305
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:119
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:367
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:280
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:303
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:118
 msgid "Death of Kalenz"
 msgstr "卡雷兹死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:399
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:520
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:801
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:176
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:215
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:375
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:229
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:311
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:309
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:199
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:217
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:261
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:392
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:514
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:794
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:170
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:213
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:372
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:227
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:304
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:301
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:196
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:214
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:257
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:269
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:267
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:265
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg:224
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:309
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:307
 msgid "Death of Landar"
 msgstr "兰达尔死亡"
 
 #. [message]: id=Velon
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:425
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:418
 msgid "We surrender!"
 msgstr "我们投降！"
 
 #. [message]: id=Graur-Tan
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:429
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:422
 msgid "Did I mention that we take no prisoners? Die!"
 msgstr "忘了说了，我们不收战俘？去死吧！"
 
 #. [message]: id=Velon
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:434
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:427
 msgid ""
 "Kalenz was right and I was wrong. Go; join Kalenz while yet you can. I and "
 "the remaining elders will cover your retreat as best we may."
@@ -600,51 +601,51 @@ msgstr ""
 "尽最大努力掩护你们撤退。"
 
 #. [message]: id=Velon
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:452
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:445
 msgid "Flee, Kalenz... find vengeance for us!"
 msgstr "快逃， 卡雷兹……为我们复仇！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:456
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:449
 msgid ""
 "Velon, I swear on the life of Irdya that I will not let you be forgotten "
 "while elves yet draw breath to sing."
 msgstr "维伦，我对艾瑞达的生命发誓，只要精灵还有气歌唱，我就不会忘记你。"
 
 #. [message]: id=Velon
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:465
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:458
 msgid "Swords will aid us more than songs, Kalenz; you saw that before I."
 msgstr "剑比歌更能帮助我们，卡雷兹；你比我预见的远。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:469
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:462
 msgid "Swordsmen you shall have, as swiftly as I can find them and return."
 msgstr "只要我找到他们并回来，你就会有自己的武装。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:479
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:472
 msgid ""
 "Velon has fallen. He counseled weakness, but did not deserve such an ugly "
 "death. We shall return with swords to avenge him!"
 msgstr "维伦死了。他很懦弱，但不该死得这么惨。我们会回来用剑给他报仇的！"
 
 #. [message]: race=orc
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:497
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:490
 msgid "You won’t get very far! After them!"
 msgstr "你们逃不掉了！追上他们！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:514
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:507
 msgid "Curse you, tree-shaggers! We will feed your young to our wolves!"
 msgstr "咒你全家，树上长毛的家伙！我要把你们的孩子都喂狼！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:527
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:520
 msgid "What is this? The orc held plunder!"
 msgstr "这是什么？兽人手上有战利品！"
 
 #. [message]: id=Velon
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:570
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg:563
 msgid "Flee, Kalenz... Our hopes ride with you..."
 msgstr "快逃，卡雷兹……你是我们最后的希望……"
 
@@ -668,29 +669,29 @@ msgstr ""
 
 #. [side]
 #. [modify_side]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:104
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:166
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:99
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:160
 #: data/campaigns/Legend_of_Wesmere/utils/characters.cfg:4
 msgid "Player"
 msgstr "玩家"
 
 #. [side]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:107
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:102
 msgid "Neutrals"
 msgstr "中立者"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:128
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:122
 msgid "Those stinking trolls ha’ stepped on <i>our</i> land!"
 msgstr "那些臭巨魔踏上<b>我们的</b>土地了！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:198
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:192
 msgid "Those lying elves have stepped on <i>our</i> land!"
 msgstr "那些不守信的精灵踏上<b>我们的</b>地盘了！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:202
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:196
 msgid ""
 "Fight to subdue, and do not kill unless you must. We have foes enough as it "
 "is without making blood enemies of these dwarves."
@@ -698,39 +699,39 @@ msgstr ""
 "克制情绪，不要一味杀戮。我们已经有了足够的敌人，不要再和这些矮人结下血仇了。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:349
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:343
 msgid ""
 "It should be rare sport to watch this... Just be sure not to trespass on our "
 "land."
 msgstr "这可难得一见啊……只要当心不要侵入我们的领土就行了。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:360
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:354
 msgid "Up axes, and death to elves!"
 msgstr "高举战斧，杀光精灵！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:371
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:365
 msgid "Up axes, and death to trolls!"
 msgstr "高举战斧，杀光巨魔！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:383
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:377
 msgid "Up axes, and kill all the interlopers!"
 msgstr "高举战斧，杀光入侵者！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:396
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:390
 msgid "Defend our bounds! Slay all who trespass them!"
 msgstr "保卫我们的边疆！杀光入侵的人！"
 
 #. [side]: type=Troll Hero, type=Great Troll, id=Grugl
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:426
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:420
 msgid "Grugl"
 msgstr "格鲁戈尔"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:470
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:464
 msgid ""
 "I had hoped to avoid these paths... The eastern way is through dwarvish "
 "territory and is shorter. I pray the dwarves will grant us safe passage, "
@@ -740,7 +741,7 @@ msgstr ""
 "我只能祈祷但愿矮人们能赏脸让我们安全通过。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:474
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:468
 msgid ""
 "Not even in yer dreams, elf. These are dwarvish lands, and troubles we want "
 "no part of nip at yer heels. Get out and stay out!"
@@ -749,7 +750,7 @@ msgstr ""
 "远点！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:478
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:472
 msgid ""
 "Our troubles will be yours, too, whether either of us wills it or not. The "
 "orcs have come down from the north like a flood; if we squabble among "
@@ -759,7 +760,7 @@ msgstr ""
 "水般冲来。如果我们鹬蚌相争，他们正好坐收渔翁之利。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:482
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:476
 msgid ""
 "Bah. More smooth words and trickery, by my beard. We know yer kind... and "
 "who needs yer help anyway, weaklings? Leave now, or feel my axe! That same "
@@ -771,12 +772,12 @@ msgstr ""
 "者。所有敢于登上河东岸的家伙会后悔那天他出生了！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:486
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:480
 msgid "I cannot see how trolls could be any less friendly."
 msgstr "我看巨魔恐怕也比他们友好些。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:490
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:484
 msgid ""
 "Hmm... Perhaps the dwarves’ intransigence can serve our purpose. Onwards, "
 "and no matter what you do, do <i>not</i> step on the eastern bank of the "
@@ -786,48 +787,48 @@ msgstr ""
 "河东岸半步！"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:506
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:500
 msgid "Kalenz or Landar must reach the signpost"
 msgstr "卡雷兹或兰达尔必须到达路标"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:512
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:506
 msgid "Defeat Grugl"
 msgstr "击败格鲁戈尔"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:524
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:233
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:317
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:207
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:221
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:265
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:279
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:518
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:231
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:309
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:204
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:218
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:261
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:277
 msgid "Death of Olurf"
 msgstr "奥勒夫死亡"
 
 #. [message]: speaker={SPEAKER_NAME}
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:540
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:534
 msgid "We made it. Onwards to Wesmere!"
 msgstr "我们成功了。继续向韦弥尔进军！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:551
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:545
 msgid "Crazy elves! But at least they felled a few trolls before they left."
 msgstr "精灵太疯狂了！不过至少走之前他们干掉了几个巨魔。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:557
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:551
 msgid "Crazy elves!"
 msgstr "精灵疯了！"
 
 #. [message]: id=Grugl
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:626
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:619
 msgid "Urgh! Grugl tried to eat dwarves, but choked on their sharp nasty axes."
 msgstr "唔哇啊！格鲁戈尔想要吃掉矮人，但被他们讨厌的利斧噎住了。"
 
 #. [message]: id=Grugl
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:642
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg:635
 msgid ""
 "Urgh! Grugl wanted tasty elf-meat, but choked on their nasty pointy spears!"
 msgstr "唔哇啊！格鲁戈尔想要尝尝精灵肉，但被他们讨厌的尖矛噎住了！"
@@ -845,105 +846,105 @@ msgid ""
 msgstr "在卡-利安，事态在卡雷兹和他的部队到达前就有了不好的转变……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:246
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:241
 msgid "Chief, the cursed tree-shaggers are defeating us!"
 msgstr "酋长，该死的树毛人打败了我们！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:332
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:326
 msgid "We die, but more come after us, orcs will rule all!"
 msgstr "我们战死了，但更多兽人将会赶来，兽人将统治一切！"
 
 #. [unit]: type=Orcish Slayer, id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:423
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:417
 msgid "Urudin"
 msgstr "乌鲁丁"
 
 #. [unit]: type=Orcish Warlord, id=Murudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:434
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:428
 msgid "Murudin"
 msgstr "穆鲁丁"
 
 #. [unit]: type=Orcish Warlord, id=Mutaf-uru
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:443
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:437
 msgid "Mutaf-uru"
 msgstr "木塔夫-乌鲁"
 
 #. [message]: id=Mutaf-uru
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:475
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:469
 msgid "Good, you are returned. What news is there?"
 msgstr "太好了，你回来了。有什么消息吗？"
 
 #. [message]: id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:479
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:473
 msgid ""
 "The elvish scum refused to surrender, Warlord. We have begun the attack, as "
 "planned."
 msgstr "精灵渣滓拒绝投降，督军。我们已经按计划进攻了。"
 
 #. [message]: id=Mutaf-uru
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:483
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:477
 msgid "Were you able to breach their citadel?"
 msgstr "你攻破他们的城堡了吗？"
 
 #. [message]: id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:491
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:485
 msgid "Yes. We slaughtered them in great numbers."
 msgstr "是的。我们宰了他们很多人。"
 
 #. [message]: id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:500
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:494
 msgid "No, our attack was repulsed."
 msgstr "不，我们的攻势被击退了。"
 
 #. [message]: id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:506
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:500
 msgid "They resisted us fiercely; the battle is not yet done."
 msgstr "他们拼死抵抗；战争还没结束。"
 
 #. [message]: id=Mutaf-uru
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:522
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:516
 msgid "Go, report this news to the warlord Grubr."
 msgstr "快去，把这个消息报告戈鲁巴督军。"
 
 #. [message]: id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:526
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:520
 msgid "I obey."
 msgstr "遵命。"
 
 #. [message]: id=Mutaf-uru
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:630
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:623
 msgid "These elves are weak, mere meat for my wolves! Get them!"
 msgstr "这些精灵太弱了，只能做我的狼的午餐！宰了他们！"
 
 #. [message]: id=Mutaf-uru
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:655
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:648
 msgid ""
 "Cursed tree-shaggers and their filthy bows! We shall await the main army."
 msgstr "该死的树毛人和他们该死的弓！我们必须等候大军。"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:793
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:303
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:786
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:296
 msgid "Defeat all enemy leaders."
 msgstr "击败所有敌方首领。"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:805
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:877
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:319
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:277
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:798
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:870
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:312
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:273
 msgid "Death of Galtrid"
 msgstr "加尔泰德死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:810
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:882
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:803
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:875
 msgid "Death of Eradion"
 msgstr "埃拉迪翁迪亚死亡"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:832
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:825
 msgid ""
 "For days, Kalenz and his small host of followers traveled, moving nearer and "
 "yet nearer to the Ka’lian. Thanks to the dense fog and elvish woodscraft, "
@@ -956,7 +957,7 @@ msgstr ""
 "开，却露出了一个残酷的景象……"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:836
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:829
 msgid ""
 "Great hosts of orcs converge on the Ka’lian! But if we fall upon them from "
 "behind as they are fully engaged with the defenders, we and they together "
@@ -966,12 +967,12 @@ msgstr ""
 "能打败兽人。"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:840
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:833
 msgid "Are you our army’s vanguard? Hurry, for we are sorely pressed here."
 msgstr "你们是军团的前锋吗？赶快，我们的压力非常大。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:844
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:837
 msgid ""
 "No, we are fleeing an attack on our home in the Lintanir. Time enough for "
 "talk later; we must defeat these orcs together, or at least hold them off "
@@ -981,36 +982,36 @@ msgstr ""
 "败这些兽人，或者至少我们顶住他们直到人类来救我们。"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:848
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:841
 msgid ""
 "Then you have not heard the ill tidings. King Haldric has broken the treaty. "
 "The humans will not come to our aid!"
 msgstr "你还没听说这糟糕的消息啊。哈德里克国王撕毁了条约。人类不会来帮我们了！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:852
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:845
 msgid "How dare they break the treaty!"
 msgstr "他们居然敢撕毁条约！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:863
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:856
 msgid ""
 "We have failed to relieve the defenders, and more orcish war-bands are "
 "arriving. All is lost!"
 msgstr "我们没能成功援救防线，更多兽人军队开来了。一切都完了！"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:872
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:865
 msgid "Hold on until turns run out."
 msgstr "坚持到回合耗尽。"
 
 #. [message]: id=guard
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:909
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:902
 msgid "Hist! Someone is sneaking about in the mist."
 msgstr "嘘！有人在雾中潜行。"
 
 #. [message]: id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:913
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:906
 msgid ""
 "Ho, elves! Hand over the stone and we <i>might</i> not destroy your cute "
 "little playhouse, and we <i>might</i> spare you. Or, at the very least, we "
@@ -1020,7 +1021,7 @@ msgstr ""
 "会放过你们。或者，至少我答应让你们死得痛快。"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:917
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:910
 msgid ""
 "What ‘stone’, foul and clumsy orc? Your lips are not fit even to name the "
 "citadel of the Ka’lian, for it has stood since before your kind crawled into "
@@ -1030,14 +1031,14 @@ msgstr ""
 "爬行时就建立起来，会一直矗立到你们从世上消失！"
 
 #. [message]: id=Urudin
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:931
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:924
 msgid ""
 "We will cram those arrogant words back down your throat before we kill you, "
 "wose-spawned worm of an elf!"
 msgstr "在我杀你们之前要叫你们把这些自大的话吞回去，精灵就是树人产下的虫卵！"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:982
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:975
 msgid ""
 "To arms, elven-kin! They are many, but our army is returning and surely "
 "close at hand. We have but to hold until it arrives!"
@@ -1046,7 +1047,7 @@ msgstr ""
 "兽人！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1067
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1060
 msgid ""
 "You will have a different recall list and amount of starting gold than you "
 "may be expecting at the beginning of this scenario, as you will not start "
@@ -1056,28 +1057,28 @@ msgstr ""
 "雷兹的军队开始。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1084
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1077
 msgid "We won! The Ka’lian is safe!"
 msgstr "我们赢了！卡-利安安全了！"
 
 #. [message]: id=Huraldur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1126
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1119
 msgid "The elvish treasury is under attack! They need help desperately!"
 msgstr "精灵的金库遭受攻击！他们急需援助！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1130
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1123
 msgid ""
 "Galtrid, your men are weary from long combat. Mine are fresher; I’ll go."
 msgstr "加尔泰德，你的人马战后疲惫。我的手下还有余力；我去增援。"
 
 #. [message]: id=Huraldur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1134
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1127
 msgid "Hurry! We were near overwhelmed as I left."
 msgstr "尽快！我要是走了我们就会招架不住的。"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1138
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg:1131
 msgid ""
 "Yes, go, Kalenz, I’ll guard the Ka’lian till our army returns from the front."
 msgstr "好的，去吧，卡雷兹，我会保护卡-利安直到我们的部队从前线回来。"
@@ -1117,58 +1118,58 @@ msgid ""
 msgstr "卡雷兹和他的部队赶去解救对精灵金库的围攻……"
 
 #. [side]: type=Saurian Ambusher, id=Shurm
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:108
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:102
 msgid "Shurm"
 msgstr "沙门"
 
 #. [side]: type=Saurian Ambusher, id=Trigr
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:133
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:127
 msgid "Trigr"
 msgstr "泰格"
 
 #. [objective]: condition=win
 #. [objectives]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:168
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:209
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:369
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:221
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:191
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:259
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:273
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:162
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:207
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:366
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:219
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:188
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:257
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:271
 msgid "Defeat all enemy leaders"
 msgstr "击败所有敌方首领"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:243
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:236
 msgid ""
 "It seems that we are too late. The Treasury has fallen to the saurians..."
 msgstr "看来我们来晚了。金库已经落入蜥蜴人手中了……"
 
 #. [message]: id=Huraldur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:247
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:240
 msgid "And I see the remains of the garrison has been taken prisoner."
 msgstr "我还看到留下的守备部队都被俘虏了。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:257
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:250
 msgid ""
 "We must free them and make these saurians pay. Attack and leave no one alive!"
 msgstr "我们必须救出他们并让蜥蜴人们为此付出代价。进攻，不留活口！"
 
 #. [message]: role=liberator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:263
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:256
 msgid ""
 "I will do as you say, sneak in and free them. Wish me good fortune and no "
 "discovery!"
 msgstr "我会按你说的作，偷偷潜入解救他们。祝我好运不要被发现！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:267
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:260
 msgid "Go swiftly and silently."
 msgstr "衔枚急行。"
 
 #. [message]: id=Shurm
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:279
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:272
 msgid ""
 "More elves are coming! Too late, we’ve taken all your gold and we’ll get "
 "more gold from the orcs for helping them out!"
@@ -1177,12 +1178,12 @@ msgstr ""
 "大笔！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:283
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:276
 msgid "You will not live to enjoy it!"
 msgstr "你们活不到享受的那天了！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:328
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:320
 msgid ""
 "We are free! My lord Kalenz, from this day forward I and my kin are your "
 "sworn followers. And there is that which you should know about the treasure "
@@ -1192,8 +1193,8 @@ msgstr ""
 "您应该知道……"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:332
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:534
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:324
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:530
 msgid ""
 "I accept your service gratefully, for I will need every sword and bow and "
 "spell with which to defeat these invaders. There will be time for talk "
@@ -1203,24 +1204,24 @@ msgstr ""
 "在，我们要作战了。"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:351
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:219
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:379
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:237
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:315
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:313
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:203
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:225
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:269
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:271
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:374
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:287
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:123
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:343
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:217
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:376
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:235
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:308
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:305
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:200
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:222
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:265
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:269
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:371
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:285
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:122
 msgid "Death of Cleodil"
 msgstr "科柳迪死亡"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:374
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:366
 msgid ""
 "Without their leaders, the saurians flee in panic. Let us free the "
 "treasury’s garrison before they can find it in them to rally and return."
@@ -1228,14 +1229,14 @@ msgstr ""
 "失去了首领，那些蜥蜴人仓皇逃跑了。在他们重新集结回击之前，解救金库守备部队。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:385
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:377
 msgid ""
 "We have defeated the saurians and freed the garrison, and that is no small "
 "thing... but our gold is gone."
 msgstr "我们打败了蜥蜴人也解救了守备军，但有件糟糕的事……我们的金币都不在了。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:390
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:381
 msgid ""
 "The saurians happily carried away the treasury gold, but they had come here "
 "looking for something more specific... some individual object they called "
@@ -1247,7 +1248,7 @@ msgstr ""
 "涂的话。"
 
 #. [message]: race=elf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:394
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:385
 msgid ""
 "The war with the orcs goes poorly. The Ka’lian will need that gold back to "
 "buy arms and food, to hire artisans, to support its armies."
@@ -1256,7 +1257,7 @@ msgstr ""
 "持军队。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:398
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:389
 msgid ""
 "We will hunt down those saurians and retrieve our gold. More, we must teach "
 "them that it is lethal folly to raid us, else they will plague us like rats."
@@ -1265,12 +1266,12 @@ msgstr ""
 "会像老鼠一样烦我们。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:409
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:400
 msgid "I am ashamed to die at the hands of tree-shaggers!"
 msgstr "我居然死在树毛人手里，脸丢光了！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:413
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg:404
 msgid ""
 "When you meet your kin in the dry hells, tell them you perished at the hands "
 "of Kalenz’s elves!"
@@ -1295,24 +1296,24 @@ msgstr ""
 "精灵侦察兵不费力气就找到了蜥蜴人军队的足迹。通往蜥蜴人金库的路一清二楚……"
 
 #. [side]: id=Hraurg, type=Saurian Ambusher
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:150
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:148
 msgid "Hraurg"
 msgstr "赫劳格"
 
 #. [side]: type=Saurian Ambusher, id=Spahr
 #. [side]: type=Saurian Flanker, id=Spahr
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:180
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:178
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg:122
 msgid "Spahr"
 msgstr "施帕尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:206
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:204
 msgid "Enter the Saurian Treasury with a horse and leave with the gold"
 msgstr "骑马进入蜥蜴人的金库，带走金子"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:273
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:271
 msgid ""
 "There they are. They have dumped our gold in their own treasury. We must "
 "strike quickly and leave with the gold before they can summon their full "
@@ -1322,7 +1323,7 @@ msgstr ""
 "大部队前带着金子离开。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:277
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:275
 msgid ""
 "Moving so much gold is no light matter. We will need horses to bear it back "
 "home."
@@ -1330,19 +1331,19 @@ msgstr "要搬运这么多金币可不是易事。我们需要马来驮回去。
 
 #. [message]: id=Hraurg
 #. Saurians often hiss their sibilants; do this in your language.
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:283
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:280
 msgid ""
 "The elves have followed ussss! We must hold the gold until reinforcements "
 "arrive."
 msgstr "精灵们一直在跟踪我们！嘶嘶~我们必须保护住金币直到增援部队到达。"
 
 #. [object]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:305
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:302
 msgid "Treasure Chest"
 msgstr "宝箱"
 
 #. [object]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:306
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:303
 msgid ""
 "The bearer of this chest is slowed in movement and attack by the same effect "
 "as the slow weapon special. Slow halves the damage caused by attacks and the "
@@ -1354,34 +1355,34 @@ msgstr ""
 "标。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:360
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:357
 msgid "We have reached the treasury. Guard me while I bring the pillage home."
 msgstr "我们已经接近金库了。在我把战利品运回去的时候掩护我。"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:366
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:363
 msgid "New Objective: Transport the treasure with a rider to the signpost"
 msgstr "新目标：用骑兵运送财宝到达路标"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:406
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:403
 msgid "Aargh! I shall never see the bright moon’s face again!"
 msgstr "啊！我再也不能见到皓月了！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:454
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:451
 msgid "We have recovered our gold; it is well."
 msgstr "我们已经夺回了我们的金币；没有少。"
 
 #. [message]: role=gold_carrier
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:484
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:481
 msgid ""
 "We have recovered much more than our own treasure. These saurians would seem "
 "to have taken up robbery as a vocation!"
 msgstr "我们夺回的金币比我们自己的财物多得多。这些蜥蜴人看来真是职业强盗！"
 
 #. [message]: id=Spahr
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:488
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:485
 msgid ""
 "They took all our treasure! Quickly, place ambushers on all trails from here "
 "to Wesmere. I will give 500 gold to whoever kills their leader. They must "
@@ -1392,7 +1393,7 @@ msgstr ""
 
 #. [message]: id=Kalenz
 #. "fare" is an archaic English verb meaning to travel or move.
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:493
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:490
 msgid ""
 "Turnabout is fair play. Now that we’ve retrieved the gold, let us fare "
 "swiftly back to Wesmere and bring the gold back as Cleodil wishes. The "
@@ -1403,7 +1404,7 @@ msgstr ""
 "期待的那样把金子带回去。蜥蜴人应该会在直达路上骚扰，那我们就绕到北面去。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:497
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:494
 msgid ""
 "But Kalenz, this is a boon unlooked for! With the surplus gold we could take "
 "the war immediately to the orcs. We could come down upon them like thunder "
@@ -1414,7 +1415,7 @@ msgstr ""
 "上！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:501
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:498
 msgid ""
 "But the Ka’lian’s gold is the Ka’lian’s. Would you have us divide our "
 "forces, some to return it to them while others attempt your thunder-stroke?"
@@ -1423,7 +1424,7 @@ msgstr ""
 "去，而另一些则尝试你的雷霆袭击？"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:505
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:502
 msgid ""
 "Cleodil’s doubt is wise. Only a foolish commander divides his forces in the "
 "presence of superior numbers; to do so is to invite defeat in detail."
@@ -1432,12 +1433,12 @@ msgstr ""
 "失败。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:509
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:506
 msgid "Landar, thoughts that brew in hot blood are seldom well-found."
 msgstr "兰达尔，想想一时热血很少有好结果的。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:513
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg:510
 msgid "It... is so. Again you speak wisdom. Very well; to the Ka’lian!"
 msgstr "这……确实是这样。你又赢了。很好；向卡-利安进发！"
 
@@ -1456,22 +1457,22 @@ msgstr ""
 "入韦弥尔森林……"
 
 #. [side]: type=Orcish Warlord, id=Urug-Tar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:130
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:128
 msgid "Urug-Tar"
 msgstr "乌鲁格-塔"
 
 #. [side]: type=Troll Warrior, id=Traur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:188
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:186
 msgid "Traur"
 msgstr "泰奥"
 
 #. [note]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:249
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:247
 msgid "Try to save leveled dwarf units"
 msgstr "请尝试保住高级矮人单位"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:259
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:257
 msgid ""
 "What’s this? It appears the orcs have surrounded a dwarvish enclave. And by "
 "the sound of the bellowing I hear, I think our old friend, Olurf, is here."
@@ -1480,7 +1481,7 @@ msgstr ""
 "朋友奥勒夫在这儿。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:263
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:261
 msgid ""
 "You again? Maybe ye were not completely wrong when ye predicted the orcs "
 "would attack us. We ha’ been forced from our home and are now surrounded."
@@ -1489,19 +1490,19 @@ msgstr ""
 "了。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:267
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:265
 msgid "Let us give them aid — it’s clear they need it!"
 msgstr "我们帮他们一把吧——显然他们很需要！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:271
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:269
 msgid ""
 "Help them? They would not even let us pass through their land to avoid the "
 "trolls. You remember, Kalenz?"
 msgstr "帮他们？他们甚至不同意我们穿过他们的地盘以避开巨魔。你忘了吗卡雷兹？"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:275
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:273
 msgid ""
 "Our enemy is the orcs, not the dwarves. Besides, the orcs are in our way. "
 "Olurf, we cannot let you have all the fun here!"
@@ -1510,36 +1511,36 @@ msgstr ""
 "悠哉了！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:279
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:277
 msgid "For an elf, you think like a dwarf! I think I like you! "
 msgstr "作为精灵，你的思考方式很矮人嘛！我想我欣赏你！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:279
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:277
 msgid "whisper^—For an elf..."
 msgstr "（作为一个精灵……）"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:291
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:289
 msgid "The orcs ha’ been defeated. My lord, we are in your debt."
 msgstr "兽人被打败了。阁下，我们欠你一份人情。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:295
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:293
 msgid ""
 "We must put aside our differences and ally against the orcish menace. Olurf, "
 "join us!"
 msgstr "我们应该放下不同共御兽敌。奥勒夫,加入我们吧！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:299
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:297
 msgid ""
 "Dwarves, ally with elves? I owe ye a debt, but my kin willna’ be happy at "
 "the thought."
 msgstr "矮人，和精灵结盟？我是欠你的人情，可不见得我的同族都愿意。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:303
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:301
 msgid ""
 "The Orcs are advancing on Wesmere, and a great battle will soon be upon us. "
 "If you can cover our flank to the north, I will pay you 400 gold."
@@ -1548,14 +1549,14 @@ msgstr ""
 "我会给你400金币。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:307
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:305
 msgid ""
 "A proper contract for good money? That’s a different matter; I’m sure I can "
 "find some o’ my people willing to fight on those terms!"
 msgstr "有丰厚报酬的合适契约？这就不同了；我肯定能找到些人为这个价钱去作战！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:311
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:309
 msgid ""
 "What? Kalenz, are you out of your mind? Surely you will not throw away 400 "
 "gold on this scheming mercenary!"
@@ -1563,7 +1564,7 @@ msgstr ""
 "什么？卡雷兹，你失去理智了吗？你怎么能把400金币扔在这些诡计多端的佣兵身上！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:315
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:313
 msgid ""
 "Where there’s a contract, our honor is involved. We will be there to cover "
 "your northern flank or else I will return your gold!"
@@ -1572,12 +1573,12 @@ msgstr ""
 "数奉还！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:319
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:317
 msgid "I sense no falsity behind his speech, my lord."
 msgstr "我感觉他不会说谎，阁下。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:323
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg:321
 msgid ""
 "I, too, believe him. Dwarves may be... rough... by our standards, but they "
 "are not liars. I think he knows that if he does not honor his contract, next "
@@ -1602,22 +1603,22 @@ msgstr ""
 "和他的部队正好及时赶回……"
 
 #. [unit]: type=Naga Myrmidon, id=Mordrum
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:214
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:207
 msgid "Mordrum"
 msgstr "莫德雷姆"
 
 #. [unit]: type=Orcish Warlord, id=Urug-Pir
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:232
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:225
 msgid "Urug-Pir"
 msgstr "乌鲁格-皮"
 
 #. [unit]: type=Great Troll, id=Truugl
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:251
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:244
 msgid "Truugl"
 msgstr "特鲁格尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:299
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:292
 msgid ""
 "You must own the field and be capable of overwhelming your opponents. "
 "(Player(s) own more than 25 units while the foes’ numbers fall below 15.)"
@@ -1626,17 +1627,17 @@ msgstr ""
 "下。）"
 
 #. [message]: race=orc,troll
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:372
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:365
 msgid "Flee! They have broken us!"
 msgstr "快逃！我们被他们击溃了！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:376
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:369
 msgid "Hunt them down and kill every single one of them!"
 msgstr "像猎人一样把他们逼入绝境，杀掉每个落单的！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:380
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:373
 msgid ""
 "It is not wise to put a wounded foe in a desperate situation; they will but "
 "fight harder for it. Break their will and let them flee, so they will spread "
@@ -1646,33 +1647,33 @@ msgstr ""
 "们逃跑，这样就会在他们间传播对我们的恐惧。"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:384
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:377
 msgid ""
 "She is right. Don’t let them lure you away from the Ka’lian, preparations "
 "for when more of them arrive must be made."
 msgstr "她说得对。不要被他们引诱离开卡-利安，必须要做好有更多敌军到来的准备。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:397
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:390
 msgid ""
 "The orcs are not defeated, and our troops and supplies are exhausted. This "
 "is the end!"
 msgstr "我们仍不能打败兽人，而我们已经弹尽粮绝了。天诛我也！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:408
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:401
 msgid ""
 "The orcs have pushed us back to the Ka’lian. There is no way out. We must "
 "win here!"
 msgstr "兽人已把我们压制回卡-利安。我们无路可走，我们必须赢下此战！"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:412
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:405
 msgid "This is our final stand. If they take the Ka’lian, all is lost!"
 msgstr "这是我们最后的据点。如果他们攻陷卡-利安，那一切就都完了！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:417
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:409
 msgid ""
 "Galtrid, speak not of defeat. Elvenkind shall rise! Our enemies shall perish "
 "in blood and fire!"
@@ -1680,41 +1681,41 @@ msgstr ""
 "加尔泰德，不要轻言失败。精灵族一定会崛起的！我们的敌人会在鲜血和火焰中毁灭！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:421
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:413
 msgid ""
 "It is a dark day indeed when elves must steel themselves with dreams of "
 "slaughter."
 msgstr "这真是黑暗的一天，精灵必须用杀戮的梦想来武装自己。"
 
 #. [message]: id=Urug-Pir
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:426
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:417
 msgid "We’ll crush those weak elves and I’ll get da stone!"
 msgstr "我们要一举粉碎这些脆弱的精灵们，我要拿到大石头！"
 
 #. [message]: id=El_Isomithir
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:430
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:421
 msgid ""
 "These are hardened orc and troll veterans. Men, prepare for a long, "
 "difficult fight..."
 msgstr "他们是冷酷无情的兽人和久经沙场的巨魔。兄弟们，做好打一场持久战的准备……"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:442
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:433
 msgid "Those dwarves must still be protecting our gold — on their land."
 msgstr "那些矮人肯定还在保护着我们的金币——在他们的领地上保护。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:446
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:437
 msgid "Yes, it seems we must defend the Kalian alone."
 msgstr "使得，看起来我们得独自保卫卡利安了。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:478
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:469
 msgid "Did ye think we’d let you have all the fun wi’ the orcs by yerselves?"
 msgstr "你以为我们会让你们自个儿跟兽人玩个够吗？"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:482
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:473
 msgid ""
 "You did, we’ve already driven them from the forest. You barely caught up in "
 "time to chase them into the hills."
@@ -1723,7 +1724,7 @@ msgstr ""
 "山里去而已。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:487
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:478
 msgid ""
 "Diplomacy, Landar. We do need to pursue the orcs into the mountains, and an "
 "army of dwarves will be welcome companions."
@@ -1732,24 +1733,24 @@ msgstr ""
 "迎的伙伴。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:491
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:482
 msgid "It’s not much of an army he is bringing with him, though."
 msgstr "不过他可没带来多少军队。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:495
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:486
 msgid ""
 "Not much of an army? These are dwarves with mighty axes, each worth three of "
 "you and your silly plinking bows!"
 msgstr "没多少人马？这些持巨斧的矮人一个顶你们那些拿玩具弓箭的三个！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:499
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:490
 msgid "Olurf, is that all the dwarves you could find? Was the gold not enough?"
 msgstr "奥勒夫，这就是你能找到的全部矮人？金币不够吗？"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:503
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:494
 msgid ""
 "They are no’ fighting for gold, they’re here for the fun. I’d ha’ brought a "
 "lot more if my men ha’ all kept quiet about helping elves! But the rest o’ "
@@ -1759,44 +1760,44 @@ msgstr ""
 "叫来更多人！不过我族的其他人几天内就能赶来。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:507
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:498
 msgid "In a few days? That’s too late! We want our gold back!"
 msgstr "几天？那太慢了！把钱还给我们！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:511
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:502
 msgid "Sure, minus expenses."
 msgstr "好的，除去开销。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:515
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:506
 msgid "What expenses?"
 msgstr "什么开销？"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:519
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:510
 msgid ""
 "It’s an ancient dwarvish custom to buy the warriors a few drinks before the "
 "battle... So minus expenses that’s about even."
 msgstr "给战士们战前买点酒自古是矮人的传统……所以那是要除去的开销。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:523
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:514
 msgid "That explains why they are so reckless in battle..."
 msgstr "这大概能解释为什么他们在战斗中如此不顾后果……"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:549
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:540
 msgid "At last! The orcs are defeated."
 msgstr "结束了！兽人被打败了。"
 
 #. [unit]: type=Orcish Warrior, id=Pirorr
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:555
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:546
 msgid "Pirorr"
 msgstr "皮罗若"
 
 #. [message]: id=Pirorr
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:566
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:557
 msgid ""
 "The elves have beaten us and they did not use da stone. Maybe they don’t "
 "have it? Great Chief will not like bad news!"
@@ -1805,23 +1806,23 @@ msgstr ""
 "消息！"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:575
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:566
 msgid "Kalenz, we are again in your debt. You returned just in time."
 msgstr "卡雷兹，我们又欠你一个人情。你回来得正是时候。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:579
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:570
 msgid "And we have what’s left of the elvish treasury with us!"
 msgstr "并且我们带来了精灵金库里留下的东西！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:583
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:574
 msgid "Perhaps the gold will give our words more weight with the Council."
 msgstr "也许这些金币能加大我们在评议会上的话语权。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:589
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:595
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:580
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:586
 msgid ""
 " has returned any remaining gold into the elvish treasury. You will start "
 "the next scenario with a preset amount."
@@ -1829,29 +1830,29 @@ msgstr " 已经把剩余的全部金币放进了精灵金库。你会以预设�
 
 #. [message]: speaker=narrator
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:589
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:41
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:51
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:76
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:92
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:102
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:112
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:122
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:37
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:57
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:82
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:92
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:102
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:117
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:127
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:147
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:157
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:177
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:192
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:202
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:217
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:227
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:242
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:580
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:40
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:50
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:75
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:91
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:101
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:111
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:121
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:36
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:56
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:81
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:91
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:101
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:116
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:126
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:146
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:156
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:176
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:191
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:201
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:216
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:226
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:241
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:27
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:47
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:78
@@ -1864,53 +1865,53 @@ msgstr " 已经把剩余的全部金币放进了精灵金库。你会以预设�
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/18_Hour_of_Glory.cfg:62
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg:54
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg:64
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:31
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:56
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:30
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:55
 #: data/campaigns/Legend_of_Wesmere/utils/characters.cfg:27
 msgid "Kalenz"
 msgstr "卡雷兹"
 
 #. [message]: speaker=narrator
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:595
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:61
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:81
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:47
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:112
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:167
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:232
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:586
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:60
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:80
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:46
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:111
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:166
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:231
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:32
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:88
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:62
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:61
 #: data/campaigns/Legend_of_Wesmere/utils/characters.cfg:77
 msgid "Landar"
 msgstr "兰达尔"
 
 #. [message]: id=Truugl
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:607
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:598
 msgid ""
 "Aargh! I should have stayed in the mountains instead of joining the orcs!"
 msgstr "可恶！我本应该呆在山里而不是加入兽人！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:618
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:609
 msgid "Orcs, death is all you will find in this forest!"
 msgstr "兽人，在这个森林里面你们只能找到死路一条！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:629
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:620
 msgid "I die without getting da stone?"
 msgstr "没有得到大石头我就死了吗？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:643
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:634
 msgid ""
 "Be grateful, tree-shagger, for I have spared you the pain of seeing your "
 "precious citadel burned and razed."
 msgstr "你要心怀感激，树毛人，我让你免了为看到你珍爱的城堡被烧毁而痛苦。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:647
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:638
 msgid ""
 "Galtrid, my friend. Do not let my death be in vain. Destroy these foul orcs, "
 "and sing for me in the green woods when we have won."
@@ -1919,22 +1920,22 @@ msgstr ""
 "候在绿林里为我歌唱。"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:651
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:642
 msgid "We shall avenge you tenfold!"
 msgstr "我们会十倍得为你报仇！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:664
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:655
 msgid "Dead he is. Too quick. His screams were sweet."
 msgstr "他死了。走得太快了。他喊出的遗言很甜蜜。"
 
 #. [message]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:674
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:665
 msgid "Let us pursue the orc who murdered $unit.name|!"
 msgstr "我们去追杀杀掉$unit.name|的兽人！"
 
 #. [message]: id=Galtrid
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:678
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg:669
 msgid ""
 "No, don’t leave your formation. An elf was slain by beast. What does it "
 "matter which beast it was? We must kill them all."
@@ -1948,7 +1949,7 @@ msgid "Council of Hard Choices"
 msgstr "评议会的艰难选择"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:36
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:35
 msgid ""
 "Kalenz, you have won a great victory! Wesmere is safe. But... for what cause "
 "have you invited a dwarf to the elvish council? This is most unusual!"
@@ -1957,14 +1958,14 @@ msgstr ""
 "老会？这太不寻常了！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:36
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:66
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:51
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:35
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:65
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:50
 msgid "Lady Dionli"
-msgstr "戴恩丽女领主"
+msgstr "迪翁莉女领主"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:41
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:40
 msgid ""
 "My lords, this is Olurf. He and his dwarves have fought by our side and have "
 "well earned a place in this meeting. The war that comes upon us must be met "
@@ -1975,14 +1976,14 @@ msgstr ""
 "争。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:46
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:36
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:45
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:35
 #: data/campaigns/Legend_of_Wesmere/utils/characters.cfg:303
 msgid "El’Isomithir"
 msgstr "厄伊索密瑟"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:46
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:45
 msgid ""
 "Leave the humans out of this. King Haldric has broken the treaty we signed "
 "with him eighteen years ago, and has sent back all our emissaries. When he "
@@ -1994,7 +1995,7 @@ msgstr ""
 "人不敢跟他开战。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:51
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:50
 msgid ""
 "My lords, the orcs have been pushed out of Wesmere, but they are far from "
 "defeated. We must take the fight to them, recover our lost lands and smash "
@@ -2004,13 +2005,13 @@ msgstr ""
 "地，把他们的大部落粉碎到不可能再威胁我们。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:56
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:26
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:55
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:25
 msgid "Legmir"
 msgstr "莱格米尔"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:56
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:55
 msgid ""
 "Too many elves have died already. To take the war to the orcs, we would have "
 "to risk all our remaining fighters on one throw. And we are not as skilled "
@@ -2022,7 +2023,7 @@ msgstr ""
 "复我们的元气。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:61
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:60
 msgid ""
 "Those of us who follow Kalenz have shown it can be done. We have been "
 "fighting ever since we were forced out of our home country, in all kinds of "
@@ -2032,7 +2033,7 @@ msgstr ""
 "且，我们愿意为击败邪恶的兽人而献身！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:66
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:65
 msgid ""
 "Our answer is still no. Prepare our defenses as best you can, but do not "
 "renew offensive war. This is the Council’s decision."
@@ -2041,17 +2042,17 @@ msgstr ""
 "会的决定。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:70
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:69
 msgid "Aftermath"
 msgstr "余波"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:71
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:70
 msgid "After leaving the Council, our friends talked in private..."
 msgstr "离开评议会后，几位战友私下讨论……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:76
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:75
 msgid ""
 "Perhaps you were wiser than I, Landar. Had we divided our forces, we would "
 "not be bound to inaction now."
@@ -2059,17 +2060,17 @@ msgstr ""
 "也许你比我明智，兰达尔。当时我们应该分开兵力，现在就不会困在这里无所作为。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:81
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:80
 msgid ""
 "And our home? How can we free Lintanir without taking the war to the orcs?"
 msgstr "我们的家乡怎么办？不跟兽人作战怎么解救林塔尼尔？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:86
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:62
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:72
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:182
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:212
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:85
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:61
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:71
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:181
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:211
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:57
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:68
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:45
@@ -2087,14 +2088,14 @@ msgid "Cleodil"
 msgstr "科柳迪"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:86
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:85
 msgid ""
 "I too am troubled by the Council’s passivity. But it was not our decision to "
 "make."
 msgstr "我也为评议会的不抵抗态度烦恼。但这不是我们能下的决定。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:92
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:91
 msgid ""
 "This is madness! The orcs will but regain their strength and attack again, "
 "if we give them the time! We must have some other sort of help. Olurf, can "
@@ -2104,7 +2105,7 @@ msgstr ""
 "求帮助。奥勒夫，我们能不能和矮人搞个战争协定？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:97
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:96
 msgid ""
 "I dinna’ think it can be, Kalenz. My people are too suspicious of you elves. "
 "But it may be there is something else we can do. I ha’ heard tale of a "
@@ -2115,22 +2116,22 @@ msgstr ""
 "试试。我听说大山里有个很厉害的法师，他曾经帮过我族。或许他会再帮我们一次。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:97
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:107
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:117
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:27
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:137
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:96
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:106
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:116
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:26
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:136
 #: data/campaigns/Legend_of_Wesmere/utils/characters.cfg:157
 msgid "Olurf"
 msgstr "奥勒夫"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:102
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:101
 msgid "And where do we find this mage, if he exists?"
 msgstr "如果这个人真的存在的话，我们要去哪儿找他？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:107
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:106
 msgid ""
 "It willna’ be easy. He lives in the mountains of Thoria and he never helps "
 "anyone for free. Thoria is very dangerous, especially for elves. Even "
@@ -2140,7 +2141,7 @@ msgstr ""
 "尤其危险，连矮人和巨魔去那也不轻松。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:112
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:111
 msgid ""
 "I think the orcs will be in no position to attack us for some time. Maybe we "
 "should go see this mage. Olurf, can you take us there?"
@@ -2149,12 +2150,12 @@ msgstr ""
 "吗？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:117
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:116
 msgid "I think I can. But dangerous this will be!"
 msgstr "我想我能办到。不过这会很危险！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:122
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg:121
 msgid ""
 "Very well. We shall leave our best troops and gold here in case the orcs "
 "attack Wesmere again."
@@ -2202,49 +2203,49 @@ msgstr ""
 "很快就会发现危险比他们料想的还要近。"
 
 #. [side]: type=Saurian Flanker, id=Huurgh
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:133
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:130
 msgid "Huurgh"
 msgstr "胡尔哥"
 
 #. [side]: type=Saurian Oracle, id=Shhar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:163
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:160
 msgid "Shhar"
 msgstr "沙哈"
 
 #. [side]
 #. [side]: type=Gryphon, id=Gryphon Leader
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:194
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:152
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:191
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:149
 msgid "Creatures"
 msgstr "怪物"
 
 #. [args]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:281
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:273
 msgid "some experienced warriors"
 msgstr "一些久经沙场的战士"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:301
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:293
 msgid "Kalenz crosses the river"
 msgstr "卡雷兹渡过河"
 
 #. [message]: id=Huurgh
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:332
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:323
 msgid "Yess! It’s the elves who stole our gold! The bounty is mine!"
 msgstr "好啊！嘶嘶~是那些偷走我们金币的精灵们！赏金是我的！"
 
 #. [message]: id=Shhar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:336
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:327
 msgid "I saw them first, fool! The bounty is all mine."
 msgstr "我先看到他们的，蠢货！赏金全是我的。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:340
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:331
 msgid "What are they talking about?"
 msgstr "他们说啥呢？"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:344
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:335
 msgid ""
 "It would seem the saurians put a bounty on our heads for having the "
 "effrontery to take our gold back after they stole it. Are you interested?"
@@ -2253,7 +2254,7 @@ msgstr ""
 "感兴趣吗？"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:348
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:339
 msgid ""
 "No, but my axe is interested in some saurian heads! They ha’ been too "
 "friendly with the orcs for my liking!"
@@ -2261,7 +2262,7 @@ msgstr ""
 "无聊，不过我的斧子对蜥蜴人的脑袋感兴趣！他们跟兽人关系好过头了，我可不喜欢！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:352
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:343
 msgid ""
 "Remember, we are here on a mission. We will fight these saurians if we must, "
 "but our mission is to get to Thoria."
@@ -2270,12 +2271,12 @@ msgstr ""
 "到索丽亚山脉去。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:356
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:347
 msgid "They are far too numerous to risk battle with. Let’s cross the river!"
 msgstr "他们人太多，不值得冒险开战。我们过河去！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:360
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:351
 msgid ""
 "We can outrun them in the woods and mountains beyond the north shore. But "
 "crossing the river without a bridge? We dwarves know water is a very "
@@ -2285,7 +2286,7 @@ msgstr ""
 "险！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:364
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:355
 msgid ""
 "Indeed, this river is, I believe, Arkan-Thoria. There are fell legends about "
 "it. Maybe they are but children’s tales... Still, be very careful when you "
@@ -2295,7 +2296,7 @@ msgstr ""
 "是讲给孩子的故事罢了……然而过河的时候还是要小心为上。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:368
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:359
 msgid ""
 "You speak my thought, Cleodil. Close in behind me; I’ll guard you from harm "
 "myself. Look to your weapons as we cross, all! And be wary."
@@ -2304,78 +2305,78 @@ msgstr ""
 "有人！要随机应变。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:375
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:366
 msgid ""
 "Before Kalenz left the Ka’lian he had ordered $left_behind_kalenz to stay "
 "and guard it."
 msgstr "在卡雷兹离开卡-利安前，他曾下令$left_behind_kalenz留下保卫卡-利安。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:383
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:374
 msgid ""
 "Before Landar left the Ka’lian he had ordered $left_behind_landar to stay "
 "and guard it."
 msgstr "在兰达尔离开卡-利安前，他曾下令$left_behind_landar留下保卫卡-利安。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:411
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:402
 msgid "We made it. Onwards to Thoria!"
 msgstr "我们成功了。继续向索丽亚前进！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:415
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:406
 msgid "At last!"
 msgstr "总算完了！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:419
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:410
 msgid "We’ll need to settle things with these saurians once and for all!"
 msgstr "我们要一次把账跟蜥蜴人算清楚！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:423
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:414
 msgid ""
 "Hasn’t enough blood been shed? I think we can compose matters with them "
 "after the threat of the orcs has been met."
 msgstr "还嫌血流得不够多吗？我想当兽人威胁到他们后，我们就能跟他们谈谈了。"
 
 #. [event]: type=Water Serpent, id=Sealurr, type=Cuttle Fish, id=Kallub, type=Water Serpent, id=Scardeep, type=Cuttle Fish, id=Kalimar, type=Cuttle Fish, id=Alkamar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:449
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:440
 msgid "Sealurr"
 msgstr "海卢尔"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:459
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:450
 msgid "The legends are true! Sea creatures are upon us!"
 msgstr "传说是真的！海里的怪物出来了！"
 
 #. [event]: type=Water Serpent, id=Sealurr, type=Cuttle Fish, id=Kallub, type=Water Serpent, id=Scardeep, type=Cuttle Fish, id=Kalimar, type=Cuttle Fish, id=Alkamar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:469
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:460
 msgid "Kallub"
 msgstr "卡卢卜"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:479
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:470
 msgid "They are coming at us from all sides!"
 msgstr "他们正从四面八方朝我们冲来！"
 
 #. [event]: type=Water Serpent, id=Sealurr, type=Cuttle Fish, id=Kallub, type=Water Serpent, id=Scardeep, type=Cuttle Fish, id=Kalimar, type=Cuttle Fish, id=Alkamar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:490
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:481
 msgid "Scardeep"
 msgstr "深疤"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:500
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:491
 msgid "Watch for the serpent!"
 msgstr "小心那条大蛇！"
 
 #. [event]: type=Water Serpent, id=Sealurr, type=Cuttle Fish, id=Kallub, type=Water Serpent, id=Scardeep, type=Cuttle Fish, id=Kalimar, type=Cuttle Fish, id=Alkamar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:510
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:501
 msgid "Kalimar"
 msgstr "卡利玛"
 
 #. [event]: type=Water Serpent, id=Sealurr, type=Cuttle Fish, id=Kallub, type=Water Serpent, id=Scardeep, type=Cuttle Fish, id=Kalimar, type=Cuttle Fish, id=Alkamar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:527
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:518
 msgid "Alkamar"
 msgstr "艾卡玛"
 
@@ -2392,34 +2393,34 @@ msgid ""
 msgstr "离开阿坎-索丽亚河，卡雷兹和他的部队冒险进入危险重重的索丽亚山脉……"
 
 #. [side]: type=Troll Warrior, id=Tafrul
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:111
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:108
 msgid "Tafrul"
 msgstr "塔弗尔"
 
 #. [side]: type=Gryphon, id=Gryphon Leader
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:145
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:142
 msgid "Gryphon Leader"
 msgstr "狮鹫头领"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:186
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:183
 msgid "Reach the signpost with Kalenz"
 msgstr "卡雷兹到达路标"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:225
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:222
 msgid "I can hardly see with all that mist around, but I can sense danger."
 msgstr "四周都是薄雾，我看不清，不过我能感到危险就在附近。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:229
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:226
 msgid ""
 "Told ye it would be no picnic excursion, elf-boy. Are ye lily-livered to "
 "continue?"
 msgstr "我告诉过你们这不是野餐郊游，精灵小子。你们害怕前进了吗？"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:233
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:230
 msgid ""
 "Gentlemen, don’t squabble. We cannot go back now. But be watchful; I don’t "
 "like the feel of this country one bit."
@@ -2427,12 +2428,12 @@ msgstr ""
 "先生们，别吵了。现在我们不能回头。不过警惕起来；我一点也不喜欢这个地方。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:237
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:234
 msgid "I, too, feel we are in great danger."
 msgstr "我也感觉到，我们在极度危险中。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:241
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:238
 msgid ""
 "Cleodil, stay close to me. If there is anything real behind this aura of "
 "dread, likely your keen senses will find it first and I will want to know "
@@ -2442,61 +2443,61 @@ msgstr ""
 "现，我要立即知道你发现了什么。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:270
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:267
 msgid "Onwards!"
 msgstr "看前面！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:274
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:271
 msgid "Yer doing pretty well, elf-boy!"
 msgstr "干得不错，精灵小子！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:290
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:287
 msgid ""
 "There is some greasy-looking smoke rising ahead of us! Kalenz... my lord... "
 "I feel something terribly wrong is happening!"
 msgstr "正前方有些像油脂燃烧的烟升起！卡雷兹……阁下……我感到有些糟糕的事发生了！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:294
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:291
 msgid "Crelanu’s place should be close now, as I remember. Quickly, this way!"
 msgstr "如果我没记错的话，克雷拉努的地盘应该不远了。赶快，这边！"
 
 #. [unit]: type=Yeti, id=Krulg
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:318
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:315
 msgid "Krulg"
 msgstr "克鲁尔格"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:330
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:327
 msgid "Watch out!"
 msgstr "当心！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:334
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:331
 msgid "It’s... it’s monstrous!"
 msgstr "它……它太大了！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:338
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:335
 msgid ""
 "I sense no malice in it; we are the interlopers here. Spare it if you can."
 msgstr "我感到它没有恶意；我们误入了它的地盘。尽量避开它。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:342
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:339
 msgid ""
 "Do as Cleodil says. We have enemies sufficient without provoking new ones."
 msgstr "照科柳迪说的做。我们的敌人够多了，再也惹不起新的了。"
 
 #. [unit]: type=Yeti, id=Tralg
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:358
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:355
 msgid "Tralg"
 msgstr "泰尔格"
 
 #. [unit]: type=Yeti, id=Drolg
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:377
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg:374
 msgid "Drolg"
 msgstr "道尔格"
 
@@ -2511,58 +2512,58 @@ msgid "Quickening their pace, the elves and dwarves raced towards the smoke..."
 msgstr "精灵和矮人加快脚步，奔向那股浓烟……"
 
 #. [side]: type=Arch Mage, id=Aquagar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:113
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:110
 msgid "Aquagar"
 msgstr "阿库阿伽"
 
 #. [side]: type=Elder Mage, id=Crelanu
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:127
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:22
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:32
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:42
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:52
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:67
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:77
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:87
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:97
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:107
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:122
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:132
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:142
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:152
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:162
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:172
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:187
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:197
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:207
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:222
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:237
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:247
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:124
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:21
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:31
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:41
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:51
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:66
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:76
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:86
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:96
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:106
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:121
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:131
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:141
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:151
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:161
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:171
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:186
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:196
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:206
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:221
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:236
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:246
 msgid "Crelanu"
 msgstr "克雷拉努"
 
 #. [side]: type=Troll Warrior, id=Trigrul
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:147
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:144
 msgid "Trigrul"
 msgstr "泰格鲁尔"
 
 #. [message]: id=Crelanu
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:176
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:173
 msgid ""
 "I sense a presence that is not one of Aquagar’s creatures. Who are you, and "
 "what is your purpose here?"
 msgstr "我能感觉到一个非阿库阿伽召唤物的存在。你是谁，你来这目的是什么？"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:180
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:177
 msgid ""
 "That, I think, must be the mage of which Olurf spoke. But he is not the one "
 "I sensed as we approached this place..."
 msgstr "那我想就是奥勒夫说的法师了。但他不是那个在我们来时我感觉到的人……"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:184
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:181
 msgid ""
 "I feel the shadow of destiny on my soul. There is something I am fated to do "
 "here, but I know not what."
@@ -2570,12 +2571,12 @@ msgstr ""
 "我能感觉到我灵魂中命运的影子。我命中注定与这有缘，但我不知道确切是什么。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:188
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:185
 msgid "If you are the mage Crelanu, we have come to seek your help."
 msgstr "如果你就是法师克雷拉努，我们是来寻求你帮助的。"
 
 #. [message]: id=Crelanu
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:192
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:189
 msgid ""
 "I am Crelanu... but if you want my help you must begin by helping me, for I "
 "am besieged here and in no state to aid anyone else."
@@ -2584,47 +2585,47 @@ msgstr ""
 "人。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:196
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:193
 msgid ""
 "Ahhh. A fight! Perhaps this is my fate. Come, Kalenz, let us make a rescue."
 msgstr "啊哈。要打架！也许这就是我的命运。来吧，卡雷兹，我们去救他。"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:209
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:206
 msgid "Defeat Aquagar"
 msgstr "击败阿库阿伽"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:229
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:226
 msgid "Death of Crelanu"
 msgstr "克雷拉努战死"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:247
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:244
 msgid ""
 "Looks like your mage friend is in trouble. There is a horde of drakes "
 "attacking him!"
 msgstr "看起来你的法师朋友有麻烦了。一大群龙正在攻击他！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:251
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:248
 msgid "Indeed. Before he can aid us, we will have to aid him."
 msgstr "的确如此，在他帮我们之前我们得先出手相助了。"
 
 #. [message]: id=Aquagar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:255
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:252
 msgid "Fools! The book will be mine!"
 msgstr "蠢货！法书会是我们的！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:259
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:256
 msgid ""
 "There... I sense magic emanating from that stone keep east of the lake. That "
 "is where we will find the mage."
 msgstr "那里……我感到湖东边石头那有魔力波动。我们能在那找到法师。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:271
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:267
 msgid ""
 "I die, but I will not go unavenged! Cursed will you be Kalenz! You will "
 "never find lasting peace in all your years. You will lose your dearest. And "
@@ -2637,7 +2638,7 @@ msgstr ""
 "墓！这就是杀死我的代价，伟大的莫若格斯的唤龙师阿库阿伽。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:276
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:272
 msgid ""
 "Some scary fellow this Aquagar thinks he is! Come now, I think Crelanu owes "
 "us some drinks."
@@ -2645,7 +2646,7 @@ msgstr ""
 "这个阿库阿伽还自以为他是个多么唬人的家伙！走吧，我想克雷拉努欠我们点喝的了。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:298
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg:294
 msgid "There goes our last hope!"
 msgstr "那是我们最后的希望！"
 
@@ -2655,7 +2656,7 @@ msgid "Revelations"
 msgstr "水落石出"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:22
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:21
 msgid ""
 "So you are the ones who defeated Aquagar and his drakes. Olurf, I know you; "
 "you were here before when we were both much younger. But elves never come to "
@@ -2667,7 +2668,7 @@ msgstr ""
 "子。我知道一切，我已预料到这将会发生。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:27
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:26
 msgid ""
 "This is Kalenz, leader of the elves. I have brought him here to ask for your "
 "advice and your aid in dealing with the orcs."
@@ -2675,7 +2676,7 @@ msgstr ""
 "这是卡雷兹，精灵领袖。我把他带来是为了得到你在对付兽人方面的建议和帮助。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:32
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:31
 msgid ""
 "Elves, you have fought valiantly and have won a great victory at the forest "
 "of Wesmere. Yet the forces ranged against you are not yet defeated. Indeed, "
@@ -2687,29 +2688,29 @@ msgstr ""
 "是转移了兽人的注意力。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:37
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:36
 msgid "What do you mean, ‘diverted their attention’?"
 msgstr "那“转移兽人注意力”是什么意思？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:42
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:41
 msgid ""
 "You cannot even imagine it. Why do you suppose orcs came all the way here to "
 "attack you?"
 msgstr "你大概想不到。你觉得为什么兽人不远万里跑来攻打你们？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:47
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:46
 msgid "Because they are orcs! Look old man, can you help us beat them or not?"
 msgstr "因为他们是兽人啊！是吧老先生，你能否帮我们击败他们？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:52
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:51
 msgid "You must be Landar. Very brave, but also very brash."
 msgstr "你就是兰达尔吧。很勇敢，不过也很性急。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:57
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:56
 msgid ""
 "Landar is brash, but he does speak plainly why we came here. I do not "
 "understand what you are talking about, either. Olurf tells me you are very "
@@ -2721,17 +2722,17 @@ msgstr ""
 "们所能满足您；只要你提出来。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:62
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:61
 msgid "Are you saying the orcs attacked us looking for something?"
 msgstr "你的意思是兽人攻打我们是为了得到什么东西对吗？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:67
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:66
 msgid "Yes, that is what I am saying."
 msgstr "不错，这就是我的意思。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:72
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:71
 msgid ""
 "It makes sense now. The saurians were asking about a dastone, and also after "
 "we won in Wesmere there was an orc mumbling something about a dastone..."
@@ -2740,17 +2741,17 @@ msgstr ""
 "其词谈及这个大石头……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:77
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:76
 msgid "It’s not a dastone, it’s the stone: They mean the Ruby of Fire..."
 msgstr "那可不是”一块“大石头，那就是”那块“石头：他们指的是圣火之红宝石……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:82
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:81
 msgid "What’s that, and what does it have to do with us?"
 msgstr "那是什么？问题是那跟我们有什么关系？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:87
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:86
 msgid ""
 "It’s the source of your troubles. It is a very powerful magical artifact. "
 "The tyrant Haldric has it, but he has fooled the orcs into believing that "
@@ -2762,7 +2763,7 @@ msgstr ""
 "大付出代价。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:92
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:91
 msgid ""
 "Hmm... You seem to love King Haldric even less than the elf-lords of the "
 "Ka’lian do... How do you know all this of him?"
@@ -2771,7 +2772,7 @@ msgstr ""
 "他，您是怎么知道这些的？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:97
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:96
 msgid ""
 "I once counted Haldric a friend, but he was the one who banished me from "
 "Wesnoth. He charged me with trying to steal the Ruby, seeking its power for "
@@ -2789,25 +2790,25 @@ msgstr ""
 "像这样不加防范，每当哈德里克靠近宝石时，它的魔力辐射就扭曲一丝他的心智。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:102
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:101
 msgid "So the orcs will, seeking the Ruby, now attack the humans?"
 msgstr "所以兽人将为了找宝石进攻人类？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:107
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:106
 msgid ""
 "Yes. But after they win, your people will be next. And after you, the "
 "dwarves."
 msgstr "是的。不过他们赢了之后，你们就是下一个。你们完了之后就轮到矮人了。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:112
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:111
 msgid ""
 "Don’t worry overmuch about us. It is clear you have troubles of your own."
 msgstr "别为我们操心太多。显然你自己也有麻烦。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:117
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:116
 msgid ""
 "We are grateful for this counsel. But can you help us directly? Is there a "
 "way to stop the orcs?"
@@ -2815,14 +2816,14 @@ msgstr ""
 "我们对您的忠告不胜感激。不过你能更直接地帮我们吗？有什么方法阻止兽人吗？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:122
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:121
 msgid ""
 "You cannot defeat them with the forces you can now muster. You can only gain "
 "time, in the hope that you can use it to grow strong again."
 msgstr "以你眼下的部队打不过他们。你只能争取时间，寄希望于你能用它东山再起。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:127
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:126
 msgid ""
 "How? Don’t tell me we had to fight the saurians, cross Arkan-Thoria, contend "
 "against the river monsters, and fight trolls and yetis to come here for "
@@ -2832,7 +2833,7 @@ msgstr ""
 "魔还有雪人来到这儿，却只能空手而归！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:132
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:131
 msgid ""
 "You need to kill their Great Chief and make it look like he was murdered by "
 "orcs. That way the orcs will start a civil war for succession, for many "
@@ -2844,23 +2845,23 @@ msgstr ""
 "崛起再度统一各部落。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:137
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:136
 msgid ""
 "Kill an orcish Great Chieftain? But he’s guarded better than a troll hole!"
 msgstr "杀掉兽人大酋长？可是他被保护得比个巨魔洞还严实！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:142
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:141
 msgid "Indeed, it will not be at all easy. But maybe I can help you..."
 msgstr "的确如此，此计绝非易事。不过也许我能助你们一臂之力……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:147
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:146
 msgid "But you want something in return..."
 msgstr "但你要什么作为交换……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:152
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:151
 msgid ""
 "It is as you say. These drakes were after my book. This book has all the "
 "magic and spells I know in it. They are very powerful, but the one enemy "
@@ -2875,12 +2876,12 @@ msgstr ""
 "了，但更多人会来。我的一个盟友被叛了我，现在有太多人知道这本书的存在。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:157
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:156
 msgid "If you come with us, we will protect you..."
 msgstr "如果你于我们同行，我们会保护你……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:162
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:161
 msgid ""
 "No, my time is done... But the charge I lay on you, Kalenz, is to take my "
 "book and keep it from unworthy hands. Find someone to hold it who will not "
@@ -2892,13 +2893,13 @@ msgstr ""
 "并真正能使用它的主人！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:167
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:166
 msgid ""
 "If your book is as powerful as you say, why not use it against the orcs?"
 msgstr "如果你的法书威力真如你说的那么巨大，为什么不用它去对抗兽人？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:172
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:171
 msgid ""
 "Because the book is like the Ruby of Fire. Any fool can use the magic in the "
 "book, but only a master can vanquish the lust for power that it will bring "
@@ -2908,33 +2909,33 @@ msgstr ""
 "才能战胜对它的力量的贪求。屈服于它的人会变得想哈德里克一样，甚至更不堪设想……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:177
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:176
 msgid ""
 "Cleodil is pure in heart. Perhaps she can guard your book without being "
 "corrupted by its secrets..."
 msgstr "科柳迪心地纯洁。也许她能保护你的法书而不被书中秘密腐蚀……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:182
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:181
 msgid ""
 "I am sure all these secrets are far beyond my art. My art is the healing "
 "kind and I..."
 msgstr "我肯定书中的秘密超出了我的能力所及。我的能力只是治疗方面的，并且我……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:187
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:186
 msgid "There is no other option."
 msgstr "别无选择。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:192
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:191
 msgid ""
 "Very well, suppose Cleodil accepts the guardianship of your book. How will "
 "you then help us slay the orcish Great Chief?"
 msgstr "很好，假如科柳迪接受保护你法书的使命，你将怎么帮我们刺杀兽人大酋长？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:197
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:196
 msgid ""
 "There is a way, but it will be very dangerous. Two of you must enter the "
 "orcish camp by stealth and kill the Great Chief. There is a potion that will "
@@ -2944,13 +2945,13 @@ msgstr ""
 "一种能让你们暂时隐身的药。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:202
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:201
 msgid ""
 "The elves have legends of such things. I suppose you have this potion, then?"
 msgstr "精灵里流传有关于这种东西的传说。我想你就有这种药，然后呢？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:207
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:206
 msgid ""
 "Indeed I do, but it is perilous to use. It is made from the eyes of a "
 "powerful undead lich. It will make you invisible, but it is likely also to "
@@ -2960,19 +2961,19 @@ msgstr ""
 "但也很可能伴随着副作用，有的短暂，有的终生！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:212
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:211
 msgid ""
 "No! This is too dark and dangerous! I fear for you, Kalenz! I... would not "
 "see you come to harm."
 msgstr "不！这太冒险了！卡雷兹，我担心你的安危！我……希望看到你们安然无恙。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:217
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:216
 msgid "What undesirable effects?"
 msgstr "什么副作用？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:222
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:221
 msgid ""
 "Your physical strength will decrease, though in return you will be able to "
 "use magic more easily and powerfully. Cleodil will show you. But the real "
@@ -2988,7 +2989,7 @@ msgstr ""
 "亏一篑；多一点则自身不保。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:227
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:226
 msgid ""
 "It is a dark and desperate course you set before me, but I see no other way; "
 "we must stop the orcs. As leader I cannot ask my men to run a risk I will "
@@ -3001,17 +3002,17 @@ msgstr ""
 "行，得冒着被邪恶魔法侵蚀的危险。有志愿者吗？"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:232
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:231
 msgid "I will come with you. We shall not fail!"
 msgstr "我跟你一起去。我们绝不能失败！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:237
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:236
 msgid "This does not seem the wisest of choices."
 msgstr "这看起来不是最明智的选择。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:242
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:241
 msgid ""
 "Landar may be impetuous, but he is a great fighter and my trusted friend. We "
 "should be about our task now, I think. Crelanu, your book will be safe with "
@@ -3022,7 +3023,7 @@ msgstr ""
 "者。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:247
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter3/12_Revelations.cfg:246
 msgid ""
 "Come, I will give you and Landar the potion and show you a safe point to "
 "cross the river."
@@ -3170,73 +3171,73 @@ msgstr "人类—精灵再度结盟，我们的英雄们又奔向战场……"
 
 #. [unit]: id=Aldar, type=General
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:109
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:108
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/15_The_Treaty.cfg:37
 msgid "Aldar"
 msgstr "阿尔达"
 
 #. [unit]: type=Orcish Warlord, id=Pirror
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:151
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:150
 msgid "Pirror"
 msgstr "皮罗鲁"
 
 #. [unit]: type=Orcish Warlord, id=Tan-Grub
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:171
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:170
 msgid "Tan-Grub"
 msgstr "坦-格鲁布"
 
 #. [unit]: type=Great Troll, id=Grol
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:194
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:193
 msgid "Grol"
 msgstr "格罗尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:252
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:248
 msgid "Last for the end of turns"
 msgstr "坚守至回合结束"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:273
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:269
 msgid "Death of Aldar"
 msgstr "阿尔达死亡"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:292
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:288
 msgid "Tremble, orcs! The vengeance of the elves is upon you!"
 msgstr "战栗吧，兽人！精灵的复仇来临了！"
 
 #. [message]: id=Aldar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:296
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:292
 msgid "So it is true! The elves have come to our aid!"
 msgstr "看来是真的！精灵来帮我们了！"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:300
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:296
 msgid "Hey! Do I look like an elf?"
 msgstr "喂！我看起来像个精灵吗？"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:304
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:300
 msgid "I can scarce believe I am fighting besides these betrayers."
 msgstr "我几乎不敢相信我会和叛徒并肩作战。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:308
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:304
 msgid "We cannot be choosy about our allies when our need is dire."
 msgstr "在处境危急时我们对盟友别无选择。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:312
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:308
 msgid "Indeed not. Save your anger for our enemies, Landar."
 msgstr "确实没办法。 把愤怒发泄到敌人身上吧，兰达尔。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:316
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:312
 msgid "I shall. But when our need is not so dire, there must be a reckoning..."
 msgstr "我会的。但等到危机过去，我一定要把账跟他们算算清……"
 
 #. [message]: id=Tan-Grub
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:322
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:318
 msgid ""
 "An elven army to the north? And they have dwarves with them? We must defeat "
 "them in detail before they combine, which means attacking before our "
@@ -3248,17 +3249,17 @@ msgstr ""
 "城堡！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:327
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:323
 msgid "The brazen cry of a war-horn is heard in the distance."
 msgstr "刺耳的战争号角声从远方传来。"
 
 #. [unit]: id=Aldun, type=Horseman
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:334
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:330
 msgid "Aldun"
 msgstr "奥敦"
 
 #. [message]: id=Aldun
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:346
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:342
 msgid ""
 "General Aldar has received your message. He asks that you engage the orcish "
 "reinforcements from the north, preventing them from joining with their "
@@ -3269,32 +3270,32 @@ msgstr ""
 "里的友军。这支新来的军队绝不能进入战场！我们的增援几天内就到。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:350
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:346
 msgid ""
 "Very well... But have you any word of the elvish troops marching to join us? "
 "We are too few to defeat the enemy without them."
 msgstr "很好……但你有没有开往这里的精灵军队的消息？没有援兵我们难以打败敌人。"
 
 #. [message]: id=Aldun
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:354
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:350
 msgid "We have no news from the Ka’lian."
 msgstr "我们没有来自卡-利安的消息。"
 
 #. [message]: id=Galtrid
 #. [message]: role=l3_store
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:359
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:523
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:355
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:519
 msgid "Kalenz! We come to fight beside you!"
 msgstr "卡雷兹！我们来帮你！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:363
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:359
 msgid ""
 "Where is the rest of the elvish army? They were promised and should be here!"
 msgstr "其余的精灵部队呢？他们应该到了！"
 
 #. [message]: id=Eradion
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:367
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:363
 msgid ""
 "The Great Council has decided it was too risky to send troops here. But some "
 "of us dissented and have come to fight beside you."
@@ -3302,20 +3303,20 @@ msgstr ""
 "大评议会认为向这里派军太冒险了。不过我们一些人有异议，就来和你并肩作战。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:371
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:529
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:367
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:525
 msgid ""
 "That is well! If the Ka’lian is too fearful or blind to see what is needed, "
 "we must do it ourselves."
 msgstr "那就行了！要是卡-利安太害怕或是对处境盲目，我们就必须自己来做。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:375
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:371
 msgid "It is not well that we have become so divided as this."
 msgstr "我们像这样分裂并不明智。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:379
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:375
 msgid ""
 "No, it is not. But if we do not defeat these orcs here and now our divisions "
 "will all be moot. I will take every sword-arm I can get and be glad of them."
@@ -3324,37 +3325,37 @@ msgstr ""
 "我会召集所有我能找到的兵力，并为他们的决定高兴。"
 
 #. [unit]: type=Paladin, id=Kulrad
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:550
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:546
 msgid "Kulrad"
 msgstr "库拉德"
 
 #. [message]: id=Kulrad
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:568
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:564
 msgid "I see foul orcs to be ridden down! Charge!"
 msgstr "我看见肮脏的兽人骑着狼袭来了！进攻！"
 
 #. [message]: race=orc
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:573
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:569
 msgid "More of the cursed horse-pokers!! Run, let’s get out of here!"
 msgstr "更多被诅咒的骷髅骑兵！！跑，赶快离开这儿！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:579
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:575
 msgid "The not-at-all-brazen cry of a war-horn is heard in the distance."
 msgstr "振奋的战争号角声从远方传来。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:609
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:605
 msgid "We have thwarted the orcs once again!"
 msgstr "我们又一次挫败了兽人！"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:613
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:609
 msgid "And we revived the alliance with the humans, which is no small thing."
 msgstr "并且我们和人类的联盟复活了，这可不是小事。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:617
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:613
 msgid ""
 "Indeed it is not. As always, Cleodil, you speak with the wisdom and care "
 "that befits a healer. That is a good reminder for those who must walk the "
@@ -3364,7 +3365,7 @@ msgstr ""
 "血战斗的人来说真是良好的提醒啊，深深触及我内心。"
 
 #. [message]: id=Olurf
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:621
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:617
 msgid ""
 "A good fight against foul enemies. These orcs make a dwarf’s hackles rise; I "
 "might even fight them for free, next time."
@@ -3373,17 +3374,17 @@ msgstr ""
 "要是有下次的话。"
 
 #. [message]: id=Aldar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:625
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:621
 msgid "The King is here! Hail Haldric II, King of Wesnoth!"
 msgstr "国王驾到！向韦诺之王，哈德里克二世致敬！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:640
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:636
 msgid "Tath will fall! We have failed!"
 msgstr "塔斯就要陷落了！我们失败了！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:654
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg:650
 msgid ""
 "I die? Great Chief never said anything about fighting elves and dwarves!"
 msgstr "我要死了？大酋长从没说过我们还要面对精灵和矮人！"
@@ -3828,34 +3829,34 @@ msgid "Done!"
 msgstr "搞定！"
 
 #. [message]: id=Ozul
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:774
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:773
 msgid ""
 "The Great Chief has been murdered! Whoever did it will only get da throne "
 "over my dead stinking body!"
 msgstr "大酋长被杀了！除非踏过我的尸体，篡位者别想得逞！"
 
 #. [message]: id=Tamitahan
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:778
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:777
 msgid "I am the strongest warlord! I will be Chief!"
 msgstr "我是实力最强的督军！我应该成为酋长！"
 
 #. [message]: id=Gvur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:782
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:781
 msgid "No way anyone will steal my throne!"
 msgstr "别人别想抢走我的宝座！"
 
 #. [message]: id=Khrubar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:786
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:785
 msgid "This is my time and I will kill anyone who disputes it!"
 msgstr "这是我的时代，谁有异议我就杀了谁！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:790
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:789
 msgid "The plan is working! Now we will take back what’s ours!"
 msgstr "计划成功了！现在我们可以拿回我们自己的东西了！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:794
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg:793
 msgid "Softly, Landar. We still have to get out of here..."
 msgstr "轻点，兰达尔。我们还得从这出去……"
 
@@ -3877,28 +3878,28 @@ msgstr ""
 "略者的据点送来。很快这边决定派兵去支援他们。不过严冬降临，再加上那条路上……"
 
 #. [side]: type=Orcish Warlord, id=Kior-Pur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:109
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:107
 msgid "Kior-Pur"
 msgstr "基尔-普尔"
 
 #. [side]: type=Orcish Warlord, id=Mbiran
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:145
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:143
 msgid "Mbiran"
 msgstr "穆巴让"
 
 #. [side]: type=Orcish Warlord, id=Tan-Durr
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:179
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:177
 msgid "Tan-Durr"
 msgstr "坦-杜尔"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:275
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:292
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:273
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:290
 msgid "Death of Uradredia"
 msgstr "尤拉德雷迪亚死亡"
 
 #. [message]: id=Kior-Pur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:307
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:305
 msgid ""
 "I see troops coming from the south! It must be that our army has beaten "
 "these elves and humans and will now help us crush these remaining elves!"
@@ -3907,54 +3908,54 @@ msgstr ""
 "这一挫精灵来了！"
 
 #. [message]: id=Uradredia
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:311
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:309
 msgid ""
 "Our defenses are stretched thin. Men, prepare to face another orcish attack!"
 msgstr "我们的防线被拉窄了。弟兄们，准备好兽人又一波攻击！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:315
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:313
 msgid "The North Elves still stand. Prepare for battle!"
 msgstr "北方的精灵还活着。作战准备！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:323
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:321
 msgid "The North Elves are now free!"
 msgstr "北方精灵现在自由了！"
 
 #. [message]: id=Uradredia
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:328
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:325
 msgid ""
 "Our thanks to you, Kalenz, son of Kliada. Our troops are at your command."
 msgstr "我们对你感激不尽，卡雷兹，克利亚达之子。我们的军队听从你的指挥。"
 
 #. [message]: id=Kior-Pur
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:341
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:338
 msgid "The elves are attacking us! Reserves!"
 msgstr "精灵正向我们进攻！后备队！"
 
 #. [unit]: type=Direwolf Rider, id=Zhuk
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:352
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:349
 msgid "Zhuk"
 msgstr "祖库"
 
 #. [unit]: type=Direwolf Rider, id=Dran
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:369
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:366
 msgid "Dran"
 msgstr "杜安"
 
 #. [unit]: type=Direwolf Rider, id=Hrugt
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:381
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:378
 msgid "Hrugt"
 msgstr "户格特"
 
 #. [unit]: type=Direwolf Rider, id=Orhtib
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:393
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:390
 msgid "Orhtib"
 msgstr "欧亨提"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:411
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg:408
 msgid ""
 "Before you die, know that you lost in Wesmere, you lost at Tath, you will "
 "lose here and that your Great Chief is dead!"
@@ -4238,7 +4239,7 @@ msgid "Council Ruling"
 msgstr "评议会的裁决"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:16
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:15
 msgid ""
 "With the once mighty saurian empire destroyed, saurians had been reduced to "
 "scattered bands lurking in waste places. But the elves still had problems of "
@@ -4248,7 +4249,7 @@ msgstr ""
 "过精灵还有他们自己的麻烦……"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:26
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:25
 msgid ""
 "Kalenz, the Council has called you here to demand that you apologize for "
 "your actions. You took the decision to help the humans at Tath, and hence "
@@ -4261,7 +4262,7 @@ msgstr ""
 "些都该是由评议会来定夺，而不该由战地指挥官决定！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:31
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:30
 msgid ""
 "With all respect my lords, we were and still are in a war. We could not "
 "spare the time to consult with you, lest our opportunities slip from our "
@@ -4275,7 +4276,7 @@ msgstr ""
 "胁。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:36
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:35
 msgid ""
 "The Council is not blind to these benefits. But, still, you cannot decide "
 "high matters of statecraft on behalf of the elves. We cannot allow it."
@@ -4284,39 +4285,39 @@ msgstr ""
 "绝不允许。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:41
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:40
 #: data/campaigns/Legend_of_Wesmere/utils/characters.cfg:278
 msgid "Galtrid"
 msgstr "加尔泰德"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:41
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:40
 msgid ""
 "If it weren’t for Kalenz and his men, none of us would be here to argue the "
 "point today."
 msgstr "如果不是卡雷兹和他的部队，今天没人能在这谈论这些问题。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:46
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:45
 msgid ""
 "I agree. What’s done is done. Let us concentrate on the future, not the past."
 msgstr "我同意。过去的事就让它过去了。让我们关注以后，不是过去。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:46
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:45
 #: data/campaigns/Legend_of_Wesmere/utils/characters.cfg:318
 msgid "Uradredia"
 msgstr "尤拉德雷迪亚"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:51
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:50
 msgid ""
 "Kalenz, the Council has decided that you are to be stripped of all military "
 "authority. You may now go."
 msgstr "卡雷兹，评议会已经决定剥夺你的全部军事领导权。你现在可以离开了。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:56
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:55
 msgid ""
 "I lay down my burden humbly and gladly. But we need to have a strong army, "
 "as the orcs will return!"
@@ -4324,22 +4325,22 @@ msgstr ""
 "我恭敬而愉悦得卸下这重担。但我们必须保留一只强大的军队，兽人随时会回来！"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:62
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg:61
 msgid "Cowards and traitors!"
 msgstr "胆小鬼！卖国贼！"
 
 #. [scenario]: id=21_Elvish_Assassins
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:15
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:14
 msgid "Elvish Assassins"
 msgstr "精灵刺客"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:37
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:36
 msgid "After the council’s decision, Kalenz and Cleodil retired in the North."
 msgstr "评议会宣布决议后，卡雷兹和科柳迪赋闲回到了北方。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:42
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:41
 msgid ""
 "Free of the pressure of war, they took delight in each other. The heart-bond "
 "they had formed amidst peril and death grew closer, and all but vanquished "
@@ -4350,7 +4351,7 @@ msgstr ""
 "密，并且卡雷兹差不多克服了克雷拉努药水的邪恶余存。他们二人开始考虑养儿育女。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:45
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:44
 msgid ""
 "But their peace was not to last. In the outer world, the blood tides were "
 "rising. And in the heart of Landar, who had once been their friend, evil was "
@@ -4360,26 +4361,26 @@ msgstr ""
 "处，邪恶没有被战胜，而是逐渐恶化并扎根蔓延……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:94
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:91
 msgid ""
 "Kalenz begins this scenario in retirement, and is not able to recall his "
 "veteran troops."
 msgstr "卡雷兹在这幕中处于停职状态，也不能召回他的老兵队伍。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:121
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:118
 msgid "As you command, my lord."
 msgstr "遵命，长官。"
 
 #. [message]: id=Cleodil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:125
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:122
 msgid ""
 "You turn on us? I cannot believe it! How has elf come to strive against elf "
 "so bitterly?"
 msgstr "你现在拿我们开刀？我简直不能相信！精灵什么时候如此残酷地内斗过？"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:129
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:126
 msgid ""
 "Evil takes many forms, my love. Today we see another of its faces... and "
 "must defeat it again. Prepare to die, $betrayer|!"
@@ -4388,66 +4389,66 @@ msgstr ""
 "的准备， $betrayer|！"
 
 #. [message]: role=betrayer
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:133
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:130
 msgid "Only Landar has the will to do what must be done to save the elves!"
 msgstr "只有兰达尔有意志去做当做之事来拯救精灵！"
 
 #. [message]: role=betrayer
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:175
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:172
 msgid "Hold, $unit.name|! Now we fight for Landar!"
 msgstr "住手，$unit.name|！现在我们要为兰达尔作战！"
 
 #. [message]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:197
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:194
 msgid "Hold your hand, $unit.name|! $second_unit.name| is on our side!"
 msgstr "停手， $unit.name|！ $second_unit.name| 是我们这方的！"
 
 #. [message]: role=betrayer
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:202
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:199
 msgid ""
 "I will not stand by as Kalenz betrays us to the humans and dwarves. We "
 "follow Landar now!"
 msgstr "我不能袖手旁观，因为卡雷兹把我们出卖给人类和矮人。我们现在追随兰达尔！"
 
 #. [side]: type=Elvish Ranger, id=Antaril
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:216
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:213
 msgid "Antaril"
 msgstr "安泰瑞尔"
 
 #. [side]: type=Elvish Marshal, id=Crintil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:283
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:227
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:280
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:225
 msgid "Crintil"
 msgstr "库鲁丁"
 
 #. [side]: type=Elvish Captain, id=Oblil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:320
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:317
 msgid "Oblil"
 msgstr "鸥比利"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:366
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:363
 msgid "Kalenz reaches the signpost"
 msgstr "卡雷兹到达路标"
 
 #. [unit]: id=Galenor, type=Elvish Scout
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:401
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:398
 msgid "Galenor"
 msgstr "盖乐诺"
 
 #. [message]: id=Galenor
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:411
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:408
 msgid ""
 "My lord Kalenz, you are in great danger! You must leave here immediately."
 msgstr "卡雷兹阁下，您现在很危险！您必须立即离开。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:415
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:412
 msgid "What?!"
 msgstr "什么？！"
 
 #. [message]: id=Galenor
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:419
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:416
 msgid ""
 "Landar has seized control of the army. He has eliminated the Council and "
 "proclaimed himself High Warlord of the Elves. What is worse, there is word "
@@ -4457,24 +4458,24 @@ msgstr ""
 "是，传言说他已经下令派人暗杀你。"
 
 #. [message]: id=Crintil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:423
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:420
 msgid "Too late! All traitors will die!"
 msgstr "太迟了！所有的叛国者必须死！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:427
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:424
 msgid ""
 "Listen to me! We have fought and bled side by side. We must trust in each "
 "other and face the orcs together!"
 msgstr "听我说！我们曾经誓死与共。我们必须相信彼此共同对抗兽人！"
 
 #. [message]: id=Oblil
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:432
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:429
 msgid "Do not listen to this traitor! You have all heard the order!"
 msgstr "不要听信叛国者！你们都听到命令了！"
 
 #. [message]: id=Galenor
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:437
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:434
 msgid ""
 "You should try to reach Uradredia and the North Elves. He too, has refused "
 "to join Landar. Word is that some troops still loyal to you are heading "
@@ -4484,7 +4485,7 @@ msgstr ""
 "终忠于您的部队正赶向那去。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:456
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg:453
 msgid "Now we must fare swiftly to the North Elves!"
 msgstr "现在我们必须赶快到北方精灵那去！"
 
@@ -4508,50 +4509,44 @@ msgstr ""
 
 #. [part]
 #: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:33
-#, fuzzy
-#| msgid ""
-#| "Kalenz’s veterans joined the host of the Northern Elves under Uradredia. "
-#| "Very soon, Landar’s army appeared..."
 msgid ""
 "Though some of Kalenz’s veterans had joined Landar in revolt, others instead "
 "joined the northern host under Uradredia. Very soon, Landar’s army "
 "appeared..."
 msgstr ""
-"卡雷兹的老兵加入了尤拉德雷迪亚领导的北方精灵。很快，兰达尔的军队出现了……"
+"虽然部分卡雷兹的老部下加入了兰达尔的叛乱，但其他人则加入了尤拉德雷迪亚麾下的"
+"北方军团。很快，兰达尔的军队便出现了……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:145
-#, fuzzy
-#| msgid ""
-#| "Kalenz can only recall shamans and their advancements from his former "
-#| "army; the rest of his men joined Uradredia before he arrived."
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:143
 msgid ""
 "Kalenz can only recall shamans and their advancements from his former army; "
 "as for the rest of his men, it’s been a bitter split — for every elf who "
 "came back from Saurgrath to stand with Uradredia, two came back pledging "
 "their blade to Landar’s call."
 msgstr ""
-"卡雷兹只能从他从前的军队中召回萨满和她的晋级单位；他其余的手下在他来之前就加"
-"入了尤拉德雷迪亚。"
+"卡雷兹只能从旧部中召回萨满及其进阶单位；至于其余部下，则经历了一场令人痛心的"
+"分裂——每有一个从索格拉斯归来追随尤拉德雷迪亚的精灵，就有两个归来响应兰达尔的"
+"号召、誓以刀剑相从。"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:277
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:275
 msgid "Survive for six days"
 msgstr "存活六天"
 
 #. [objective]: condition=lose
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:313
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:311
 msgid "Kalenz survives for six days"
 msgstr "卡雷兹存活六天"
 
 #. [note]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:324
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:322
 msgid ""
 "If you lose you still have a chance to defeat Kalenz in the next scenario."
 msgstr "如果失败，你还可以在下一幕场景中获得一次击败卡雷兹的机会。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:333
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:331
 msgid ""
 "Landar, listen to me! It does not have to come to this. I know about the "
 "potion. Let us help!"
@@ -4559,25 +4554,25 @@ msgstr ""
 "兰达尔，听我说！我们没必要走到这一步。我知道是因为那瓶药。让我们帮助你！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:337
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:335
 msgid ""
 "Here is Kalenz. There can be no talk with traitors! Leave none of them alive!"
 msgstr "卡雷兹就在这。跟叛国者没什么好谈的！一个不留！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:353
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:351
 msgid "Things are not going well! Retreat! We will meet again, traitors!"
 msgstr "形势不对！撤退！我们会再见面的，叛国者！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:371
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:369
 msgid ""
 "We have yet to break their defenses! While we are getting weaker, the enemy "
 "is getting stronger! Retreat!"
 msgstr "我们还没有击溃他们的防御！我们士气渐衰，他们士气高昂！撤退！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:375
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg:373
 msgid "We won!"
 msgstr "我们赢了！"
 
@@ -4587,7 +4582,7 @@ msgid "End of War"
 msgstr "战争的尽头"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:33
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:32
 msgid ""
 "It is said that the battle with the North Elves was the beginning of the end "
 "for Landar’s revolt. But civil war smoldered on for many more years, neither "
@@ -4603,48 +4598,48 @@ msgstr ""
 "敌，兰达尔进军，在吉塔莫斯的丛林中……"
 
 #. [objective]: condition=win
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:115
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:114
 msgid "Defeat Landar"
 msgstr "击败兰达尔"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:140
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:139
 msgid "Landar, let us spill no more elvish blood. Give up. We can help you!"
 msgstr "兰达尔，让我们停止挥霍精灵们的鲜血。放弃吧，我们会帮助你！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:144
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:143
 msgid "No! It all ends here!"
 msgstr "不！一切到此为止！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:163
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:162
 msgid ""
 "Forgive me $unit.name|. I will sing your name in praise under the stars!"
 msgstr "原谅我 $unit.name|。我会在星星下歌颂你的名字！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:167
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:166
 msgid "We must all pass, $second_unit.name|. Make your song beautiful..."
 msgstr "我们都要去的， $second_unit.name|。把歌唱得好听点……"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:185
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:184
 msgid "Forgive me, $unit.name|, this victory brings me no joy."
 msgstr "原谅我， $unit.name|，这样的胜利谁也不会开心。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:189
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:188
 msgid "Remember me to the trees, $second_unit.name|."
 msgstr "把我的名字刻在树上， $second_unit.name|。"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:201
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:200
 msgid "I fall. Perhaps now I can rest!"
 msgstr "我的使命结束了。也许现在我能安息了！"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:205
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:204
 msgid ""
 "I am deeply grieved that it came to this, Landar. You were my best friend. I "
 "was blind to what the potion was doing to you. I was fighting it myself!"
@@ -4653,7 +4648,7 @@ msgstr ""
 "摧残视而不见。我只顾自己跟药剂抗衡！"
 
 #. [message]: id=Landar
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:209
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:208
 msgid ""
 "I know. But you are not at fault, for I did not take just one bottle. I "
 "wanted to make sure we could kill the orcish Great Chief, so I went back for "
@@ -4666,7 +4661,7 @@ msgstr ""
 "至尝试杀死自己的朋友。我是精灵们的耻辱。"
 
 #. [message]: id=Kalenz
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:213
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg:212
 msgid ""
 "It was not all your fault. Maybe the curse of Aquagar struck true, or maybe "
 "yours was the blood-price fate required of us for victory. Rest well, my "
@@ -4689,7 +4684,7 @@ msgstr ""
 "卡雷兹以崇高的心境埋葬了兰达尔并为他竖起纪念碑使他的名字位列众精灵英雄之中。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:20
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:19
 msgid ""
 "Landar’s remaining followers’ lives were spared, but they were banished to "
 "Gitamoth forest, henceforth known as Silent Forest."
@@ -4698,7 +4693,7 @@ msgstr ""
 "林。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:25
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:24
 msgid ""
 "As Landar had wiped out the Elvish Council, Kalenz was unanimously chosen as "
 "High Lord of the Elves. North and South Elves swore allegiance to him."
@@ -4707,7 +4702,7 @@ msgstr ""
 "灵都宣誓拥护他。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:30
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:29
 msgid ""
 "Kalenz reorganized the elves so they could mobilize for war more readily. He "
 "knew that the orcish threat was not over; that the elves, through "
@@ -4718,7 +4713,7 @@ msgstr ""
 "束，由于犹豫不决，精灵们错过了消灭威胁的黄金机会，麻烦总有一天会回来。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:34
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:33
 msgid ""
 "When Kalenz felt his work to have been done as well as it might be, he "
 "retired with Cleodil to their home in the Forest of Lintanir."
@@ -4727,7 +4722,7 @@ msgstr ""
 "们在林塔尼尔树林的家中。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:39
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:38
 msgid ""
 "Cleodil bore Kalenz children who were tall, and beautiful, and inherited in "
 "full measure both their mother’s healing gifts and their father’s talented "
@@ -4741,7 +4736,7 @@ msgstr ""
 
 #. [part]
 #. "Sundered" is archaic English roughly meaning "torn apart".
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:43
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:42
 msgid ""
 "But Kalenz’s story was not yet over. Aquagar’s curse was fulfilled; "
 "prolonged in life by Crelanu’s philter, he outlived not only his beloved but "
@@ -4757,7 +4752,7 @@ msgstr ""
 "的智慧或魔法又或他锋利的宝剑援助他们。"
 
 #. [part]
-#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:46
+#: data/campaigns/Legend_of_Wesmere/scenarios/chapter5/24_Epilogue.cfg:45
 msgid ""
 "To learn of Kalenz’s last and perhaps greatest deeds, and those in which he "
 "was most alone, seek ye the tale of Delfador the Great and the fall of the "

--- a/translations/wesnoth/po/wesnoth-nr/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-nr/zh_CN.po
@@ -1,5 +1,5 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
@@ -10,21 +10,22 @@
 # MrKing <yideey@gmail.com>, 2012.
 # wind <everywherewind@gmail.com>, 2011.
 # CloudiDust <cloudidust@gmail.com>, 2017.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.16\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2025-08-19 15:14 UTC\n"
-"PO-Revision-Date: 2024-08-24 11:54+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-08-03 03:45 UTC\n"
+"PO-Revision-Date: 2026-08-26 22:17+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=Northern_Rebirth
 #: data/campaigns/Northern_Rebirth/_main.cfg:9
@@ -154,7 +155,6 @@ msgid ""
 "place until the orcs came..."
 msgstr "就这样过了很多年，矮人之门一直是平静和繁荣的，直到兽人的到来……"
 
-# Translated by ollama with model glm4
 #. [part]
 #: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:34
 msgid ""
@@ -211,7 +211,7 @@ msgstr ""
 "人之门人民的生活——永远改变。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:55
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:54
 msgid ""
 "It was an early spring day, in the year 518YW. The humans — joyless beneath "
 "the orcish whip — were dispiritedly planting the yearly crop. All at once, "
@@ -225,7 +225,7 @@ msgstr ""
 "他。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:60
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:59
 msgid ""
 "He came charging out of the woods, his cape streaming in the breeze, his "
 "sword flashing quicker than thought. All around him, the hated orcs fell. To "
@@ -240,7 +240,7 @@ msgstr ""
 
 #. [part]
 #. tyrant -> Queen Asheviere from Heir to the Throne.
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:66
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:65
 msgid ""
 "Word quickly spread among the humans that this hero was none other than "
 "Prince Konrad of Wesnoth, faring to the ruins of Knalga to retrieve the "
@@ -252,7 +252,7 @@ msgstr ""
 "样站着，在他们所在的地方敬畏地站着。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:71
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:70
 msgid ""
 "As quickly as it had begun, it was over. Konrad reached the entrance to the "
 "tunnels and ushered his men through. Then he turned one last time to face "
@@ -265,7 +265,7 @@ msgstr ""
 "有一天会自由的！”</b>，然后他走了。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:76
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:75
 msgid ""
 "After that day, nothing could be the same. Hope rose in their hearts like a "
 "flame long-smothered but rekindled. The brightest and boldest of them began "
@@ -276,7 +276,7 @@ msgstr ""
 "秘密计划着。而兽人的领袖，则被愚蠢的骄傲冲昏了头脑，毫无察觉。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:83
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:81
 msgid ""
 "There was one among these peasants named Tallin. He had been a little child, "
 "barely out of his mother’s arms, when Konrad broke the Orcish host. But he "
@@ -291,7 +291,7 @@ msgstr ""
 "孩已经长大成人，他可以接触到刀剑，也心怀梦想。于是，他行动了。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:88
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:86
 msgid ""
 "Then one day Al’Tar, the current ‘master’ of Dwarven Doors, was attacked by "
 "a neighboring tribe of orcs. Tallin seized his moment. Using knowledge born "
@@ -305,61 +305,61 @@ msgstr ""
 
 #. [side]
 #. [side]: type=Dwarvish Lord, id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:103
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:53
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:100
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:27
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:32
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:37
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:100
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:51
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:96
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:26
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:31
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:36
 msgid "Rebels"
 msgstr "义军"
 
 #. [unit]: type=Peasant, id=Zlex, role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:112
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:108
 msgid "Zlex"
 msgstr "兹莱克斯"
 
 #. [side]: type=Orcish Warlord, id=Al'Tar
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:131
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:126
 msgid "Al'Tar"
 msgstr "阿尔·塔"
 
 #. [side]: type=Orcish Warlord, id=Al'Tar
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:136
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:131
 msgid "Al’Tar"
 msgstr "阿尔·塔"
 
 #. [side]: type=Orcish Warrior, id=Garrugch
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:161
 #: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:166
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:171
 msgid "Garrugch"
 msgstr "嘎拉格奇"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:215
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:210
 msgid "Defeat enemy leaders"
 msgstr "击败敌方首领"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:219
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:263
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:102
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:199
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:331
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:201
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:333
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:303
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:154
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:387
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:712
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:206
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:428
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:214
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:259
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:99
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:196
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:328
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:197
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:327
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:299
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:151
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:382
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:706
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:202
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:424
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:566
 msgid "Death of Tallin"
 msgstr "塔林死亡"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:237
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:232
 msgid ""
 "This challenger has made the orcs careless — I managed to sneak in and filch "
 "the key to the storerooms. Come with me lads, and grab some weapons! Let "
@@ -371,7 +371,7 @@ msgstr ""
 "滓。谁愿意和我一起上？"
 
 #. [message]: speaker=Zlex
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:242
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:237
 msgid ""
 "Brave words, Tallin, but if I didn’t know you better I’d say you were moon-"
 "touched. These are not weapons, just pitchforks and hunting bows. We have no "
@@ -383,7 +383,7 @@ msgstr ""
 "大骂来击败他们吗？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:247
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:242
 msgid ""
 "Well, those things will certainly get their attention, but there’s nothing "
 "wrong with pitchforks. We easily outnumber the orcs and they’re even now "
@@ -393,14 +393,14 @@ msgstr ""
 "人，而且他们现在正在互相残杀。"
 
 #. [message]: speaker=Zlex
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:252
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:247
 msgid ""
 "But their wolves run faster than we can walk, and their swords are sharper "
 "than these farm tools."
 msgstr "但是他们的狼跑得比我们走的速度快，而且他们的剑也比这些农具锋利。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:257
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:252
 msgid ""
 "Our numbers are our strength. Stay shoulder-to shoulder with the man next to "
 "you; never get isolated, especially not on open ground. Swarm them — "
@@ -410,12 +410,12 @@ msgstr ""
 "开阔地上落单。淹没他们——包围他们，五六个围住他们一个，他们就完蛋了。"
 
 #. [message]: speaker=Zlex
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:262
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:257
 msgid "But still, Tallin, this is going to be a slaughter."
 msgstr "但是……塔林，这会变成一场屠杀。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:267
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:262
 msgid ""
 "But, but, but... Are you full of nothing but doubts? (<i>Sigh</i>) Yes, it "
 "will be a massacre. But would you rather live as slaves to the orcs forever?"
@@ -424,26 +424,26 @@ msgstr ""
 "会变成一场屠杀。但是难道你情愿永远活在兽人的奴役下吗？"
 
 #. [message]: speaker=Zlex
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:272
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:267
 msgid "Never! I would rather die!"
 msgstr "绝不！那还不如死掉算了！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:277
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:272
 msgid ""
 "Then what choice do we have? This may be the only chance we ever get, it’s "
 "time to fight!"
 msgstr "那我们还有什么选择呢？这可能是我们唯一的机会，到了战斗的时刻了！"
 
 #. [message]: speaker=Al'Tar
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:282
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:277
 msgid ""
 "You dare greatly, you miserable excuse for an orc! How dare you step onto my "
 "land!"
 msgstr "你这兽人之耻，胆大包天！竟敢踏上我的土地！"
 
 #. [message]: speaker=Garrugch
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:288
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:282
 msgid ""
 "Idle threats. Time as a slavemaster has made you weak. You have the strength "
 "of a goblin, and the brains to match. This land now belongs to my master. "
@@ -453,58 +453,58 @@ msgstr ""
 "此。这片土地现在属于我的主人。现在投降，他或许会让你做（<b>他的</b>）奴隶的。"
 
 #. [message]: speaker=Al'Tar
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:294
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:287
 msgid ""
 "Pah! Grunts, attack! Whoever brings me the head of Garrugch will be rewarded "
 "in gold!"
 msgstr "呸！小的们，给我上！谁能给我呈上嘎拉格奇的头颅，我就赏他金币！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:310
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:303
 msgid "Ack! These bloody slaves are always getting in the way. Cut them down!"
 msgstr "啊！这些该死的奴隶真是碍眼。砍倒他们！"
 
 #. [message]: speaker=Garrugch
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:315
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:308
 msgid ""
 "Look at that, the weakling Al’Tar can’t even keep his slaves under control. "
 "This will prove easier than I thought!"
 msgstr "看看，看看，阿尔·塔连他的奴隶都管不住。这恐怕比我所想的还要容易！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:329
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:322
 msgid "This is one of the entrances to the dwarven caves."
 msgstr "这是一个通向矮人洞穴的入口。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:335
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:327
 msgid "Aaaaah! Trolls! The caves are infested with trolls!"
 msgstr "啊！巨魔！洞穴里都是巨魔！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:357
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:349
 msgid "<i>Yes</i>! We did it! We are free!"
 msgstr "<b>万岁</b>！我们成功了！我们自由了！"
 
 #. [unit]: type=Orcish Grunt, id=Khrulg
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:369
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:361
 msgid "Khrulg"
 msgstr "鲁尔格"
 
 #. [message]: speaker=Khrulg
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:377
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:369
 msgid ""
 "Garrugch failed in mission, but Al’tar dead by peasant slaves. Better tell "
 "the Master."
 msgstr "嘎拉格奇的任务失败了，阿尔·塔也被农民奴隶杀死了。我最好去报告给首领。"
 
 #. [message]: speaker=Khrulg
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:382
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:374
 msgid "Master needs more meat for wolves. Peasants good meat."
 msgstr "主人需要更多肉食喂狼。农民的肉不错。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:410
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:402
 msgid ""
 "I die now, you orcish scum, but I die free! More will come after me. We will "
 "rise again until our vengeance has wiped your stain from our land!"
@@ -513,71 +513,71 @@ msgstr ""
 "起义，直到我们的复仇将你们的污迹从我们的土地之上洗去！"
 
 #. [message]: speaker=Al'Tar
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:422
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:414
 msgid "Pah! Grunts, put the rest of that peasant rabble back in chains."
 msgstr "呸！小的们，把剩下的农民杂碎锁回去。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:442
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:434
 msgid "What the...? (<i>Gurgle</i>) Killed... by... slaves?"
 msgstr "这怎……？（<b>呃</b>）我被……奴隶……杀了？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:446
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:457
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:438
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:449
 msgid "(<i>Stab</i>)"
 msgstr "（<b>刺入</b>）"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:453
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:445
 msgid "What the...? (<i>Gurgle</i>) Defeated... by... a grunt?"
 msgstr "这怎……？（<b>呃</b>）我被……苦工……打败了？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:464
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:456
 msgid "(<i>Smack</i>)"
 msgstr "（<b>猛击</b>）"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:471
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:463
 msgid "Ugh!"
 msgstr "啊！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:487
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:479
 msgid "Not a very bright one, was he?"
 msgstr "他并不怎么聪明，不是吗？"
 
 #. [message]: speaker=second_unit
 #. "him" is referring to Al'Tar
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:501
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:493
 msgid "We got him, chief!"
 msgstr "我们干掉他了，老大！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:507
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:499
 msgid "We avenged our leader..."
 msgstr "我们为领袖报仇了……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:524
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:516
 msgid "No! I have failed in my mission!"
 msgstr "不！我的任务失败了！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:536
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:528
 msgid "Mission? What mission?"
 msgstr "任务？什么任务？"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:544
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:536
 msgid ""
 "Sounds of drums and horns echo on the mountainsides. A large orc army draws "
 "near!"
 msgstr "战鼓和号角声在山中回响。庞大的兽人军队逼近了！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:549
+#: data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg:541
 msgid ""
 "If only we were faster escaping into the mines this wouldn’t have happened. "
 "At least we will die free..."
@@ -644,7 +644,7 @@ msgstr ""
 "引力。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:32
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:31
 msgid ""
 "So the matter lay. The peasants dithered from one suggested plan of action "
 "to the next, never arriving at any conclusion. However, some unlooked help "
@@ -661,7 +661,7 @@ msgstr ""
 "找并训练那些愿意学习他们粗犷战斗风格的人。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:35
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:34
 msgid ""
 "A fortnight after their victory, the town was awakened from slumber in the "
 "dead of night by the distant booming of orcish drums. Scouts training with "
@@ -674,7 +674,7 @@ msgstr ""
 "看着塔林。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:38
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:37
 msgid ""
 "Faced with certain destruction at the hands of the orcs, or a fate unknown "
 "in the caves of Knalga, Tallin chose the latter. The people quickly "
@@ -692,34 +692,34 @@ msgstr ""
 #. [side]: type=Troll Hero, id=Bor
 #. [side]: type=Troll Rocklobber, id=Oof
 #. [side]: type=Troll Hero, id=Glu
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:70
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:84
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:170
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:44
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:199
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:217
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:234
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:251
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:66
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:80
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:166
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:41
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:194
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:212
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:229
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:246
 msgid "Trolls"
 msgstr "巨魔"
 
 #. [side]: type=Troll, id=Knash
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:74
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:70
 msgid "Knash"
 msgstr "克纳什"
 
 #. [side]: type=Troll, id=Krog
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:88
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:84
 msgid "Krog"
 msgstr "克洛格"
 
 #. [side]: type=Dwarvish Lord, id=Hamel
 #. [unit]: type=Dwarvish Lord, id=Hamel
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:105
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:48
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:42
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:56
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:101
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:45
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:40
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:53
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:312
 #: data/campaigns/Northern_Rebirth/utils/utils.cfg:144
 msgid "Hamel"
@@ -738,97 +738,93 @@ msgstr "哈梅尔"
 #. [side]: type=Death Knight, id=Author
 #. [side]: type=Death Knight, id=Boblin
 #. [side]: type=Death Knight, id=Antrasis
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:154
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:198
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:216
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:44
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:70
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:94
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:119
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:145
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:48
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:109
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:131
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:155
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:188
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:209
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:150
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:194
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:212
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:41
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:67
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:91
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:116
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:142
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:45
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:106
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:128
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:152
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:185
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:206
 msgid "Undead"
 msgstr "亡灵"
 
 #. [side]: type=Death Knight, id=Mal Barath
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:159
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:155
 msgid "Mal Barath"
 msgstr "玛尔·巴拉斯"
 
 #. [side]: type=Troll Warrior, id=Thung
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:174
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:170
 msgid "Thung"
 msgstr "桑格"
 
 #. [side]: type=Death Knight, id=Delzath
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:203
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:199
 msgid "Delzath"
 msgstr "德尔扎斯"
 
 #. [side]: type=Death Knight, id=Mal Tath
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:221
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:217
 msgid "Mal Tath"
 msgstr "玛尔·塔斯"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:242
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:238
 msgid "Find the dwarves"
 msgstr "找到矮人"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:252
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:248
 msgid "Move Tallin to the dwarvish area to meet with Lord Hamel"
 msgstr "移动塔林至矮人区域以面见哈梅尔领主"
 
 #. [objectives]
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:261
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:257
 msgid "Clear the caves"
 msgstr "将洞穴清理干净"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:267
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:263
 msgid "The dwarves are defeated"
 msgstr "矮人被击败了"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:293
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:289
 msgid "So here we are..."
 msgstr "我们来了……"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:298
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:294
 msgid "(<i>Trip</i>) <i>Oof!</i>"
 msgstr "（<b>绊倒</b>）<b>啊！</b>"
 
 #. [message]: role=Supporter
 #. sarcasm about the idea of entering the mines where this scenario takes place
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:304
-#, fuzzy
-#| msgid ""
-#| "Great idea, Tallin. It's so dark I probably couldn’t even fight a bat "
-#| "down here."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:300
 msgid ""
 "Great idea, Tallin. It’s so dark I probably couldn’t even fight a bat down "
 "here."
 msgstr "好主意，塔林。这里太暗了，我在这下面可能连一只蝙蝠都打不过。"
 
 #. [message]: type=Blood Bat
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:318
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:314
 msgid "Neep Neep!"
 msgstr "讷讷！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:323
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:319
 msgid "Ahhhh!"
 msgstr "啊！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:328
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:324
 msgid ""
 "Calm down. Come what may, we’ll handle them. Come on now, let’s find those "
 "dwarves!"
@@ -836,27 +832,27 @@ msgstr ""
 "冷静。不管遇到什么，我们一定都能解决的。现在行动起来，让我们找到那些矮人！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:364
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:359
 msgid "<i>Prepare to die, you foul orc!</i>"
 msgstr "<b>准备受死吧，你们这些邪恶的兽人！</b>"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:369
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:364
 msgid "Hold it! I am no orc, I am a human!"
 msgstr "我不是兽人，我是人类！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:374
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:369
 msgid "A human! Amazing, I haven’t seen a human ever since the orcs attacked."
 msgstr "一个人类！太令人吃惊了，自从兽人来袭我就没有见过一个人类。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:379
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:374
 msgid "How have you managed to survive all this time?"
 msgstr "在这种环境下，你是怎么活下来的？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:384
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:379
 msgid ""
 "By frying every orc, troll or skeleton I come across. Duh! Those monsters "
 "desecrated my life’s work, now I shall not rest till I send every last one "
@@ -868,18 +864,18 @@ msgstr ""
 "比坐在后方整天搞研究有意思多了……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:389
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:384
 msgid "... Uh, sure!"
 msgstr "……哦，是的！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:394
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:389
 msgid ""
 "But silly me, where are my manners? Would you like to come inside for tea?"
 msgstr "你瞧，我真是糊涂了，都忘了礼节了。你愿意进来喝杯茶吗？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:399
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:394
 msgid ""
 "Um... err... well actually we are presently busy fighting our way through "
 "hordes of trolls and skeletons trying to find the dwarves... if there are "
@@ -889,59 +885,59 @@ msgstr ""
 "果还有矮人幸存的话。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:404
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:399
 msgid "Hordes of trolls and skeletons! Where?! Let’s go burn ’em all!"
 msgstr "一大群巨魔和骷髅兵！在哪儿？让我烧死他们！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:410
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:404
 msgid "Er... let’s go..."
 msgstr "呃……好的……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:415
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:409
 msgid "whisper^Is it safe to have this lunatic with us?"
 msgstr "（耳语）真的要带上这个疯子吗？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:433
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:427
 msgid "<i>Burn, you disgusting filth!</i>"
 msgstr "<b>烧死你们，你们这些恶心的渣滓！</b>"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:437
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:431
 msgid "Ahhh! Fire!"
 msgstr "啊！火！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:450
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:444
 msgid "<i>Yeah! Die, scum, die!</i>"
 msgstr "<b>耶！去死吧，垃圾，去死吧！</b>"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:467
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:461
 msgid "This tunnel keeps on going..."
 msgstr "这个隧道很长……"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:472
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:466
 msgid ""
 "I think we should finish searching this part of Knalga first before we go "
 "deeper into the caves."
 msgstr "我想我们完成了纳尔迦的这个部分的搜索，我们将去更深的地方。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:488
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:482
 msgid "Grim Gods of Darkness! What are those things?"
 msgstr "黑暗之神！这是些什么东西？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:493
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:487
 msgid "Skeletons!"
 msgstr "骷髅兵！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:498
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:492
 msgid ""
 "Look at the axes they bear. At one time those skeletons must have been "
 "dwarves!"
@@ -949,7 +945,7 @@ msgstr "看他们的斧子。他们曾经也是矮人！"
 
 #. [message]: speaker=Tallin
 #. The dwarves are skeletal undead.
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:504
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:498
 msgid ""
 "So it is true! The dwarven defenders of Knalga have risen once again. Stand "
 "firm men! Now it remains to be seen whether or not they recognize us as "
@@ -959,154 +955,130 @@ msgstr ""
 "认为我们是朋友。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:520
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:514
 msgid "They are attacking us!"
 msgstr "他们在攻击我们！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:525
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:519
 msgid "Destroy them!"
 msgstr "消灭他们！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:554
-#, fuzzy
-#| msgid ""
-#| "Hey look, it’s an ancient door. It seems the trolls were too stupid to "
-#| "figure out how to open it."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:548
 msgid "An ancient gate... it seems the trolls were unable to open it."
-msgstr "嘿，看！这有一个古代的门。看来愚蠢的巨魔没有找到开启它的方法。"
+msgstr "一扇古老的门……看来巨魔没法开启它。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:560
-#, fuzzy
-#| msgid ""
-#| "Hey look, it’s an ancient door. It seems the trolls were too stupid to "
-#| "figure out how to open it."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:554
 msgid ""
 "Hey look, it’s an ancient gate. It seems the trolls were too stupid to "
 "figure out how to open it."
-msgstr "嘿，看！这有一个古代的门。看来愚蠢的巨魔没有找到开启它的方法。"
+msgstr "嘿，看！是一扇古老的门。看来巨魔们太蠢了，找不到开启它的方法。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:577
-#, fuzzy
-#| msgid ""
-#| "Hey look, it’s an ancient door. It seems the skeletons were too stupid to "
-#| "find out how to open it."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:571
 msgid "An ancient gate... it seems the skeletons did not bother opening it."
-msgstr "嘿，看！这有一个古代的门。看来愚蠢的骷髅没有找到开启它的方法。"
+msgstr "一扇古老的门……看来骷髅们都懒得打开它。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:583
-#, fuzzy
-#| msgid ""
-#| "Hey look, it’s an ancient door. It seems the skeletons were too stupid to "
-#| "find out how to open it."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:577
 msgid ""
 "Hey look, it’s an ancient gate. It seems the skeletons were too stupid to "
 "find out how to open it."
-msgstr "嘿，看！这有一个古代的门。看来愚蠢的骷髅没有找到开启它的方法。"
+msgstr "嘿，看！是一扇古老的门。看来骷髅们太蠢了，找不到开启它的方法。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:600
-#, fuzzy
-#| msgid "Well, let’s see what’s behind it."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:594
 msgid "Let’s see what lies behind it..."
-msgstr "好，让我们看看门后面有什么。"
+msgstr "我们来看看门后面有什么……"
+
+#. [message]: speaker=Tallin
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:599
+msgid "Ugh... It’s stuck. I’ll have to kick it down then."
+msgstr "呃……卡住了。那我只能把它踹开了。"
 
 #. [message]: speaker=Tallin
 #: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:605
-msgid "Ugh... It’s stuck. I’ll have to kick it down then."
-msgstr ""
-
-#. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:611
 msgid "Well, let’s see what’s behind it."
 msgstr "好，让我们看看门后面有什么。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:616
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:610
 msgid ""
 "All right. (<i>Grunt... strain...</i>) It’s not moving. It seems to be stuck."
 msgstr "好的。（<b>嘎吱……拉门的声音……</b>）拉不动，好像卡住了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:621
-#, fuzzy
-#| msgid "Well, just kick it down then."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:615
 msgid "Just kick it down then."
-msgstr "好吧，那就把它踢倒。"
+msgstr "那就踢倒它吧。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:626
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:620
 msgid "... Right."
 msgstr "……好的。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:663
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:657
 msgid "The old gate opens, revealing a narrow tunnel."
-msgstr ""
+msgstr "古旧的门打开了，露出一条狭窄的隧道。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:689
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:683
 msgid "Another gate... I guess I’ll kick it down like the other one."
-msgstr ""
+msgstr "又是一扇门……我想我只能像刚才那样把它踹开。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:695
-#, fuzzy
-#| msgid "On the end of the passage is another door. I try to open it."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:689
 msgid "On the end of the passage is another gate. I will try to open it."
 msgstr "在通路尽头是另一扇门。我试试看打开它。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:709
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:703
 msgid "Another one. I’ll kick this one down too."
-msgstr ""
+msgstr "又来了。我会把这扇也踹开。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:715
-#, fuzzy
-#| msgid "Here is a similar door as the one before. I try to open it."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:709
 msgid "Here is a similar gate to the one before. I will try to open it."
 msgstr "这里有一扇和之前的差不多的门。我试试看打开它。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:756
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:750
 msgid ""
 "Hmm... the wall here looks very thin and damaged. Let’s bring it down, it "
 "could offer us a faster way to navigate these caves."
 msgstr ""
+"嗯……这面墙看起来很薄，而且破损严重。我们把它推倒吧，这样或许能让我们在洞穴中"
+"穿行得更快捷。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:762
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:756
 msgid ""
 "Look, the wall here seems to be very thin and damaged. We might be able to "
 "bring it down."
-msgstr ""
+msgstr "看，这面墙看起来很薄，而且破损严重。我们或许能把它推倒。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:766
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:760
 msgid "Do it. It can give us a faster way to traverse through these caves."
-msgstr ""
+msgstr "动手吧。这样我们就能更快地穿过这些洞穴。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:786
-#, fuzzy
-#| msgid "A large section of wall crumbles away."
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:780
 msgid "A large section of the wall collapses."
-msgstr "墙裂开了一大块。"
+msgstr "墙倒塌了一大块。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:796
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:790
 msgid ""
 "Tallin, this situation is hopeless — there are endless monsters swarming "
 "from all directions!"
 msgstr "塔林，情况糟透了——无穷无尽的怪物正从四面八方涌来！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:801
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:795
 msgid ""
 "We are in a dire situation indeed — but just see — the trolls and the "
 "skeletons are also attacking each other. We must all stay together in one "
@@ -1118,7 +1090,7 @@ msgstr ""
 "因此惧怕，转而寻找更弱小的猎物。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:806
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:800
 msgid ""
 "But still, Tallin, we will take losses, and for each one of us, there is no "
 "replacement — whereas for every monster we kill, it seems that two more come "
@@ -1128,7 +1100,7 @@ msgstr ""
 "乎就会有两个怪物来代替它的位置！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:811
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:805
 msgid ""
 "Which is why we must make haste to find the dwarves. Dwarves are hardy "
 "creatures and they know their caves backwards and forwards — so I am sure at "
@@ -1141,24 +1113,24 @@ msgstr ""
 "是在地面上还是在这下面，我们怎么选都面临着毁灭的威胁！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:952
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:946
 msgid "Stand where ye be, you... Och! A human!"
 msgstr "不许动！你……哦！一个人类！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:957
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:951
 msgid "Greetings from the people of Dwarven Doors, friend."
 msgstr "朋友，矮人之门的人类向你们问候。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:962
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:956
 msgid ""
 "Dwarven Doors? I thought ye surface humans had been enslaved or slain by the "
 "orcs years ago."
 msgstr "矮人之门？我以为人类现在正被兽人奴役，或者多年前就被屠杀了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:967
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:961
 msgid ""
 "Yes, we were enslaved, but we rose against Al’Tar and defeated his warband. "
 "In order to stay free, we seek help and equipment from our old allies, the "
@@ -1168,7 +1140,7 @@ msgstr ""
 "卫自由，我们需要老朋友，矮人的帮助和装备。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:972
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:966
 msgid ""
 "Och, the dwarves of Knalga are themselves in desperate straits — but we "
 "havena’ forgotten the old bonds. Be welcome to our keep. Aye, and have "
@@ -1181,31 +1153,31 @@ msgstr ""
 #. [message]: speaker=unit
 #. [message]: speaker=Father Morvin
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:977
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1349
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2483
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2601
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2655
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2700
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:612
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:903
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:971
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1339
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2472
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2590
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2644
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2689
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:605
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:896
 msgid "Very well."
 msgstr "好的。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1003
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:997
 msgid "Well met, Tallin. My men have told me of your victory against Al’Tar."
 msgstr "很高兴见到你，塔林。我的人已经和我说了你战胜阿尔·塔的事。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1008
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1002
 msgid ""
 "Thank you and well-met indeed, Lord Hamel. I must say, this place is "
 "interesting."
 msgstr "谢谢，我也很高兴和你见面，哈梅尔领主。我得说，这地方很有趣。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1013
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1007
 msgid ""
 "This is how we get our food, me lad. Since we are a tad close to the surface "
 "here, some sunlight shines down through the cracks in the roof. If we baby "
@@ -1217,17 +1189,17 @@ msgstr ""
 "们就是靠着它们活了这么多年。来吧，我们谈谈！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1018
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1012
 msgid "Whew, we did it!"
 msgstr "哇！我们做到了！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1023
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1017
 msgid "Awww! Are we done already?"
 msgstr "哇哇！我们真的做到了？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1045
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1039
 msgid ""
 "Good, we managed to clear the caves... for now, anyway. Now let’s get to the "
 "dwarven keep and dicker for better weapons."
@@ -1236,7 +1208,7 @@ msgstr ""
 "从他们那里讨点好武器来。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1051
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1045
 msgid ""
 "Good, there are no more monsters lurking in these parts of the tunnels. I "
 "think I can hear the clamor of dwarves just ahead. Come on men, let’s go "
@@ -1246,62 +1218,62 @@ msgstr ""
 "我们去找他们吧。"
 
 #. [message]: role=Messenger
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1083
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1077
 msgid ""
 "Tallin, we have just received the news that the dwarvish Lord Hamel has just "
 "been slain. We are too late!"
 msgstr "塔林，我们刚刚得到消息，矮人的首领哈梅尔领主已经死了，我们来的太晚了！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1088
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1082
 #: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:62
 msgid "No! Without the dwarvish weapons we have no hope!"
 msgstr "不！没有矮人们的武器我们就没有希望！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1123
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1116
 msgid "Hey, what’s going on in here?"
 msgstr "嘿，这里发生了什么事？"
 
 #. [message]: role=Admirer
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1163
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1156
 msgid "We are killing lots of trolls and skeletons."
 msgstr "我们正在与巨魔和骷髅兵作战。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1168
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1161
 msgid "Really! Did you save any for me?"
 msgstr "真的？你们有给我留几个吗？"
 
 #. [message]: role=Admirer
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1173
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1166
 msgid "Uh, not really..."
 msgstr "哦，恐怕没有……"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1178
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1171
 msgid "Awww!"
 msgstr "嗷！"
 
 #. [message]: role=Admirer
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1183
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1176
 msgid ""
 "But hey, if you want to join us, I am sure we will be fighting a lot more "
 "orcs, trolls and skeletons in the near future."
 msgstr "不过，如果你加入我们，我保证我们不久要收拾更多的兽人，巨魔和骷髅兵。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1188
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1181
 msgid "Really! Oh yeah, I am in!"
 msgstr "真的！噢耶，我加入！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1193
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1186
 msgid "... That was rather odd. Who is this guy?"
 msgstr "……太奇怪了，这家伙是谁？"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1198
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1191
 msgid ""
 "Oh, dinna’ mind him, that’d be Camerin. He used to be yer usual scholarly "
 "mage, and he moved awa’ up here to be alone and study. But then when the "
@@ -1320,13 +1292,13 @@ msgstr ""
 "什么危害……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1218
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1211
 msgid ""
 "Without eating or sleeping for days, Tallin’s men begin to fall one by one."
 msgstr "好几日不吃不喝之后，塔林的士兵们一个接一个倒下了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1223
+#: data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg:1216
 msgid ""
 "We were too slow in finding the dwarves. I don’t think we can fight for much "
 "longer!"
@@ -1348,20 +1320,20 @@ msgstr ""
 "洞穴，开始了仓促的商讨。"
 
 #. [side]: type=Dwarvish Lord, id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:43
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:51
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:40
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:48
 msgid "Dwarves"
 msgstr "矮人"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:93
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:90
 msgid ""
 "Be welcome to the Southern Tunnels, friends... or at least, what’s left o’ "
 "them."
 msgstr "朋友们，欢迎你们来到南部隧道……或者说，至少是隧道剩下的部分。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:98
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:95
 msgid ""
 "Thank you, Lord Hamel. Though Knalga lies in chaos, it is a great relief to "
 "see that at least some dwarves have survived."
@@ -1369,12 +1341,12 @@ msgstr ""
 "谢谢，哈梅尔。纳尔迦仍陷在黑暗的深渊中，对于幸存的矮人来说这是个极大的伤痛。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:108
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:105
 msgid "And I, don’t forget me!"
 msgstr "还有我，别忘了我！"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:113
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:110
 msgid ""
 "Thank you, human. And you, Camerin. It is likewise a great relief to see "
 "that our allies of old have managed to break their bonds, and live as free "
@@ -1384,21 +1356,15 @@ msgstr ""
 "存，吾心甚慰。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:119
-#, fuzzy
-#| msgid ""
-#| "Thank you, human. And you, Camerin. It is likewise a great relief to see "
-#| "that our allies of old have managed to break their bonds, and live as "
-#| "free men once again."
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:116
 msgid ""
 "Thank you, human. It is likewise a great relief to see that our allies of "
 "old have managed to break their bonds, and live as free men once again."
 msgstr ""
-"谢谢，人类。还有你，卡梅林。我们旧时的盟友挣脱了枷锁，再一次作为自由人而生"
-"存，吾心甚慰。"
+"谢谢你们，人类。我们旧时的盟友挣脱了枷锁，再一次作为自由人而生存，吾心甚慰。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:126
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:123
 msgid ""
 "Yes, that touches on the main reason for our visit. We have broken free, but "
 "to stay free we need better weapons and armor. Clubs and pitchforks will not "
@@ -1408,14 +1374,14 @@ msgstr ""
 "易的自由。棍子和耙子不能给我们太多的帮助了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:131
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:128
 msgid ""
 "Dwarves are known to be the finest metalworkers and weapon-smiths. We were "
 "hoping that you would be able to help us."
 msgstr "矮人们是公认最好的冶炼工人和武器制造者。我希望你们能够帮助我们。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:136
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:133
 msgid ""
 "Aye, our craft is great... but we dinna’ ha’ much of weapons and armor "
 "ourselves. We’re but a remnant that survived the orcs’ in-taking of these "
@@ -1427,7 +1393,7 @@ msgstr ""
 "过。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:141
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:138
 msgid ""
 "If you don’t mind me asking, Lord Hamel, how exactly did you manage to "
 "survive the orcish invasion? And since it was the orcs who reduced Knalga to "
@@ -1439,7 +1405,7 @@ msgstr ""
 "没在这些洞穴里的大部分是巨魔和骷髅啊。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:146
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:143
 msgid ""
 "Oh, there are orcs enough down here, but ye’ll not likely see them; they "
 "hide from us like vermin. You see, lad, in these caves there is no more "
@@ -1459,7 +1425,7 @@ msgstr ""
 "的进攻已经变得毫无组织纪律，更别说他们相互之间似乎也在争斗着。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:151
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:148
 msgid ""
 "In more recent years, however, I ha’ noticed that there have been fewer orcs "
 "and more skeletons around. The orcs seem to fear them and shy away from them "
@@ -1472,7 +1438,7 @@ msgstr ""
 "个粉碎，然后吸取骷髅骨头里残存的骨髓。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:156
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:153
 msgid ""
 "What is the story with those skeletons anyway? They look like they were "
 "dwarves when they lived, but now they just seem to be mindless killers."
@@ -1480,7 +1446,7 @@ msgstr ""
 "那些骷髅是怎样一回事？看起来他们生前是矮人，但现在他们是毫无心智的杀手。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:161
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:158
 msgid ""
 "In truth, we ha’ no idea. They just started appearing one day. They came by "
 "ones and twos in the beginning, and now by the hordes. We were fair "
@@ -1495,7 +1461,7 @@ msgstr ""
 "见过更难对付的敌人。真正让人担忧的，是他们不断增长的数量……"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:166
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:163
 msgid ""
 "Well, we are here with you now Lord Hamel, and in exchange for proper "
 "weapons, we will gladly assist you in clearing these caves of monsters."
@@ -1504,7 +1470,7 @@ msgstr ""
 "这些怪物。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:171
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:168
 msgid ""
 "That is the problem lad, we ha’ been stranded in these tunnels for years "
 "now, almost completely cut off from sources of food or metals or tools. It "
@@ -1520,12 +1486,12 @@ msgstr ""
 "现在可以了。所以当前最紧缺的是金属。而为了熔炼，矿石是首先必须有的。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:176
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:173
 msgid "So, is there not any source of good ores nearby?"
 msgstr "那么，附近有好的矿场吗？"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:181
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:178
 msgid ""
 "Aye, there is. A few miles north of here is the place where we mined many of "
 "our raw metals. However, that place also seems to be where all those "
@@ -1537,7 +1503,7 @@ msgstr ""
 "全部力量也只够守住我们自己的阵地，到那里去是必死无疑。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:186
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:183
 msgid ""
 "With all respect, my Lord Hamel, we the people from Dwarven Doors have faced "
 "certain death many times now. Rising up against the orcs was said to be "
@@ -1550,7 +1516,7 @@ msgstr ""
 "活着，我就会领导我的人民为自由而战！"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:191
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:188
 msgid ""
 "Och, human though ye be, ye speak very like a dwarf, lad. Form up, men! To "
 "the mines! Let the guardsmen stay behind along with the noncombatants — for "
@@ -1560,12 +1526,12 @@ msgstr ""
 "兵就留下来和平民呆在一起，保护他们的安全并守卫要塞。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:201
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:198
 msgid "Ahahahaha! Yes, smash the skeletons! Smash them!"
 msgstr "啊哈哈哈哈！是的，砸碎那些骷髅！砸碎它们！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:206
+#: data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg:203
 msgid "..."
 msgstr "……"
 
@@ -1586,66 +1552,66 @@ msgstr ""
 "是，离开洞穴后，他们又面临着新的威胁。"
 
 #. [side]: type=Direwolf Rider, id=Pruol
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:70
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:67
 msgid "Goblins"
 msgstr "地精"
 
 #. [side]: type=Direwolf Rider, id=Pruol
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:75
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:72
 msgid "Pruol"
 msgstr "普如尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:97
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:94
 msgid "Enter the mines"
 msgstr "进入矿脉"
 
 #. [objectives]
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:100
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:97
 msgid "Eliminate the wolf riders"
 msgstr "消灭狼骑兵"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:106
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:203
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:103
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:200
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:578
 msgid "Death of Hamel"
 msgstr "哈梅尔死亡"
 
 #. [message]: speaker=Pruol
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:124
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:121
 msgid "Hey look, there is our meat! Come on, boys, lunchtime!"
 msgstr "嘿，看，来了一群走肉！快来，孩子们，午饭来了！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:129
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:126
 msgid "I don’t think so, buddy."
 msgstr "别高兴的太早，伙计。"
 
 #. [message]: speaker=Pruol
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:143
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:140
 msgid "Argh! They are stronger than we thought. Someone go tell the Master..."
 msgstr "啊！他们比我们预想的强。快去报告主人……"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:148
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:145
 msgid "What’s with this ‘Master’ business? It’s starting to make me nervous."
 msgstr "这“主人”是什么来头？我开始有点紧张了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:175
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:172
 msgid "Here is the entrance to the dwarven mines. In we go!"
 msgstr "这是进入矮人矿脉的入口。我们走！"
 
 #. [message]: speaker=Pruol
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:180
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:177
 msgid ""
 "Hey, there goes our lunch! Hmmm, they are stronger than we thought, let’s go "
 "tell Master."
 msgstr "嘿，我们的午餐跑了！唔，他们比我们预想的强，快去报告主人。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:185
+#: data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg:182
 msgid ""
 "What’s with this whole ‘Master’ business? It’s starting to make me nervous."
 msgstr "这“主人”是什么来头？我开始有点紧张了。"
@@ -1664,17 +1630,17 @@ msgstr "当队伍终于进入矿脉之时，他们并没有失望。"
 #. [side]: type=Elvish Avenger, gender=female, id=Sisal
 #. [side]: type=Lieutenant, id=Tallin
 #. [side]: type=Dwarvish Lord, id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:29
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:32
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:162
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:269
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:284
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:38
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:145
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:121
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:135
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:265
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:282
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:28
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:31
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:159
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:264
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:279
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:36
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:141
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:119
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:131
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:261
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:278
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:52
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:297
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:320
@@ -1684,47 +1650,47 @@ msgid "Alliance"
 msgstr "联盟"
 
 #. [side]: type=Ancient Lich, id=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:49
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:53
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:46
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:50
 msgid "Malifor"
 msgstr "玛利弗"
 
 #. [side]: type=Draug, id=Thorin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:75
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:72
 msgid "Thorin"
 msgstr "索林"
 
 #. [side]: type=Draug, id=Herlin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:99
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:96
 msgid "Herlin"
 msgstr "和林"
 
 #. [side]: type=Draug, id=Fervin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:124
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:121
 msgid "Fervin"
 msgstr "弗林"
 
 #. [side]: type=Draug, id=Hellian
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:139
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:136
 msgid "Hellian"
 msgstr "黑连"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:195
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:373
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:380
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:202
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:192
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:368
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:375
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:198
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:562
 msgid "Defeat the enemy leaders"
 msgstr "打败众敌将"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:223
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:220
 msgid "Behold! The Dwarven Mines."
 msgstr "看吧！矮人矿脉。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:228
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:225
 msgid ""
 "Look at yon canal. Dwarves built it to transport mined metals deeper into "
 "Knalga. And d’ye ken those two rooms, one to the north-west and the other to "
@@ -1736,14 +1702,14 @@ msgstr ""
 "优势。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:233
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:230
 msgid ""
 "Grim gods of darkness! The whole place is swarming with undead! They have "
 "raised corpses to do their work."
 msgstr "可怕的黑暗！整个地区充满了不死族的战士！他们召唤战死的人为他们战斗。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:238
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:235
 msgid ""
 "And they seem to have good security, too. Look, most of the fortifications "
 "are repaired and they have those nasty skeletons everywhere."
@@ -1752,49 +1718,49 @@ msgstr ""
 "心的骷髅兵。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:243
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:240
 msgid ""
 "Fortunately, this entrance seems to be in disrepair. It doesn’t look like "
 "they have noticed us yet."
 msgstr "幸好这个入口没被修理过。他们好像还没有注意到我们。"
 
 #. [message]: speaker=Thorin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:248
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:245
 msgid "WHO GOES THERE?"
 msgstr "来这的是谁？"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:253
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:250
 msgid "(<i>Wince</i>)."
 msgstr "（<b>抽搐了一下</b>）。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:258
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:255
 msgid "Oops, I spoke too soon."
 msgstr "噢，说来就来。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:264
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:261
 msgid "Maybe he needs a fireball..."
 msgstr "也许他们需要火球……"
 
 #. [message]: speaker=Thorin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:269
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:266
 msgid "YOU DO NOT ANSWER. ALERT THE MASTER!"
 msgstr "谁要你回答。小心点！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:286
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:283
 msgid "Who goes there? Ahhh, more slaves, I see."
 msgstr "来这的是谁？哈哈，在我看来，是很多奴隶。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:291
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:288
 msgid "Others have made that mistake before. Who are you?"
 msgstr "以前就有人和你有一样的错误看法。你是谁？"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:296
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:293
 msgid ""
 "Who am I? (<i>Cackles wildly</i>) I am Malifor the Great, the master of "
 "death! These tunnels, haunted by the ghosts of the dead dwarves of Knalga, "
@@ -1804,13 +1770,13 @@ msgstr ""
 "死去的纳尔迦矮人的鬼魂，他们都被我的力量控制。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:301
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:298
 msgid ""
 "You dared disturb the rest of those brave dwarves? You shall pay in blood!"
 msgstr "你敢向勇敢的矮人战士挑战吗？你会死无全尸！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:306
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:303
 msgid ""
 "HAHAHAHA! Your petty temper tantrums are most amusing, you puny dwarf. Soon "
 "I will finish the slaughter that the orcs have begun so promisingly, and "
@@ -1821,28 +1787,28 @@ msgstr ""
 "兽人一样。整个纳尔迦都是我的！从这我将横扫整个北方的生灵，并且攻占整个韦诺！"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:311
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:308
 msgid ""
 "Quit your ranting, you wretched bag of bones! Prepare to return to the dust!"
 msgstr "停止妄想吧，你只是一包枯骨！我会把你打成粉末！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:316
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:313
 msgid "HAHAHAHA! Such vast threats from one so small? HAHAHA!"
 msgstr "哈哈哈哈！明明是个小不点，还敢口出狂言？哈哈哈哈！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:321
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:318
 msgid "But– My my, what do we have here? — Tallin."
 msgstr "等一下——天呐，看看谁在这里？——塔林。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:326
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:323
 msgid "He knows your name, Tallin. I don’t like the sound of this."
 msgstr "他知道你的名字，塔林。这可不是个好兆头。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:331
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:328
 msgid ""
 "Oh yes, I know you, Tallin. I have been watching you for a long time. You "
 "are a perfect candidate to become one of my immortal generals."
@@ -1850,12 +1816,12 @@ msgstr ""
 "是的，我知道你，塔林。我找你很久了。你是作为我的不死族将军的最佳候选人。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:336
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:333
 msgid "...!"
 msgstr "……！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:341
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:338
 msgid ""
 "Look around you, Tallin; see all the power, see all of the wealth, the "
 "glory, the pleasure that the realm of death has to offer. Think of the great "
@@ -1865,12 +1831,12 @@ msgstr ""
 "荣誉和快乐。想想伟大的纳尔迦帝国，这些都可以是你的。来吧，和我分享这一切！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:346
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:343
 msgid "Tallin! Get hold of yourself!"
 msgstr "塔林！把持住自己！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:351
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:348
 msgid ""
 "It’s very easy, Tallin... See that little vermin by your side? Take out your "
 "knife... cut his throat... feel his hot blood pump over your hands... "
@@ -1880,7 +1846,7 @@ msgstr ""
 "温热的鲜血流过你的双手……杀了他！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:356
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:353
 msgid ""
 "(<i>Shakes head</i>) I reject your evil. Attack, men! Let us rid the good "
 "green world of this rotting filth!"
@@ -1889,23 +1855,23 @@ msgstr ""
 "腐坏的脏东西吧！"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:361
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:358
 msgid ""
 "Aye! That’s the way of it, lad! For the murdered dwarves of Knalga! Attack!"
 msgstr "没错！做的对，年轻人！为了被谋杀的纳尔迦矮人！进攻！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:366
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:363
 msgid "You fool! You will pay for your folly with your life."
 msgstr "傻瓜！你会为你的愚蠢付出生命代价的。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:371
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:368
 msgid "Yeah, right, buddy."
 msgstr "是的，说的没错，伙计。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:381
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:378
 msgid ""
 "These little vermin are making progress! This is unacceptable. Rise, my "
 "minions — gorge on the flesh of these scurrying little rats!"
@@ -1914,7 +1880,7 @@ msgstr ""
 "小老鼠的鲜肉吞噬吧！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:395
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:392
 msgid ""
 "Look out everyone, something is coming out of the canals! Already the water "
 "is churning and clogging with their filth. Get back and brace yourselves."
@@ -1922,17 +1888,17 @@ msgstr ""
 "各位小心，沟渠里流出些东西！这污物已经搅动并阻塞了水流。退后，做好准备。"
 
 #. [message]: type=Necrophage
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:424
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:421
 msgid "<i>Fooood</i>!"
 msgstr "<b>食——物——</b>！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:429
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:426
 msgid "Lords of Light, what kind of vile creation are those things!"
 msgstr "光明之神啊，这些邪恶的东西是什么！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:439
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:436
 msgid ""
 "Out of all of a necromancer’s creations, I must say those things are the "
 "most tortured and vile. They have an insatiable hunger for flesh and "
@@ -1944,7 +1910,7 @@ msgstr ""
 "会变小一些。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:444
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:441
 msgid ""
 "Oh, and try to stay away from their claws. If you get even one scratch, and "
 "don’t get it treated quickly, you will soon find yourself weak, sick and "
@@ -1954,7 +1920,7 @@ msgstr ""
 "生病、无法再战斗了。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:449
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:446
 msgid ""
 "Bah! They look like fat slugs to me. Come on boys, let’s chop them to pieces "
 "before they can leave the canal!"
@@ -1963,7 +1929,7 @@ msgstr ""
 "成碎片！"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:455
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:452
 msgid ""
 "Ghouls! They have an insatiable hunger for flesh. One scratch from their "
 "claws will weaken you with sickness and disease. Nasty things; let’s chop "
@@ -1973,7 +1939,7 @@ msgstr ""
 "弱无力。实在是恶心的东西。在它们离开运河之前，我们把它们砍成碎片吧。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:470
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:467
 msgid ""
 "HAHAHA, you puny weaklings think you can destroy me? <i>Fools</i>! You will "
 "all soon be serving me!"
@@ -1981,12 +1947,12 @@ msgstr ""
 "哈哈哈，你们这些卑微的弱者还想打败我？<b>蠢货</b>！你们很快就会是我的奴隶了！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:486
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:483
 msgid "Oh no, he just... disappeared."
 msgstr "噢不，他……消失了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:496
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:493
 msgid ""
 "We have finally secured the mines. But what should we do about that foul "
 "lich? He is a menace to all that lives, and must be ended."
@@ -1995,7 +1961,7 @@ msgstr ""
 "必须消灭他。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:502
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:498
 msgid ""
 "Aye! We’ll have to lay both his skeletons and himself to final rest before "
 "these caves will be fit for dwarvenkind again."
@@ -2003,14 +1969,14 @@ msgstr ""
 "是的！要让这些洞穴再次成为适合矮人族的地方，我们必须把他和他的骷髅兵清理完。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:507
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:503
 msgid ""
 "But I’m sore vexed. We need better weapons. Luck and spirit can carry us "
 "only so far."
 msgstr "但是我很担心，我们需要更好的武器。我们不能一直光凭着好运和意志作战。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:512
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:508
 msgid ""
 "Aye. We must do both. I’m thinking it might be best if I muster my folk to "
 "start on the weapon-making while you and your followers pursue yon lich. By "
@@ -2022,12 +1988,12 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:517
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:513
 msgid "So it shall be."
 msgstr "就这样吧。"
 
 #. [message]: role=follower
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:527
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:523
 msgid ""
 "With all respect, Lord Hamel, some o’ us would like to fare forth with "
 "Tallin. He’s lucky, he is — or he makes his own luck."
@@ -2036,13 +2002,13 @@ msgstr ""
 "他在创造他自己的好运气。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:532
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:528
 msgid ""
 "And so it shall be. You’ve my leave and welcome. Try to keep the lad safe..."
 msgstr "好的。你们可以随时离开，也欢迎回来。保护好那个年轻人……"
 
 #. [message]: role=follower
-#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:537
+#: data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg:533
 msgid "Thank you, Lord Hamel."
 msgstr "谢谢，哈梅尔领主。"
 
@@ -2059,79 +2025,79 @@ msgid ""
 msgstr "塔林和他的队伍把大多数矮人落下，出发前去追击玛利弗。"
 
 #. [side]: type=Death Knight, id=Hettel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:114
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:111
 msgid "Hettel"
 msgstr "黑特尔"
 
 #. [side]: type=Death Knight, id=Tervor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:136
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:133
 msgid "Tervor"
 msgstr "特沃"
 
 #. [side]: type=Death Knight, id=Author
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:160
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:157
 msgid "Author"
 msgstr "奥瑟"
 
 #. [side]: type=Death Knight, id=Boblin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:193
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:190
 msgid "Boblin"
 msgstr "保博林"
 
 #. [side]: type=Death Knight, id=Antrasis
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:214
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:211
 msgid "Antrasis"
 msgstr "安崔斯"
 
 #. [side]
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:233
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:230
 msgid "Monsters"
 msgstr "怪兽"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:317
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:314
 msgid "Get past the Revenants."
 msgstr "摆脱亡魂。"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:324
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:321
 msgid "Find Malifor and destroy him"
 msgstr "找到玛利弗并消灭他"
 
 #. [note]
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:341
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:338
 msgid "Be sure to explore"
 msgstr "确保你探索了"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:388
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:385
 msgid "There he goes! Quick, get him!"
 msgstr "他从这逃了！快追，抓住他！"
 
 #. [message]: role=starting_speaker
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:393
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:390
 msgid "I don’t think so, you living vermin."
 msgstr "你们是不可能追上来的，活着的臭虫。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:398
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:395
 msgid ""
 "We’ll have to kill these revenants to get after him. There are only two of "
 "them. This shouldn’t last long."
 msgstr "要赶上他，我们必须杀掉这些亡魂。他们只有两个。这应该不需要多久。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:415
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:412
 msgid "Uh... Which way?"
 msgstr "嗯……该走哪条路？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:420
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:417
 msgid "Blast it! We lost him."
 msgstr "该死！我们跟丢了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:425
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:422
 msgid ""
 "It makes no difference in the end, because we will hunt him down and crush "
 "him to powder. HEAR THAT, YOU OLD SKELETON?"
@@ -2140,49 +2106,49 @@ msgstr ""
 "——？"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:430
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:427
 msgid "(<i>Faint cackle of laughter in the distance</i>)"
 msgstr "（<b>远方传来模糊的笑声</b>）"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:436
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:433
 msgid "Yeah! This is gonna be fun!"
 msgstr "啊！越来越有趣了！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:441
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:438
 msgid ""
 "Let us proceed with caution. Nobody is to go off by himself. We don’t know "
 "what could be lurking in these tunnels."
 msgstr "我们要小心前行，大家不要单独行动。我们不知道在隧道的前方潜伏着什么。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:471
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:468
 msgid "The Dungeon"
 msgstr "地牢"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:476
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:473
 msgid "Those poor wretches!"
 msgstr "那些可恶的巫师！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:481
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:478
 msgid "We won’t leave them in Malifor’s chains!"
 msgstr "我们不会把他们留在玛利弗的锁链之中！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:500
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:497
 msgid "Intruders! Stop them before they free the prisoners!"
 msgstr "入侵者！在他们释放囚犯之前阻止他们！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:505
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:502
 msgid "Good luck with that."
 msgstr "祝你好运。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:538
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:534
 msgid ""
 "Finally! I am free. Lord Tallin, I am forever in your debt! We will follow "
 "you to the end of the world if need be."
@@ -2191,45 +2157,45 @@ msgstr ""
 "会跟随您到天涯海角。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:543
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:539
 msgid "It’s just ‘Tallin’, no ‘Lord’. And no problem."
 msgstr "我只是“塔林”，不是什么“领主”。不客气。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:555
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:670
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:550
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:664
 msgid "Morvin!"
 msgstr "莫文！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:560
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:675
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:555
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:669
 msgid "Thera!"
 msgstr "席拉！"
 
 #. [message]: speaker=Tallin
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:571
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:577
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:566
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:572
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:679
 #: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:685
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:691
 msgid "Please, folks, not now."
 msgstr "拜托，二位，现在可不是时候。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:584
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:697
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:579
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:691
 msgid "Oh, sorry."
 msgstr "噢，对不起。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:591
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:703
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:586
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:697
 msgid "Who are you? How did you end up down here?"
 msgstr "你是谁？为什么被关在这？"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:596
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:591
 msgid ""
 "My name is Morvin. My wife, Thera and I were advisers and healers for the "
 "dwarvish nobles. We could not shield them from the wrath of Khazg Black-"
@@ -2240,14 +2206,14 @@ msgstr ""
 "中保护他们，但我们自己躲过了兽人和巨魔的追击——不料被这些骷髅兵抓住了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:601
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:596
 msgid ""
 "Funny, why would the bonebag keep you as his prisoners? He doesn’t really "
 "seem to be the merciful type."
 msgstr "有意思，为什么那骨头架子只是把你们关起来？他看起来可不像是善良之辈。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:606
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:601
 msgid ""
 "He didn’t keep us alive out of mercy, he wanted to study us to see if there "
 "was a way to counteract our arcane attacks. His kind are very vulnerable to "
@@ -2257,8 +2223,8 @@ msgstr ""
 "这类攻击面前很脆弱。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:611
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:723
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:606
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:717
 msgid ""
 "Indeed, that is good to know. But you are now free to go wherever you like. "
 "May the Lords of Light guide your path."
@@ -2266,7 +2232,7 @@ msgstr ""
 "确实，这是个好消息。现在你自由了，想去哪里都可以。愿光明之神指引你前进。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:616
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:611
 msgid ""
 "As I have said, Tallin, I am eternally in your debt, and I take my debts "
 "seriously. If you have no objection, I will serve you until one of us "
@@ -2276,7 +2242,7 @@ msgstr ""
 "追随你直至生命终结。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:621
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:616
 msgid ""
 "Oh, think nothing of it. Let no talk of debts come between us; rather let us "
 "join hands as allies in restoring these Northlands to sanity."
@@ -2286,19 +2252,19 @@ msgstr ""
 #. [message]: speaker=Father Morvin
 #. [message]: speaker=Sister Thera
 #. [message]: id=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:626
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:738
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:621
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:732
 #: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:275
 msgid "Thank you, Tallin."
 msgstr "谢谢你，塔林。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:655
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:649
 msgid "Freedom at last! Thank you, Lord Tallin."
 msgstr "自由了！谢谢您塔林领主。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:660
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:654
 msgid ""
 "Just ‘Tallin’. I am no Lord, just a humble peasant trying to restore our "
 "people to freedom."
@@ -2306,7 +2272,7 @@ msgstr ""
 "我是“塔林”，不是什么“领主”。我只是一个想要为我们的人民争取自由的普通农民。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:708
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:702
 msgid ""
 "My name is Thera. My husband Morvin and I were advisers and healers for the "
 "dwarvish nobles of Knalga. We could not save them from Khazg Black-Tusk’s "
@@ -2318,14 +2284,14 @@ msgstr ""
 "还是被抓住了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:713
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:707
 msgid ""
 "Funny, why would the bonebag keep you as his prisoners? He didn’t seem to be "
 "the merciful type."
 msgstr "有意思，为什么那骨头架子只是把你们关起来？他看起来可不像是善良之辈。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:718
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:712
 msgid ""
 "He didn’t keep us alive out of mercy, he wanted to study us to see if there "
 "was a way to counteract our arcane attacks. His kind are very vulnerable to "
@@ -2335,7 +2301,7 @@ msgstr ""
 "这类攻击面前很脆弱，我想你现在应该已经知道这一点了。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:728
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:722
 msgid ""
 "If you have no objection, Tallin, we would like to join you. These "
 "Northlands are hardly safe these days for anyone to be traveling on their "
@@ -2345,17 +2311,17 @@ msgstr ""
 "全的，而且我们会给你们的大业带来很多帮助。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:733
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:727
 msgid "Very well, you are most welcome to join us."
 msgstr "太好了。欢迎你们加入。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:751
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:745
 msgid "Look at this. There’s some sort of opening in the wall..."
 msgstr "看看这个。墙上有个洞口之类的东西……"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:756
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:750
 msgid ""
 "It was there when I was thrown down here. The hole wasn’t big enough for me "
 "to go through, but perhaps one of you might enlarge it?"
@@ -2364,17 +2330,17 @@ msgstr ""
 "中有谁可以把它扩大？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:761
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:755
 msgid "Hmmm, let’s see..."
 msgstr "呣，我来试试……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:793
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:787
 msgid "There we go. Now let’s see where this tunnel leads."
 msgstr "好嘞。让我们看看这隧道通向哪里。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:806
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:800
 msgid ""
 "Wow! That’s incredible. Now I understand why the bag of bones kept you in "
 "jail; he just simply couldn’t kill you!"
@@ -2383,47 +2349,47 @@ msgstr ""
 "杀死你们！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:811
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:275
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:805
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:272
 msgid "(<i>Giggle</i>)"
 msgstr "（<b>呵呵呵</b>）"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:842
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:835
 msgid "Tallin, look! Oh, she’s not in good shape..."
 msgstr "塔林，看！她看起来不太妙……"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:854
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:847
 msgid "Here, let me see her."
 msgstr "来，让我看看。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:868
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:861
 msgid "This should help."
 msgstr "这应该有用。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:889
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:934
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:882
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:927
 msgid "Uh... where... am... I...?"
 msgstr "呃……我……在……哪……？"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:894
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:887
 msgid ""
 "You are in the dungeons of Malifor. These brave people have just released "
 "you."
 msgstr "你在玛利弗的地牢里，这些勇敢的人们刚解救了你。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:899
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:944
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:892
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:937
 msgid "... Thanks."
 msgstr "……谢谢。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:904
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:897
 msgid ""
 "No problem. Sister Thera, you take care of her. If she wants to join us she "
 "would make a powerful ally."
@@ -2432,13 +2398,13 @@ msgstr ""
 "友。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:909
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:954
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:902
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:947
 msgid "Yes, I would... like to join you... Lord Tallin."
 msgstr "是的，我愿意……加入你们……塔林领主。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:914
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:907
 msgid ""
 "Just Tallin; I am no lord. But gee, that sure is some powerful spell you "
 "used on her, Thera. She’s looking better already."
@@ -2447,228 +2413,220 @@ msgstr ""
 "来已经好多了。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:919
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:912
 msgid "And I feel better too. Now where’s that disgusting skeleton?"
 msgstr "我的确感觉好多了。现在那些恶心的骷髅在哪里？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:925
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:918
 msgid "I wish we had some healers with us; I’ll try to help her as best I can."
 msgstr "我真希望我们有些疗伤师在身边；我会尽力帮助她的。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:939
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:932
 msgid "You are in the dungeons of Malifor. We have just released you."
 msgstr "你在玛利弗的地牢里，我们救了你。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:949
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:942
 msgid ""
 "No problem. Just take it easy. If you would like to join us your help could "
 "mean life or death for a lot of us."
 msgstr "没问题。放心。假如你们愿意加入我们，你们的帮助将影响我们很多人的生命。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:959
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:952
 msgid "Just Tallin, I am no lord. And you are looking better already."
 msgstr "我只是塔林，不是什么领主。你现在看起来好多了。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:981
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:974
 msgid ""
 "Oh, just a few tricks I know, otherwise I probably would be dead by now. Now "
 "where’s that disgusting skeleton?"
 msgstr "哦，之前我是装的，不然我可能已经死掉了。现在那些恶心的骷髅在哪里？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:988
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:981
 msgid "Why did the bag of bones capture you in the first place?"
 msgstr "为什么骷髅兵把你也抓进这种地方？"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:993
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:986
 msgid "Because he thought I was pretty."
 msgstr "他被我的美貌吸引。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:999
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:991
 msgid "That old skeleton? Geez, what a nutcase."
 msgstr "那个老骷髅？哦，真是疯了。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1004
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:996
 msgid "You’re telling me."
 msgstr "谁说不是呢。"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1038
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1029
 msgid "Be careful companions! There was a drake in this cage!"
-msgstr ""
+msgstr "小心，伙伴们！笼子里有个龙人！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1044
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1035
 msgid "Holy cow! What did I just let out of that cage? Look out everyone!"
 msgstr "我的天呐！我刚刚把什么东西放出来了？大家小心！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1051
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1042
 msgid "Oooooh, cool, it’s a drake!"
 msgstr "喔呜，好酷啊，一个龙人！"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1056
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1047
 msgid "(<i>Whimper</i>)"
 msgstr "（<b>呜咽</b>）"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1061
-#, fuzzy
-#| msgid ""
-#| "Bright Gods, such a fierce creature whimpering! What the heck have they "
-#| "done to it?"
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1052
 msgid ""
 "Bright Gods, such a fierce creature whimpering! What in the world have they "
 "done to it?"
 msgstr "我的老天爷啊，如此凶猛的生物竟在呜咽！他们究竟对它做了什么？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1066
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1057
 msgid "The bastards!"
 msgstr "该死的混蛋！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1077
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1068
 msgid "Probably another one of Malifor’s experiments."
 msgstr "它可能是玛利弗的另一个实验品。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1082
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1073
 msgid "I don’t know, see if it talks."
 msgstr "也许吧，看看它能说话不。"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1095
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1086
 msgid "Have no fear, drake. We have no intentions to hurt you."
-msgstr ""
+msgstr "别害怕，龙人。我们不想伤害你。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1101
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1092
 msgid "Hey, big guy. We aren’t gonna hurt you. We wanna be your friends."
 msgstr "嘿，大家伙。我们不想伤害你，我们是你的朋友。"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1108
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1099
 msgid "... Not... going... to... hurt... me?"
 msgstr "……不……会……伤……害……我？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1113
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1104
 msgid "Hey, it talks!"
 msgstr "嘿，它开口了！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1118
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1109
 msgid "It’s a ‘he’, and yes, they’re actually very intelligent creatures."
 msgstr "应该是“他”。没错，他们其实是非常有智慧的生物。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1123
-#, fuzzy
-#| msgid ""
-#| "Hush, I am trying to talk to him. Nope, we’ll never hurt you. But if you "
-#| "want to you can hurt some skeletons."
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1114
 msgid ""
 "Hush, I am trying to talk to him. Nope, we’ll never hurt you. But if you "
 "want to, you can hurt some skeletons."
 msgstr ""
-"嘘，我要和他谈谈。当然不会，我们绝不会攻击你。如果你愿意，你可以去攻击那些骷"
-"髅兵。"
+"嘘，我要和他谈谈。当然不会，我们绝不会伤害你。如果你愿意，你可以去伤害些骷"
+"髅。"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1128
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1119
 msgid "Skeletons! GRRRR!!"
 msgstr "骷髅兵！啊啊啊啊！！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1133
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1124
 msgid "Look out! He is ready to go! Hey, is that smoke coming out of his ears?"
 msgstr "小心！他要走了！嘿，那烟是从他的耳朵里冒出来的吗？"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1147
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1138
 msgid "ROOOAARR!"
 msgstr "吼吼吼！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1152
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1143
 msgid ""
 "Whoa! Maybe he isn’t so friendly after all... or at least to some things."
 msgstr "哇！他好像并不怎么友好……也许他只是不喜欢某些东西。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1168
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1159
 msgid "(<i>Sigh</i>) There doesn’t seem to be anything down this tunnel."
 msgstr "（<b>叹气</b>）看来这个隧道里什么也没有。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1192
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1183
 msgid "The Treasury"
 msgstr "金库"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1197
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1188
 msgid "The Treasury! Excellent, let’s clean out the gold!"
 msgstr "金库！太好了，我们去把金币拿空吧！"
 
 #. [message]: role=Treasury Guard
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1230
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1221
 msgid "Intruders! Get them!"
 msgstr "入侵者！抓住他们！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1235
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1226
 msgid "Bring it on!"
 msgstr "来吧！"
 
 #. [scenario]: id=05a_01_The_Pursuit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1280
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1271
 msgid "There are at least several hundred gold coins in here!"
 msgstr "这里至少有几百枚金币！"
 
 #. [scenario]: id=05a_01_The_Pursuit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1282
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1273
 msgid "I don’t think the undead will be be needing this anyway."
 msgstr "反正我可不觉得亡灵会需要这些。"
 
 #. [scenario]: id=05a_01_The_Pursuit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1284
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1275
 msgid ""
 "Our people could rebuild their lives ten-fold with the gold in this treasury."
 msgstr "靠着这宝库里的金币，我们的人民可以重建人生，让自己的生活更美好十倍。"
 
 #. [scenario]: id=05a_01_The_Pursuit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1286
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1277
 msgid "We’re rich!"
 msgstr "我们发财了！"
 
 #. [scenario]: id=05a_01_The_Pursuit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1288
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1279
 msgid "Why do these skeletons have so much gold just sitting around?"
 msgstr "这些骨头架子为什么会有这么一大堆金币躺在这儿？"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1314
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1304
 msgid ""
 "The Rod of Justice! What in the world is it doing all the way down here?"
 msgstr "公正之杖！它怎么会在这里？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1319
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1309
 msgid "What do you have there, Abhai?"
 msgstr "什么东西，安彼海？"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1324
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1314
 msgid ""
 "This is the Great Rod of Justice, my boy. It was an ancient artifact even "
 "when I was young. They say it was crafted by the Great Gods themselves, and "
@@ -2683,7 +2641,7 @@ msgstr ""
 "中充满公正，恶魔和战争也没有侵袭大地。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1329
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1319
 msgid ""
 "Well, if you don’t mind me saying — that certainly isn’t the state of "
 "affairs now. Knalga lies in ruins, orcs ravage the surface, and these dark "
@@ -2698,7 +2656,7 @@ msgstr ""
 "权杖的徒劳搜寻中死亡了。"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1334
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1324
 msgid ""
 "Ahh, with the Rod of Justice down here it is to be expected. Come Tallin, "
 "either you or one of your trusted men must wield this staff and bring peace "
@@ -2708,12 +2666,12 @@ msgstr ""
 "回这个世界。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1339
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1329
 msgid "Why can’t you wield it, Abhai?"
 msgstr "难道你不能用它吗，安彼海？"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1344
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1334
 msgid ""
 "I am a creature of the past, and thus my time to wield it is long gone. This "
 "is your era, Tallin, and thus it is your responsibility to see to it that "
@@ -2724,7 +2682,7 @@ msgstr ""
 "你的责任。快来，或者派一个人，时间紧迫。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1373
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1363
 msgid ""
 "An elegantly carved sceptre rests at the bottom of the chest. Precious "
 "jewels glitter across its surface, and it exudes a great aura of power."
@@ -2733,29 +2691,29 @@ msgstr ""
 "从中发散。"
 
 #. [option]
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1375
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1365
 msgid "rod of justice^Take it"
 msgstr "拿起"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1379
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1369
 msgid ""
 "This thing is... incredible! What is such a powerful artifact doing hidden "
 "all the way back here?"
 msgstr "这东西真是……不可思议！这么一件强大的魔法物品为什么会藏在这种地方？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1389
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1379
 msgid "That’s... that’s the Rod of Justice!"
 msgstr "这就是……这就是公正之杖！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1394
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1384
 msgid "Do you know anything about it, Camerin?"
 msgstr "你知道关于它的情况吗，卡梅林？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1399
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1389
 msgid ""
 "I don’t think there is a person alive who knows anything more solid than "
 "rumors and legends. There are very few people who even knows it exists!"
@@ -2764,19 +2722,19 @@ msgstr ""
 "它的存在！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1404
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1394
 msgid "How did you come to know of it?"
 msgstr "那你是怎样知道的？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1409
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1399
 msgid ""
 "Some of the most ancient elvish legends make some vague mention of this "
 "artifact. But beyond that..."
 msgstr "一些精灵的古书中模糊的记载了这些……"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1414
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1404
 msgid ""
 "Interesting. I wonder who — or what — could have created such a powerful "
 "artifact. There must be one heck of a story behind this thing."
@@ -2785,12 +2743,12 @@ msgstr ""
 "定一大堆故事。"
 
 #. [object]: id=justice_rod
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1427
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1417
 msgid "Rod of Justice"
 msgstr "公正之杖"
 
 #. [object]: id=justice_rod
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1430
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1420
 msgid ""
 "A magical staff of tremendous power and unknown origin. Although the full "
 "extent of its power has not been fathomed, there are a few features about it "
@@ -2806,81 +2764,81 @@ msgstr ""
 "之道付出生命的人才能持有这柄法杖。"
 
 #. [effect]: type=fire
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1439
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1429
 msgid "rod of justice"
 msgstr "公正之杖"
 
 #. [option]
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1519
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1509
 msgid "rod of justice^Leave it"
 msgstr "放下"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1546
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1536
 msgid "The Great Chamber"
 msgstr "大厅"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1551
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1541
 msgid "‘The Great Chamber’? Hmmm, wonder what that could be."
 msgstr "“大厅”？呣，那是个什么样的地方呢。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1568
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1558
 msgid "Halt! You’re not allowed to be here! Authorized undead only!"
 msgstr "站住！你们不得进入这里！只有经过授权的亡灵才行！"
 
 #. [unit]: type=Dwarvish Steelclad, id=Dulcatas
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1591
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1581
 msgid "Dulcatas"
 msgstr "杜凯特斯"
 
 #. [unit]: type=Dwarvish Thunderguard, id=Antolos
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1603
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1593
 msgid "Antolos"
 msgstr "安特勒斯"
 
 #. [unit]: type=Dwarvish Fighter, id=Varem
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1615
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1605
 msgid "Varem"
 msgstr "瓦伦"
 
 #. [message]: speaker=Dulcatas
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1626
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1616
 msgid "Halt! Who goes there? Friend or foe?"
 msgstr "站住！来者何人？朋友还是敌人？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1631
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1621
 msgid "Depends. Are you loyal to Malifor?"
 msgstr "不好说。你是玛利弗的人吗？"
 
 #. [message]: speaker=Dulcatas
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1636
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1626
 msgid ""
 "Never! If you ha’ been sent by Malifor, then know that we will never yield! "
 "Come and meet your death!"
 msgstr "决不可能！如果你是玛利弗派来的，那就让你知道我们还未屈服！过来受死吧！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1641
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1631
 msgid ""
 "Hold! We aren’t friends of Malifor in the least. Rather, we have come to "
 "destroy him."
 msgstr "慢着！我们根本不是玛利弗的同伙。相反，我们来这里就是为了打败他。"
 
 #. [message]: speaker=Dulcatas
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1646
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1636
 msgid "Finally! You don’t know how long we have been waiting for this day."
 msgstr "太好了！你不知道为了这一天我们等了多久啊。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1651
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1641
 msgid "How did you get here and how long have you been here?"
 msgstr "你们是怎样到这里，在这里待了多久？"
 
 #. [message]: speaker=Dulcatas
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1656
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1646
 msgid ""
 "We were originally prisoners of Malifor, but we tunneled out and escaped. "
 "Since then, we have eked out a precarious survival on what we have been able "
@@ -2890,62 +2848,62 @@ msgstr ""
 "抢来的一点食物勉强生活。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1661
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1651
 msgid "By now you have tunnels all through this place."
 msgstr "现在你们有了通向各处的隧道。"
 
 #. [message]: speaker=Dulcatas
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1666
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1656
 msgid ""
 "Aye. That seemingly blank wall to the south there is actually a hidden "
 "entrance to the treasury."
 msgstr "是的。南边那堵看起来什么都没有的墙其实是通向金库的秘密入口。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1671
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1661
 msgid "Awesome, let’s go!"
 msgstr "太好了，我们走！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1687
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1677
 msgid "Here we go."
 msgstr "我们来了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1729
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1719
 msgid ""
 "So this is the Great Chamber, eh? Doesn’t look like there is much to see "
 "here."
 msgstr "所以说这就是大厅吗，呃？没什么好看的嘛。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1737
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1727
 msgid "The ground shakes."
 msgstr "地面震动起来。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1742
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1732
 msgid "Perhaps I spoke too soon..."
 msgstr "或许我太早下判断了……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1793
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1783
 msgid "What is this? Our retreat is cut off!"
 msgstr "怎么回事？我们的退路被切断了！"
 
 #. [message]: type=Giant Spider
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1834
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1824
 msgid "Hsssss"
 msgstr "嘶嘶嘶嘶嘶"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1839
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1829
 msgid "‘Great Chamber’, my foot! This is a death chamber!"
 msgstr "“大厅”个鬼！这分明是个行刑室！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1858
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2545
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1848
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2534
 msgid ""
 "Hmmm. The wall appears weak here. I think there might be something on the "
 "other side."
@@ -2953,30 +2911,30 @@ msgstr "呣。墙的这部分看起来不坚固。我猜另一面可能有什么
 
 #. [message]: speaker=unit
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1872
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2586
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:573
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1862
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2575
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:570
 msgid "There we go."
 msgstr "我们来了。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1897
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1887
 msgid "Malifor the Great’s Study"
 msgstr "伟大的玛利弗的书屋"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1902
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1892
 msgid "There we go! This way!"
 msgstr "我们走！这边！"
 
 #. [message]: role=Study Guard
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1920
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1910
 msgid ""
 "They are attacking the master’s study! We must stop them! Call the reserves!"
 msgstr "他们进攻了主人的书房！我们必须阻止他们！呼叫后备队！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1948
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1938
 msgid ""
 "Caution! Tunnel flooded and infested with aquatic monsters. Enter at the "
 "risk of your unlife."
@@ -2985,24 +2943,24 @@ msgstr ""
 "生命危险。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1953
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1943
 msgid ""
 "Interesting. It seems like someone really doesn’t want us going down this "
 "tunnel."
 msgstr "有意思，看来有人真的不想让我们走进这个隧道。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1971
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1961
 msgid "Intruders? Capture them and throw them in with the toxic waste!"
 msgstr "入侵者？抓住他们，把他们连同剧毒废弃物一起扔进去！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2003
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1993
 msgid "A section of wall slides away."
 msgstr "墙的一部分移开了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2012
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2002
 msgid ""
 "Holy water! For a certainty, those skeletons won’t like us getting our hands "
 "on this stuff. But that’s probably why they kept them back here in the first "
@@ -3012,43 +2970,39 @@ msgstr ""
 "里的原因。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2026
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2016
 msgid ""
 "Warning! These bottles contain toxic waste. Causes disintegration on contact."
 msgstr "警告！这些瓶子里有剧毒废弃物。任何东西接触它就会瓦解。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2031
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2021
 msgid "(<i>rolls eyes</i>) Oh, the hazardous life of a skeleton."
 msgstr "（<b>转动眼珠</b>）噢，一个骷髅的危机四伏的生活。"
 
 #. [message]: speaker=Krash
 #. Krash has landed in one of the hexes of a small underground lake
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2053
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2043
 msgid "Wet."
-msgstr ""
+msgstr "湿。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2059
-#, fuzzy
-#| msgid "Hey, an underground lake."
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2049
 msgid "An underground lake."
-msgstr "嘿，一个地下湖。"
+msgstr "一个地下湖。"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2084
-#, fuzzy
-#| msgid "Monsters"
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2074
 msgid "Monster! Kill!"
-msgstr "怪兽"
+msgstr "怪物！杀掉它！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2090
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2080
 msgid "Ack! What are those things!"
 msgstr "啊，那些是什么东西！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2102
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2092
 msgid ""
 "Oh yeah, those things. Watch out, they are the arms of some sort of "
 "underwater creature. They’ll try to pummel you to death, then drag you under "
@@ -3058,14 +3012,14 @@ msgstr ""
 "吃掉。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2107
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2097
 msgid ""
 "Then how do we get past? I can see that the passage continues to both the "
 "north and south, and we haven’t found Malifor yet..."
 msgstr "那我们怎么才能过去？我看见北面和南面都有路，而我们还没有找到玛利弗……"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2112
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2102
 msgid ""
 "Creatures of that type regenerate over time; it’s doubtful we can destroy it "
 "completely. But if we destroy its arms we’ll be relatively safe until they "
@@ -3075,65 +3029,63 @@ msgstr ""
 "这样在它修复触手之前，我们都是安全的。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2117
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2107
 msgid "Let’s get to it, then."
 msgstr "那我们就行动吧。"
 
 #. [unit]: type=Wraith, id=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2141
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2131
 msgid "Abhai"
 msgstr "安彼海"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2151
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2141
 msgid "AH! A ghost!"
 msgstr "<b>啊！</b>一个幽灵！"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2156
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2146
 msgid "Who are you that dares to venture down these tunnels?"
 msgstr "你是谁，竟敢冒险进到这隧道里？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2167
-#, fuzzy
-#| msgid "Tallin"
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2157
 msgid "I am Tallin."
-msgstr "塔林"
+msgstr "我是塔林。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2173
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2163
 msgid "I... I am one of Tallin’s men..."
 msgstr "我……我是塔林的一个手下……"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2178
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2168
 msgid "Who is this ‘Tallin’?"
 msgstr "“塔林”是谁？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2183
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2173
 msgid "That would be me."
 msgstr "那就是我。"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2190
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2180
 msgid "What is your purpose in coming here?"
 msgstr "你到此有何意图？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2195
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2185
 msgid "We seek the destruction of the lich Malifor."
 msgstr "我们要去毁灭玛利弗。"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2200
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2190
 msgid "Malifor...! Finally someone here in force to deal with that menace!"
 msgstr "玛利弗……！终于有人带着大军来对付那威胁了！"
 
 #. [message]: speaker=Tallin
 #. "this spirit" is referring to the Ghost named Abhai.
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2206
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2196
 msgid ""
 "<i>Did this spirit get even paler?</i> Can you tell us where he is? And, if "
 "I may ask, who are — or rather, were — you?"
@@ -3142,7 +3094,7 @@ msgstr ""
 "应该说，曾经是——谁？"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2211
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2201
 msgid ""
 "I am Lord Abhai, the ruler... once... of a great kingdom far to the west. In "
 "time, as all men do, I grew old and passed to the Land of the Dead. I know "
@@ -3154,12 +3106,12 @@ msgstr ""
 "从安息中抽离出来，被一股可怕的力量吸入了这个世界。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2216
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2206
 msgid "Let me guess. Malifor?"
 msgstr "让我猜猜。是玛利弗干的？"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2221
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2211
 msgid ""
 "Indeed. He was once a great sorcerer, but he coveted wealth and power. To "
 "gain his ends, he allied himself with the Lich-Lords, and from them he "
@@ -3182,7 +3134,7 @@ msgstr ""
 "里。玛利弗的奴仆们很害怕的某种怪物生活在此处的水中；在这里他们不会骚扰我。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2226
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2216
 msgid ""
 "I am afraid times have changed much. Our first king, Haldric I, fled the "
 "Green Isle with the Wesfolk, the orcs in pursuit. He came ashore on this "
@@ -3194,17 +3146,17 @@ msgstr ""
 "了巫妖领主劫复魇，之后他建立了韦诺王国。那已经是好多个世纪之前的事了。"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2231
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2221
 msgid "So... much time has passed indeed."
 msgstr "那么说……确实已经过去了很长时间了啊。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2236
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2226
 msgid "Would you join us to defeat this evil creature?"
 msgstr "你想加入我们的队伍，一起击败这个可怕的造物吗？"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2242
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2231
 msgid ""
 "Wouldn’t miss it. Maybe after he is destroyed my kind and I can live... "
 "er... be dead peacefully."
@@ -3213,59 +3165,57 @@ msgstr ""
 "息了。"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2247
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2236
 msgid ""
 "Keep following these flooded tunnels. I think they might lead you directly "
 "to Malifor."
 msgstr "沿着水道走，我想就可以直接找到玛利弗了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2252
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2241
 msgid "Great. Forward, men!"
 msgstr "很好！前进，战士们！"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2280
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2269
 msgid "Corpse here... It stinks."
-msgstr ""
+msgstr "这里的尸体……好臭。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2286
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2275
 msgid "Ugh, a corpse. And it — (<i>gags</i>) — reeks!"
 msgstr "啊，一具尸体。它——（<b>捂住嘴</b>）——散发着恶臭！"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2307
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2296
 msgid ""
 "Yet more bodies... I’ve noticed them drifting down the river as of late."
-msgstr ""
+msgstr "更多尸体……我注意到近来它们总是顺着河水漂下来。"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2319
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2308
 msgid "More bodies. Float down river?"
-msgstr ""
+msgstr "更多尸体。沿河漂下？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2325
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2314
 msgid ""
 "Gee, what’s with these bodies floating around? Is this river some sort of "
 "body disposal?"
 msgstr "哎呀，四周漂浮的这些尸体是怎么回事？这条河是用来处理尸体的吗？"
 
 #. [message]: speaker=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2349
-#, fuzzy
-#| msgid "(<i>Sigh</i>) There doesn’t seem to be anything down this tunnel."
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2338
 msgid "There doesn’t seem to be anything this way other than another body."
-msgstr "（<b>叹气</b>）看来这个隧道里什么也没有。"
+msgstr "这个方向除了又一具尸体，似乎什么都没有。"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2361
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2350
 msgid "Grrr... Cold. Wet. Mad."
-msgstr ""
+msgstr "噶啊……冷。湿。疯了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2367
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2356
 msgid ""
 "Just great, I am cold, wet, and tired and what have we here? Another dead "
 "body. This place is starting to get on my nerves!"
@@ -3274,27 +3224,27 @@ msgstr ""
 "了！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2387
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2376
 msgid "Hold it, people, there’s something just ahead!"
 msgstr "等一下，大伙儿，前面有什么东西！"
 
 #. [message]: type=Naga Warrior
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2408
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2397
 msgid "(<i>sniff</i>) I smell humans."
 msgstr "（<b>嗅嗅</b>）我闻到了人类的味道。"
 
 #. [message]: type=Naga Fighter
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2413
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2402
 msgid "You are just plain deaf. I heard them coming a mile off."
 msgstr "你真是个聋子。他们离这儿还有一里远时我就听到他们正在过来了。"
 
 #. [message]: type=Naga Warrior
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2418
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2407
 msgid "Ahh, shut up. Let’s go kill them."
 msgstr "啊，闭嘴。我们去杀了他们。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2451
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2440
 msgid ""
 "It looks like this is it. Here is the door to Malifor’s study. Are we all "
 "ready for this?"
@@ -3302,77 +3252,77 @@ msgstr "看来就是这里了。这是通向玛利弗书房的门。大家做好
 
 #. [option]
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2453
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2507
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2442
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2496
 msgid "Get those doors open!"
 msgstr "打开那些门！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2468
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2457
 msgid "Let’s go!"
 msgstr "我们走！"
 
 #. [option]
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2479
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2597
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2696
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2468
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2586
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2685
 msgid "Just wait a sec."
 msgstr "等一下。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2550
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2539
 msgid "Anything you can’t handle?"
 msgstr "有你搞不定的事吗？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2555
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2544
 msgid "Nope. Should I open it?"
 msgstr "没有。我来打开它吗？"
 
 #. [option]
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2557
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2637
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2546
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2626
 msgid "Go for it!"
 msgstr "去吧！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2625
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2725
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2614
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2714
 msgid "Hey, check this out, it looks like some sort of lever."
 msgstr "嘿，看看这个，像个控制杆。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2630
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2619
 msgid "Throw it and see what it does."
 msgstr "推一下，看看有什么效果。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2635
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2624
 msgid "Should I throw it?"
 msgstr "推动控制杆吗？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2645
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2634
 msgid "Nothing. That door is not moving."
 msgstr "什么都没发生。门根本不动。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2650
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2639
 msgid "Why don’t you try ‘knocking’?"
 msgstr "你就不会‘敲门’吗？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2681
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2670
 msgid "Anybody home?"
 msgstr "有人在家吗？"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2776
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2765
 msgid "You wretched vermin, I have had it with you! Guards!"
 msgstr "你们这些讨厌的臭虫，我已经受够你们了！卫兵！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2800
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2789
 msgid ""
 "You invaded my kingdom, drove me from my mines, raided my dungeon, and "
 "plundered my treasury. Your audacity ends here!"
@@ -3380,7 +3330,7 @@ msgstr ""
 "你侵略了我的国家，把我从矿脉驱逐，突袭地牢，劫掠金库。你们的无礼到此结束了！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2813
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2802
 msgid ""
 "You are wrong, Malifor, for you shall be the one who is destroyed. You are "
 "cruel, merciless and a terror to all that lives. The world will be a better "
@@ -3390,7 +3340,7 @@ msgstr ""
 "让世界更美好！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2818
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2807
 msgid ""
 "To feed your greed and hunger you have terrorized all that is good. You have "
 "disturbed the rest of the brave defenders of Knalga. Now, your evil reign "
@@ -3400,7 +3350,7 @@ msgstr ""
 "息。现在你的邪恶统治即将结束。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2823
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2812
 msgid ""
 "Fools! Don’t think it’s so easy to kill me. Your corpses shall all soon be "
 "serving me. Fall on them, my hordes!"
@@ -3409,57 +3359,88 @@ msgstr ""
 "们！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2861
-msgid "HAHAHAHA, DEATH HAS NO EFFECT ON ME YOU FOOLS!"
-msgstr "哈哈哈哈，你们这些笨蛋，我是不会死的！"
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2850
+msgid "HAHAHAHA, THAT WEAPON CANNOT HARM ME!"
+msgstr "哈哈哈哈，那件武器伤不了我！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2866
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2855
 msgid "Well, blades don’t work."
 msgstr "好吧，刃器没用。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2876
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2865
 msgid "HAHAHAHA, YOUR IDIOCY AMUSES ME GREATLY!"
 msgstr "<b>哈哈哈哈，你们这些白痴真是太逗了！</b>"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2881
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2870
 msgid "Geez, how are we going to kill him? This weapon is ineffective!"
 msgstr "天哪，我们怎么才能杀死他？这武器不起作用！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2891
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2880
+msgid "YOUR WEAPONS CANNOT HARM ME, FOOLS!"
+msgstr "你们的武器伤不了我，蠢货们！"
+
+#. [message]: speaker=Tallin
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2885
+msgid "We’ll have to try something else. Perhaps magic will help."
+msgstr "我们得试试其他办法。也许魔法能行。"
+
+#. [message]: speaker=Malifor
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2895
 msgid "YOU PUNY MORTALS SHALL SOON BE SERVING ME!"
 msgstr "<b>你们这些渺小的凡人将很快来服侍我！</b>"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2896
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2900
 msgid "Blast it! Even fire has no effect on him!"
 msgstr "该死！就算是火焰也对他无效！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2901
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2905
 msgid "Let’s try using something different on him."
 msgstr "让我们试试用别的方法来对付他。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2916
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2915
+msgid "HAHAHAHA, FOOL! THE COLD IS MY DOMAIN!"
+msgstr "哈哈哈哈，蠢货！冰寒是我的领域！"
+
+#. [message]: speaker=Tallin
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2920
+msgid "I suppose we should’ve known better than to try freezing a Lich."
+msgstr "我想我们早该知道，不该试图去冻结巫妖的。"
+
+#. [message]: speaker=Malifor
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2930
+msgid "FOOLS! I FREED MYSELF OF WEAKNESS LONG AGO!"
+msgstr "蠢货！我很久以前就把我的弱点消灭掉了！"
+
+#. [message]: speaker=Tallin
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2935
+msgid ""
+"Even arcane weapons have no effect on him! We need an expert in white magic."
+msgstr "甚至连奥术武器都对他无效！我们得找个白魔法专家来。"
+
+#. [message]: speaker=Malifor
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2950
 msgid "AAAAAAHHHHHH!"
 msgstr "<b>啊啊啊啊啊啊！</b>"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2921
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2955
 msgid "I see now. It is impossible to destroy him by ordinary means."
 msgstr "我现在知道了。使用普通的方法是不可能消灭他的。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2926
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2960
 msgid "Then how are we going to destroy him? Surely there must be a way."
 msgstr "那我们该怎样消灭他？一定有什么方法的。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2931
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2965
 msgid ""
 "Yes, I think there is, but only myself or Thera have the means to do it. "
 "Come on Thera, let’s destroy that old skeleton."
@@ -3468,33 +3449,33 @@ msgstr ""
 "老骷髅。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2936
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2970
 msgid "Yeah, I can’t wait to get my hands on that bastard!"
 msgstr "好，我已经迫不及待想亲手消灭那个杂种了！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2941
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2975
 msgid "That was very unladylike of you."
 msgstr "你真没有淑女风范。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2946
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:451
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2980
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:449
 msgid "(<i>Giggle</i>) Sorry."
 msgstr "（<b>咯咯笑着</b>）对不起。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2963
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2997
 msgid "AHHHH! YOU BLASTED MAGE!"
 msgstr "<b>啊啊啊！你这该死的法师！</b>"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2968
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3002
 msgid "Good. We finally got him. He is dissolving."
 msgstr "好了。我们终于逮住他了。他正在消失。"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2973
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3007
 msgid ""
 "Curses on you you blasted mages, curses on you you blasted dwarves, curses "
 "on you you blasted humans, and CURSES ON YOU YOU BLASTED TALLIN! MAY YOUR "
@@ -3506,12 +3487,12 @@ msgstr ""
 "近和珍爱的都将远离你！我诅咒雷电劈在你的头顶！我诅咒——</b>"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2978
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3012
 msgid "May you shut your ugly mouth and hurry up and die."
 msgstr "闭上你邪恶的嘴，去死吧！"
 
 #. [message]: speaker=Malifor
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2983
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3017
 msgid ""
 "MAY THE EARTH OPEN UP AND SWALLOW YOU! MAY ALL YOUR TEETH FALL OUT! MAY YOU "
 "BECOME A WEAK SKINNY OLD MAN! MAY—"
@@ -3520,22 +3501,22 @@ msgstr ""
 "老男人！你——</b>"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:2998
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3032
 msgid "Finally! He has been reduced to dust."
 msgstr "结束了！他的身体化为灰烬。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3003
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3037
 msgid "At last! Victory is ours! Good work, men!"
 msgstr "结束了！我们胜利了！干得漂亮！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3008
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3042
 msgid "So, where to now, Tallin?"
 msgstr "那么，现在去哪里，塔林？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3013
+#: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:3047
 msgid ""
 "Now, let’s get back to the dwarves and see what progress they have made in "
 "forging us weapons."
@@ -3590,7 +3571,7 @@ msgid ""
 msgstr "当塔林的部队休整完毕之后，人类和矮人再次开会商讨。"
 
 #. [unit]: type=Dwarvish Steelclad, id=Galim
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:81
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:78
 msgid "Galim"
 msgstr "伽利姆"
 
@@ -3637,18 +3618,13 @@ msgstr "太好了！武器和铠甲方面的情况怎样？"
 #. [message]: speaker=Hamel
 #. As you can see, Tallin there are a lot of them ready to be born into battle. Some of us dwarves are experts in the sword, mace, and bow and can aid your veterans in teaching others.
 #: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:164
-#, fuzzy
-#| msgid ""
-#| "As ye ken see, Tallin, there be muckle heaps o’ them, all ready to be "
-#| "borne inta battle. And, some o’ us dwarves be experts in the sword, mace, "
-#| "and bow and ken aid yer veterans in teaching others."
 msgid ""
 "As ye can see, Tallin, there be muckle heaps o’ them, all ready to be borne "
 "inta battle. And, some o’ us dwarves be experts in the sword, mace, and bow "
 "and can aid yer veterans in teaching others."
 msgstr ""
-"正如你所见，塔林，这里有大堆大堆的武器和铠甲，都已经整备完毕可以带上战场了。"
-"另外，有些矮人是使用刀剑、棍棒和弓箭的专家，可以帮助你的老兵教其他人。"
+"如你所见，塔林，那儿可有一大堆家伙，随时都能拉上战场。而且咱矮人里有些可是使"
+"剑、使锤、使弓的好手，能帮你那些老兵一起教导其他人。"
 
 #. [message]: speaker=Tallin
 #: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:169
@@ -3660,7 +3636,7 @@ msgstr ""
 "来作战呢。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:175
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:174
 msgid ""
 "Aye, it’s true we do prefer our axes and hammers, but then again, we make "
 "swords. We couldna’ claim to be expert weaponsmiths wi’out kenning how to "
@@ -3670,7 +3646,7 @@ msgstr ""
 "道怎么用，我们又怎么敢自称专业的武器工匠呢。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:180
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:179
 msgid ""
 "There are some dwarves out there that are bonny fighters wi’ a sword as any "
 "ye are like to meet. Belike with bows, maces and any other weapons we "
@@ -3680,7 +3656,7 @@ msgstr ""
 "们所使用的弓箭、棍棒和任何其它武器。实际上，这位伽利姆就很懂剑术。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:185
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:184
 msgid ""
 "That’s great! What is the price of your weapons? We have gathered much gold "
 "from Malifor’s treasury and will be able to pay you generously."
@@ -3689,7 +3665,7 @@ msgstr ""
 "跟你买。"
 
 #. [message]: speaker=Galim
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:190
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:189
 msgid ""
 "Price?! Don’t insult us, Tallin. Ye have done great things to help the "
 "dwarves — it’s because of you that we ha’ made a start rebuilding Knalga in "
@@ -3699,12 +3675,12 @@ msgstr ""
 "们才能开始纳尔迦的重建。别再和我们谈价钱的事了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:195
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:194
 msgid "But don’t you need the gold to help rebuild Knalga? We have plenty."
 msgstr "难道你们不需要金币来重建纳尔迦吗？我们有很多金币呢。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:200
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:199
 msgid ""
 "Tallin, Knalga was an extremely rich nation. Malifor’s treasury is hardly a "
 "fraction of the riches that we will find, and are finding every day now. So "
@@ -3715,17 +3691,17 @@ msgstr ""
 "矮人之门的时候会用到那些金币的。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:205
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:204
 msgid "Thank you, Hamel."
 msgstr "谢谢，哈梅尔。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:211
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:209
 msgid "Pahhh, thank <i>you</i>!"
 msgstr "呸呸呸，应该是谢谢<b>你</b>才对！"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:216
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:214
 msgid ""
 "And Tallin, one more thing, I have been leading our people into battle for "
 "many years now. As a young dwarf I was trained in the arts of leadership and "
@@ -3735,7 +3711,7 @@ msgstr ""
 "的训练。有些事我想让你知道……"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:222
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:219
 msgid ""
 "I know you’re impressive wi’ a pitchfork, and you are not half bad with a "
 "sword when you choose to use one. But there skills beyond swingin’ a weapon "
@@ -3745,12 +3721,12 @@ msgstr ""
 "器以外，还有更多东西要学。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:227
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:224
 msgid "I would be honored, Lord Hamel."
 msgstr "我十分荣幸，哈梅尔领主。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:232
+#: data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg:229
 msgid ""
 "Ahhhh, quit with the formality, me lad. Now, first things first. One of the "
 "most important things about being a leader is..."
@@ -3798,11 +3774,11 @@ msgstr ""
 
 #. [side]
 #. [side]: type=Dwarvish Lord, id=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:43
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:130
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:148
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:99
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:28
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:42
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:126
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:142
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:97
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:27
 msgid "Knalgans"
 msgstr "纳尔迦人"
 
@@ -3819,17 +3795,17 @@ msgstr "纳尔迦人"
 #. [side]: type=Orcish Warlord, id=Ar'Muff
 #. [side]: type=Orcish Warlord, id=Calter
 #. [side]: type=Orcish Warlord, id=Halter
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:57
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:87
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:110
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:113
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:128
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:53
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:77
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:93
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:109
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:125
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:182
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:55
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:83
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:106
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:109
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:124
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:49
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:73
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:89
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:105
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:121
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:178
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:64
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:117
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:162
@@ -3839,39 +3815,39 @@ msgid "Orcs"
 msgstr "兽人"
 
 #. [side]: type=Orcish Warlord, id=Drung
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:92
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:88
 msgid "Drung"
 msgstr "泽乱"
 
 #. [side]: type=Orcish Warlord, id=Poul
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:115
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:111
 msgid "Poul"
 msgstr "保罗"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:193
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:189
 msgid "Resist until the end of turns"
 msgstr "坚持到回合数耗尽"
 
 #. [objectives]
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:198
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:194
 msgid "Defeat Rakshas, if you can..."
 msgstr "打败拉克夏斯，如果你能做到的话……"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:217
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:213
 msgid ""
 "So I see you stinky-midgets and human-worms finally mustered up the courage "
 "to face me."
 msgstr "你们这些臭小矮人和人类虫子终于鼓起勇气来见我了。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:222
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:218
 msgid "Who are you, and what do you want?"
 msgstr "你是谁，你要做什么？"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:227
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:223
 msgid ""
 "I am Emperor Rakshas and by the power of my sword, I lead the orcish people. "
 "I am here simply finishing the job Khazg Black-Tusk started years ago — the "
@@ -3881,14 +3857,14 @@ msgstr ""
 "单，就是完成哈兹·黑牙多年前启动的计划——征服纳尔迦。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:232
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:228
 msgid ""
 "Khazg tried and failed, and if you repeat his folly you will soon join him "
 "in the Land of the Dead!"
 msgstr "哈兹试过，但失败了，如果要重复他的愚蠢，你就去阴曹地府见他吧！"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:238
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:233
 msgid ""
 "Pah! I would like to see those cowardly dwarves try their treachery on me as "
 "they did on the Black-Tusk! In any case, those dwarves will soon be "
@@ -3903,12 +3879,12 @@ msgstr ""
 "会成为被烧光、抢光的废墟。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:243
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:238
 msgid "Boy, this guy sure has delusions of grandeur."
 msgstr "朋友，这家伙肯定得了妄想症。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:248
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:243
 msgid ""
 "I am not so sure it’s that simple, Tallin. Think back to those orcs at the "
 "Dwarven Doors, and those wolves on the way to the mines; they were both "
@@ -3918,17 +3894,17 @@ msgstr ""
 "那些狼，他们都提到了“主人”什么的。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:253
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:248
 msgid "Yeah?"
 msgstr "嗯？"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:258
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:253
 msgid "Well, unless I miss my guess, dreamy fellow would be him."
 msgstr "呃，如果我没猜错的话，他就是那家伙。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:263
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:258
 msgid ""
 "Well, if that is so, then it’s time to end this menace once and for all! "
 "Fall on them, boys!"
@@ -3937,7 +3913,7 @@ msgstr ""
 "们！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:285
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:280
 msgid ""
 "Come on, why are we just sitting here in these caves?! Have you forgotten "
 "already all these orcs have done to us! Let us spill their foul blood on the "
@@ -3948,120 +3924,120 @@ msgstr ""
 
 #. [message]: id=Rakshas
 #. knights means wolf riders
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:303
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:298
 msgid ""
 "So! Your forces are managing to advance upon me? Very impressive, but it "
 "shall do you no good. KNIGHTS!!"
 msgstr "哦！你的军队想前进到我这里？有胆量，但是这对你没有好处。骑士们！！"
 
 #. [message]: type=Goblin Knight
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:346
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:341
 msgid "HAHAHA! GOT YOU, SUCKERS!"
 msgstr "哈哈哈！逮住你们了，笨蛋！"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:351
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:346
 msgid "CHARGE!!"
 msgstr "冲啊！！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:356
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:351
 msgid ""
 "Oh, hell! Form up, men, back to back! Don’t let them penetrate our ranks!"
 msgstr "哦，见鬼！布阵，战士们，背靠背！不要让他们突破我们的阵形！"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:361
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:356
 msgid "That’s not all, my friends. GENERALS, CALL THE RESERVES!"
 msgstr "还没完呢，我的朋友们。将军们，派出预备队！"
 
 #. [message]: id=Drung
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:366
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:361
 msgid "Oh yeah!"
 msgstr "噢耶！"
 
 #. [message]: id=Poul
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:371
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:366
 msgid "HAHAHA!"
 msgstr "哈哈哈！"
 
 #. [message]: id=Drung
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:376
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:371
 msgid "You are so dead, you human vermin!"
 msgstr "你们死定了，人类臭虫！"
 
 #. [message]: id=Poul
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:381
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:376
 msgid "Oooooooh! Time to start the fun!"
 msgstr "噢噢噢噢！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:393
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:388
 msgid "This doesn’t look good..."
 msgstr "情况不妙……"
 
 #. [message]: id=Drung
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:406
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:401
 msgid "Argh! I have been slain!"
 msgstr "啊！我死了！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:411
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:406
 msgid ""
 "Killed him! Got his gold too. Let’s see, hmmm, about five-hundred gold "
 "pieces. Not bad."
 msgstr "我杀掉他了！还拿到了他的金币。来看看，呣，大概五百枚金币。还不错。"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:421
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:416
 msgid "They have killed one of my generals! REINFORCEMENTS!"
 msgstr "他们杀了我的部将！<b>增援！</b>"
 
 #. [message]: id=Poul
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:439
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:434
 msgid ""
 "My death will only make the Master’s punishment for you worse, you fools!"
 msgstr "我的死只会让主人对你们的惩罚更严厉，你们这些蠢货！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:444
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:439
 msgid "Your death makes your Master’s punishment from us one step closer!"
 msgstr "你的死会让你的主人离我们对他的惩罚更近一步！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:449
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:444
 msgid "But— my my, what’s in that big pouch? 300 gold! Not bad."
 msgstr "瞧瞧，我的天，这大袋子里装的是什么？300金币！收获不错。"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:459
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:454
 msgid "You vermin will pay for that! REINFORCEMENTS!"
 msgstr "你们这些小虫子要付出代价！增援！"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:477
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:472
 msgid "Ahhhh! Run for your life!"
 msgstr "哈哈哈！逃命去吧！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:482
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:477
 msgid "What the... Hey, where do you think you are running off to, you coward!"
 msgstr "怎么……嘿，你们想逃到哪里去，一群懦夫！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:487
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:482
 msgid "Stop him!"
 msgstr "阻止他！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:492
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:487
 msgid ""
 "It’s too late! I am sorry, Tallin, he got away! We did not expect he would "
 "flee like a coward."
 msgstr "来不及了！抱歉，塔林，让他跑了！我们没想到他会像懦夫一样逃走。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:497
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:492
 msgid ""
 "Damn! We had the opportunity to end the war in one stroke there. Now we will "
 "have to go after him, assuming we can break this siege!"
@@ -4069,7 +4045,7 @@ msgstr ""
 "可恶！我们有机会一次结束这场战争的！现在我们必须追他，还得先攻破这包围！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:513
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:507
 msgid ""
 "Geez, we have been fighting them for three whole days, and there’s still as "
 "many orcs as ever. What should we do?"
@@ -4077,7 +4053,7 @@ msgstr ""
 "天哪，我们已经和他们打了整整三天，而兽人还是像以前那么多。我们该怎么办？"
 
 #. [message]: id=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:519
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:513
 msgid ""
 "It seems hopeless to continue on like this. The orcs’ numbers are unlimited "
 "and Rakshas is very well guarded. The only possible outcome to all this is "
@@ -4087,22 +4063,22 @@ msgstr ""
 "结果就只能是更多的杀戮了。"
 
 #. [message]: id=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:525
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:519
 msgid "I propose that we retreat into the caves and consult with the dwarves."
 msgstr "我建议我们退回洞穴，找矮人们商量一下。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:530
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:524
 msgid "I agree, Tallin, it is pointless to carry on."
 msgstr "我同意，塔林，这样坚持下去没意义。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:535
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:529
 msgid "Very well. Everyone fall back!"
 msgstr "好的，各位。快撤！"
 
 #. [message]: id=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:541
+#: data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg:535
 msgid "Awwwww! Just when I was having the most fun!"
 msgstr "啊哈哈哈！我正玩得高兴！"
 
@@ -4112,14 +4088,14 @@ msgid "Settling Disputes"
 msgstr "解决争端"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:21
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:19
 msgid ""
 "Tallin and his men made an orderly withdrawal into the caves, the orcs "
 "pressing close behind them."
 msgstr "塔林和他的部队有序地撤回洞穴，兽人则穷追不舍，紧跟其后。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:24
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:22
 msgid ""
 "The dwarves were more than ready for them, however, and as soon as the "
 "humans got through the defenses the well-prepared dwarves fell on the battle-"
@@ -4128,24 +4104,24 @@ msgstr ""
 "矮人则在此接应人类，当人类躲进防护掩体后，等候多时的矮人和兽人展开了血战。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:27
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:25
 msgid ""
 "Wave after wave of orcs crashed onto the dwarven defenses only to be "
 "shattered."
 msgstr "兽人发动了一波又一波的疯狂进攻，不过在矮人的防御战线前被打破了。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:30
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:28
 msgid "As the battle raged on, Tallin again made council with Hamel."
 msgstr "随着战事的发展，塔林和哈梅尔再次开会商讨。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:33
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:31
 msgid "How did ye fare?"
 msgstr "现在进展如何？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:35
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:33
 msgid ""
 "It was fierce and bloody. We fought them for three days and nights. Every "
 "time we killed an orc, it seemed that two more would take his place. We most "
@@ -4155,7 +4131,7 @@ msgstr ""
 "多的兽人涌上来。如果情况还是如此，此战我们必输无疑。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:37
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:35
 msgid ""
 "So you withdrew. Rightly done, me lad. Our prepared defenses will be able to "
 "hold the orcs off far longer and with less loss than ye could ha’ done in "
@@ -4165,7 +4141,7 @@ msgstr ""
 "且和在开阔地作战相比，我们的损失会更小。看来我对你的训练还是有效果的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:39
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:37
 msgid ""
 "And I am grateful — but what should we do from here? The number of humans "
 "and dwarves is limited, unlike the orcs whose numbers seem unlimited."
@@ -4174,13 +4150,13 @@ msgstr ""
 "是无穷的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:41
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:39
 msgid ""
 "Aye. But we must utterly crush this orcish host if we are to ever ha’ peace."
 msgstr "是的。但我们必须完全摧毁这个兽人集团，否则我们没法获得片刻的安宁。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:43
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:41
 msgid ""
 "Orcs are fickle; if we negotiated a treaty with them — assuming they would "
 "accept — it would just be broken as soon as the next warlord arose among "
@@ -4190,7 +4166,7 @@ msgstr ""
 "后，和约也还是会被撕毁的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:45
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:43
 msgid ""
 "Then what shall we do? Can we assassinate this Rakshas fellow and throw them "
 "into disarray once more?"
@@ -4200,7 +4176,7 @@ msgstr ""
 #. [story]
 #. "coil" meant, in Middle and Early Modern English, a difficulty
 #. or problem.
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:49
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:47
 msgid ""
 "That will be very difficult. We did that last time and they will no doubt be "
 "alert to that threat now. Anyway, it would be but a temporary solution. Soon "
@@ -4211,12 +4187,12 @@ msgstr ""
 "时之困。另一个强势的头领很快又会被选出来，到时候我们又会陷入同样的困境。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:51
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:49
 msgid "Well, back to the drawing board. What should we do?"
 msgstr "好吧，回到开始的讨论，我们现在该做什么？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:53
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:51
 msgid ""
 "I think we should try to gather more allies. That way we can engage them on "
 "many fronts, or divide them into smaller groups, or cut them off from their "
@@ -4226,13 +4202,13 @@ msgstr ""
 "阻断他们的后援。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:55
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:53
 msgid ""
 "Wise words, but who is there in these wild Northlands that might aid us?"
 msgstr "好建议，但是在这茫茫北国谁可以助我们一臂之力？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:57
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:55
 msgid ""
 "You can count the elves out. They are a selfish lot, only interested in "
 "themselves. They would only aid us if something drastic happened to them and "
@@ -4242,14 +4218,14 @@ msgstr ""
 "们的帮助，否则他们是不会帮助我们的。请求韦诺帮助怎样？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:59
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:57
 msgid ""
 "Wesnoth is too far away, and we have no idea what political state they are "
 "in."
 msgstr "韦诺国离我们太远了，我们也不知道那里现在的政治情况。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:61
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:59
 msgid ""
 "The last news we heard of them was years ago when Prince Konrad passed "
 "through here. At that time the evil Queen Asheviere was ruling, and it was "
@@ -4259,14 +4235,14 @@ msgstr ""
 "艾什薇尔女王正统治着，据说她和兽人结了盟。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:63
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:61
 msgid ""
 "And then that Princess Li’sar was in hot pursuit of Konrad as well. I wonder "
 "what became of them."
 msgstr "那时莉莎公主也正在紧紧地追捕着科纳德。我不知道他们后来怎么样了。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:65
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:63
 msgid ""
 "The last time any dwarf set eyes on Konrad was when he set out to the "
 "eastern tunnels in search of the Sceptre of Fire, so he could claim his "
@@ -4276,20 +4252,20 @@ msgstr ""
 "个来证明自己王者的地位。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:67
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:65
 msgid ""
 "Geez, what a fool’s quest. Everyone in these Northlands knows that the "
 "Sceptre is long gone."
 msgstr "天哪，真是个不靠谱的想法。每个北陆上的人都知道，权杖已经丢失很久了。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:69
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:67
 msgid ""
 "But we’re meandering. Where can we find allies in these wild Northlands?"
 msgstr "我们真是不走运啊。在这北方的蛮荒之地，我们到哪里去找盟友啊？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:71
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:69
 msgid ""
 "Tallin, before I was captured by Malifor, I used to be in contact with a "
 "powerful magician called Ro’Arthian and his brother Ro’Sothian."
@@ -4298,17 +4274,17 @@ msgstr ""
 "来往。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:73
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:71
 msgid "Ro’Arthian, bah! Don’t utter that cursed name!"
 msgstr "若·艾瑟恩，呸！别提这个可恶的名字！"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:75
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:73
 msgid "Why not, Hamel, have you a grievance with him?"
 msgstr "怎么了，哈梅尔，为何对他如此不满？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:77
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:75
 msgid ""
 "I have heard all about him from my good friend Stalrag. He is — or was "
 "anyway, haven’t heard from him in years — the chief o’ the villages that lay "
@@ -4318,12 +4294,12 @@ msgstr ""
 "已经多年没有他的消息了——高溪谷一带村子的首领。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:79
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:77
 msgid "Those foul mages have long terrorized Stalrag and his people."
 msgstr "那些可恶的法师长期恐吓威胁斯托莱格和他的子民。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:81
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:79
 msgid ""
 "Remember, Hamel, there are often two sides to a story like this. Perhaps the "
 "mages see your dwarves as invaders. How would you feel if say... the elves "
@@ -4334,43 +4310,43 @@ msgstr ""
 "果精灵决定来把纳尔迦推平，在上面种植另一片大森林，你会怎么想呢？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:83
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:81
 msgid "Those filthy elves! I’ll..."
 msgstr "那些丑恶的精灵！我会……"
 
 #. [story]
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:85
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:634
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:83
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:631
 msgid "See?"
 msgstr "你明白了吗？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:87
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:85
 msgid ""
 "What were you doing keeping contact with mages such as those anyway? Trying "
 "to save their souls?"
 msgstr "你们为什么要和那些法师来往？拯救他们的灵魂？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:89
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:87
 msgid "(<i>Giggle</i>) Something like that."
 msgstr "（<b>咯咯笑</b>）差不多吧。"
 
 #. [story]
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:91
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:235
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:89
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:232
 msgid "(<i>Rolls eyes</i>)"
 msgstr "（<b>转眼珠</b>）"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:93
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:91
 msgid "Father Morvin, what are you trying to say?"
 msgstr "莫文神父，你有什么想说的吗？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:95
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:93
 msgid ""
 "I propose that we go to Highbrook Pass and see how matters stand for "
 "ourselves. If the wizards are still alive, we might be able to persuade them "
@@ -4381,12 +4357,12 @@ msgstr ""
 "当然，如果斯托莱格还在，我们也可以请他帮忙。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:97
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:95
 msgid "I don’t see how just two mages could help us very much, Father."
 msgstr "神父，我不明白，区区两个法师能帮到我们什么。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:99
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:97
 msgid ""
 "They are not just any two mages. They have fine control over many creatures "
 "of the wild such as ogres, gryphons, and sometimes even trolls! It would be "
@@ -4396,12 +4372,12 @@ msgstr ""
 "魔！让他们加入我们的队伍也不是坏事。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:101
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:99
 msgid "That sounds really good. What do you think, Hamel?"
 msgstr "听起来不错。你怎么想，哈梅尔？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:104
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:101
 msgid ""
 "Hrmph. These are desperate times. If those lunatics of mages will agree to "
 "help, I guess we’ll nae have any other choice but to accept."
@@ -4410,7 +4386,7 @@ msgstr ""
 "能接受了。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:106
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:103
 msgid ""
 "Hey, we have had experiences with crazy mages ourselves. Believe me, they "
 "are dangerous! You will feel a lot better with some of them on your side."
@@ -4419,7 +4395,7 @@ msgstr ""
 "是一伙的，你会觉得很不错。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:108
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:105
 msgid ""
 "Ye’ll need to travel light to reach Highbrook Pass before the orcs mount "
 "another assault in force. I think ye should take as little gold as possible. "
@@ -4430,26 +4406,26 @@ msgstr ""
 "能少的金币。我们会把剩下的存在隧道最深处，以防兽人突破防线。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:110
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:107
 msgid "So it shall be. Now how exactly do we get to this mountain pass?"
 msgstr "就这样吧。我们具体该怎样到达那个山口？"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:115
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:112
 msgid "And so Tallin and his party set out to secure the help of the mages."
 msgstr "随后塔林和他的部队出发去寻求法师的帮助。"
 
 #. [side]: type=Dwarvish Lord, id=Stalrag
 #. [unit]: type=Dwarvish Lord, id=Stalrag
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:153
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:222
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:147
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:218
 #: data/campaigns/Northern_Rebirth/utils/utils.cfg:184
 msgid "Stalrag"
 msgstr "斯托莱格"
 
 #. [side]: type=Ancient Lich, id=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:217
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:211
 msgid "Liches"
 msgstr "巫妖"
 
@@ -4457,8 +4433,8 @@ msgstr "巫妖"
 #. [unit]: type=Ancient Lich, id=Ro'Arthian
 #. [modify_side]
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:222
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:249
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:216
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:245
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:396
 #: data/campaigns/Northern_Rebirth/utils/utils.cfg:160
 msgid "Ro’Arthian"
@@ -4466,48 +4442,48 @@ msgstr "若·艾瑟恩"
 
 #. [unit]: type=Lich, id=Ro'Sothian
 #. [modify_side]
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:261
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:276
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:255
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:272
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:479
 msgid "Ro’Sothian"
 msgstr "若·索瑟恩"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:317
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:311
 msgid "Save Stalrag from Ro’Sothian"
 msgstr "从若·索瑟恩手中解救斯托莱格"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:326
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:320
 msgid "Capture Ro’Arthian"
 msgstr "俘获若·艾瑟恩"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:337
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:331
 msgid "Death of Stalrag"
 msgstr "斯托莱格死亡"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:356
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:350
 msgid ""
 "Upon arriving at the mountain pass it appeared to Tallin and his men that "
 "they were just a bit too late."
 msgstr "来到山口，塔林和他的部队发现晚来了一步。"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:362
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:356
 msgid "HAH! I finally have you, you wretched dwarf!"
 msgstr "哈！我终于等到你们了，你们这些倒霉的矮人！"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:367
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:361
 msgid ""
 "Argh! You blasted mages! How many times do I have to kill you two before you "
 "will leave us in peace!"
 msgstr "啊！你们这些该死的法师！只有杀了你们两个才能还我们和平！"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:372
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:366
 msgid ""
 "Leave <i>you</i> in peace?! It is your kind that won’t leave <i>us</i> in "
 "peace! Ever since you blasted dwarves built that damn road you have harassed "
@@ -4521,7 +4497,7 @@ msgstr ""
 "再也回不来了。"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:377
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:371
 msgid ""
 "You cursed mage! I now go to join all of my men you have killed. But know "
 "this, the Shinsplitters will <i>never</i> submit! We will defy you to our "
@@ -4531,29 +4507,29 @@ msgstr ""
 "屈服的！我们会和你对抗直到最后一息！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:382
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:376
 msgid "Hold it! What’s going on here?"
 msgstr "住手！这里发生了什么事？"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:387
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:381
 msgid "Ro’Sothian, is that you?"
 msgstr "若·索瑟恩，是你吗？"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:392
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:386
 msgid "Not now, Father. I’m a little busy at the moment."
 msgstr "一会儿再谈，神父。我现在有点忙。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:404
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:397
 msgid ""
 "Ro’Sothian! How are you doing, my old friend! Boy, you sure look... erm... "
 "different!"
 msgstr "若·索瑟恩！你过得怎样，我的老朋友！伙计，你看起来……呃……变了很多！"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:409
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:402
 msgid ""
 "Camerin! Great Lords of Darkness, I haven’t seen you in ages! Here, let me "
 "just finish off this little vermin and I’ll be right over."
@@ -4562,32 +4538,32 @@ msgstr ""
 "们再慢慢叙旧。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:414
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:407
 msgid "whisper^Camerin, you know him?"
 msgstr "（耳语）卡梅林，你认识他？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:419
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:412
 msgid "whisper^Duh! His brother Ro’Arthian is the one who taught me magic!"
 msgstr "（耳语）嗯！我的魔法就是跟他的哥哥若·艾瑟恩学的！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:424
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:417
 msgid "whisper^Oh...!"
 msgstr "（耳语）哦……！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:431
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:424
 msgid "Hang on a sec, Ro’Sothian, you don’t want to kill him."
 msgstr "等一下，若·索瑟恩，你不会是想杀他吧。"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:436
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:429
 msgid "Huh?! He killed me!"
 msgstr "哈？！是他先要杀我！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:441
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:434
 msgid ""
 "Oh... I see. But we come on more pressing business. We are in desperate need "
 "of your help. Here is Tallin from the community of Dwarven Doors. As you "
@@ -4600,14 +4576,14 @@ msgstr ""
 "脱了枷锁，并和纳尔迦的哈梅尔联合起来，要从混乱中重振纳尔迦。"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:446
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:439
 msgid ""
 "So? What does this have to do with me? And hurry up, my staff is buzzing to "
 "blast this little vermin once and for all."
 msgstr "什么？这关我何事？我只想解决了这些小家伙们。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:451
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:444
 msgid ""
 "Don’t! Please, my friend, listen. The orcs are on the rise again and they "
 "are threatening to complete their conquest of Knalga and convert it into an "
@@ -4619,7 +4595,7 @@ msgstr ""
 "哥帮我们一同抵御兽人。"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:456
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:449
 msgid ""
 "Take your begging and shove it, Father! We don’t help no-one. Not even you "
 "and <i>especially</i> not any dwarf!"
@@ -4628,7 +4604,7 @@ msgstr ""
 "了！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:466
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:459
 msgid ""
 "Hold a moment, my friend. You won’t believe what a blast it is fighting with "
 "these guys. You get to fry skeletons, orcs, trolls, and wolves by the "
@@ -4638,7 +4614,7 @@ msgstr ""
 "骷髅兵，兽人，巨魔，还有狼！来吧老伙计，活动活动筋骨。"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:471
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:464
 msgid ""
 "Camerin, you were always a little crazy. Now I see you have gone stark "
 "raving mad! Do you really think we would help anyone? <i>Especially</i> a "
@@ -4648,7 +4624,7 @@ msgstr ""
 "去帮助别人吗？<b>特别</b>是一群矮人！"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:478
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:471
 msgid ""
 "I tire of this; prepare to die, wretched dwarf! And the rest of you, get "
 "lost and don’t come back, unless you’re tired of life!"
@@ -4657,32 +4633,32 @@ msgstr ""
 "你们不想活了！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:483
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:476
 msgid "Uh oh, he is gathering energy for a cold blast."
 msgstr "噢，他正在收集冷冻风暴的能量。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:488
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:481
 msgid "Quick, honey, we’ve got to stop him!"
 msgstr "快，亲爱的，我们必须阻止他！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:498
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:491
 msgid "Hey, are you two going to hog all the fun for yourselves?"
 msgstr "嘿，你们两个是不是想独吞好玩的事？"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:503
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:496
 msgid "All right, all right, hang on!"
 msgstr "好吧，好吧，抓紧了！"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:565
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:558
 msgid "BROTHER! HELP ME!"
 msgstr "哥哥！救我！"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:570
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:563
 msgid ""
 "(<i>Booming voice coming from all directions</i>) SO YOU MAGES HAVE THE "
 "AUDACITY TO ATTACK MY BROTHER! YOU SHALL DIE FOR YOUR FOLLY!"
@@ -4691,20 +4667,20 @@ msgstr ""
 "愚蠢行为付出生命的代价！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:575
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:568
 msgid ""
 "Ro’Arthian, listen to me. We don’t want to fight with you, we have come here "
 "to seek your assistance."
 msgstr "若·艾瑟恩，听我说。我们并不想与你为敌，我们来此是为了得到你的帮助。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:581
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:592
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:574
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:585
 msgid "(<i>No answer</i>)"
 msgstr "（<b>没有答话</b>）"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:586
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:579
 msgid ""
 "I know you can hear me, Ro’Arthian. Please, the fate of every creature in "
 "the north depends on your help."
@@ -4712,7 +4688,7 @@ msgstr ""
 "我知道你能听见我说话，若·艾瑟恩。求你了，北陆上生灵的命运全靠你的帮助了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:597
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:590
 msgid ""
 "Give it up, father, he isn’t answering. I am afraid we may have to use um... "
 "more forceful means to convince him."
@@ -4720,73 +4696,73 @@ msgstr ""
 "算了吧，神父，他不会答应的。我想我们只能用……呃……更强硬的手段来说服他了。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:602
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:595
 msgid "(<i>Sigh</i>) Yes, you are right."
 msgstr "（<b>叹气</b>）是啊，你说的没错。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:607
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:600
 msgid "Put Ro’Sothian into that jail over there until we capture his brother."
 msgstr "把若·索瑟恩关到那边的监狱里，然后我们去抓他哥哥。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:617
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:610
 msgid "And someone keep an eye on him. We don’t want him to get away."
 msgstr "留下人看好他，别让他跑了。"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:657
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:650
 msgid "Ha! I am free! Now you foul traitors will pay!"
 msgstr "哈！我自由了！你们这些愚蠢的奸贼要付出代价！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:662
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:655
 msgid "Oh no, he got away! Quick, men, we must capture him again!"
 msgstr "不，他逃跑了！快，战士们，必须把他抓住！"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:674
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:667
 msgid "Ahhhh! Not again!"
 msgstr "啊！不要！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:679
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:672
 msgid ""
 "Come on, Ro’Sothian, we really don’t have to be doing this. Come, join us!"
 msgstr "好了，若·索瑟恩，我们真的没必要做到这一步。来吧，加入我们！"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:684
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:677
 msgid "Never!"
 msgstr "不可能！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:689
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:682
 msgid "Sigh, we’ll talk later."
 msgstr "唉，我们等会儿再谈吧。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:694
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:687
 msgid "Back to jail, my friend."
 msgstr "回牢里去，我的朋友。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:740
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:733
 msgid "Ro’Arthian, are you ready to talk yet?"
 msgstr "若·艾瑟恩，你有什么话想说的吗？"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:745
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:738
 msgid "Fine, you trespassers. What do you want?"
 msgstr "好，你这个侵略者。你要做什么？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:750
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:743
 msgid "Well... First, why don’t you tell us what <i>you</i> want?"
 msgstr "呃……你先告诉我们<b>你</b>想做什么？"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:755
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:748
 msgid ""
 "What do <i>I</i> want? I’ll tell you what I want! I want the stinking "
 "carcasses of you, all your henchmen and those dwarvish vermin off my land! "
@@ -4796,17 +4772,17 @@ msgstr ""
 "追随者，还有那些矮人臭虫滚出我的土地！<b>永远地</b>离开！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:760
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:753
 msgid "So basically, you want to be left alone in peace, right?"
 msgstr "也就是简单来说，你就是想一个人不被打扰，过平静的生活，对吧？"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:765
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:758
 msgid "Wow! Someone <i>finally</i> figured it out!"
 msgstr "哇！<b>终于</b>有人开窍了！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:770
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:763
 msgid ""
 "All right! Listen, then. Right now we have very little power to grant your "
 "request. We are simply a band of peasants fighting for the freedom of our "
@@ -4816,7 +4792,7 @@ msgstr ""
 "的自由而奋斗的农民。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:775
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:768
 msgid ""
 "But when we defeat the orcish host, re-establish Knalga, and bring law and "
 "order into these Northlands, we will have gained some authority by right of "
@@ -4826,7 +4802,7 @@ msgstr ""
 "权所带来的威信。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:780
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:773
 msgid ""
 "When that time comes, I hereby make a solemn oath: no man or dwarf shall "
 "ever set foot on your land without your leave. If any of my men violates "
@@ -4837,7 +4813,7 @@ msgstr ""
 "土地。如果我的人违背了这一法令，那他将被处以极刑。我想哈梅尔也同意这一点的。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:785
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:778
 msgid ""
 "In order for that to come about, we must crush the orcish host. But we can’t "
 "do that without your help. Will you join us?"
@@ -4846,7 +4822,7 @@ msgstr ""
 "一点。你们愿意加入我们吗？"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:790
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:783
 msgid ""
 "Think of it, Ro’Arthian, it is a fair bargain. If you don’t agree to "
 "Tallin’s proposal, the endless war you two wage with the dwarves will never "
@@ -4858,17 +4834,17 @@ msgstr ""
 "应该获得安息了。"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:795
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:788
 msgid "Hrmph. What do you think, brother?"
 msgstr "嗯……兄弟，你是怎么想的？"
 
 #. [message]: speaker=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:828
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:821
 msgid "(<i>Shrugs</i>) I don’t think we have any other choice left."
 msgstr "（<b>耸肩</b>）我想我们没有别的选择了。"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:833
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:826
 msgid ""
 "Come on, guys, it will be great! Those orcs will never know what hit them! "
 "Together we’ll rip them to shreds! If you are planning to retire after this, "
@@ -4881,7 +4857,7 @@ msgstr ""
 "说！<b>“两个可怕的法师，从亡灵中现身，击溃了兽人的军队！”</b>"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:838
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:831
 msgid ""
 "Very well, Tallin. We accept under the terms that your people will forever "
 "leave us in peace after this."
@@ -4890,7 +4866,7 @@ msgstr ""
 "活。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:843
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:836
 msgid ""
 "Ro’Arthian, I am not of royal blood, but I am a man of my word. I will "
 "uphold the oath I have given even at the cost of my life."
@@ -4899,12 +4875,12 @@ msgstr ""
 "我也会遵守我的诺言。"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:848
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:841
 msgid "Very well. The orcish hosts shall feel our wrath!"
 msgstr "好吧，让兽人领袖尝尝我们的厉害吧！"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:853
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:846
 msgid ""
 "Wait a second, Tallin. Are you saying that we should abandon our homeland to "
 "these wretched mages?!"
@@ -4914,15 +4890,15 @@ msgstr "等一等，塔林。你是说要把我们的家园送给这些可恶的
 #. [message]: speaker=Ro'Sothian
 #. [message]: speaker=Eryssa
 #. [message]: id=Ro'Sothian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:858
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1057
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:526
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1019
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:851
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1050
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:522
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1018
 msgid "(<i>Snicker</i>)"
 msgstr "（<b>窃笑</b>）"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:863
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:856
 msgid ""
 "Chief Stalrag, it is said that to save a family, we should be willing to "
 "sacrifice one person; to save a town we should be willing to sacrifice a "
@@ -4932,12 +4908,12 @@ msgstr ""
 "镇，我们可以牺牲一个家庭；而为了保全一个国家，我们可以牺牲一个城镇。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:868
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:861
 msgid "Now, Stalrag, it is up to you. Do you want to save Knalga or not?"
 msgstr "现在，斯托莱格，轮到你了。你想挽救纳尔迦吗？"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:873
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:866
 msgid ""
 "Well Tallin, if you put it that way... We don’t like it, but if that’s what "
 "is needed to save Knalga, we shall do it."
@@ -4946,19 +4922,19 @@ msgstr ""
 "意。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:878
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:871
 msgid ""
 "Thank you, Stalrag. I am sure that the sacrifice of you and your people will "
 "always be remembered."
 msgstr "谢谢你，斯托莱格。我相信你和你的人民作出的牺牲将被永远铭记。"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:883
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:876
 msgid "(<i>Mumbles</i>) Yeah, great compensation..."
 msgstr "（<b>嘟囔</b>）是啊，很好的补偿……"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:888
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:881
 msgid ""
 "I have the power to control many creatures, such as gryphons, trolls and "
 "ogres. So while I am with you they shall be at your command."
@@ -4967,12 +4943,12 @@ msgstr ""
 "都会听命于你。"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:893
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:886
 msgid "The Shinsplitters will be at your service, Tallin."
 msgstr "敢死队也愿意听你调遣，塔林。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:898
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:891
 msgid ""
 "My thanks, Stalrag and Ro’Arthian. However, I have sufficient forces under "
 "my control presently and I think that merging our forces will just create "
@@ -4984,7 +4960,7 @@ msgstr ""
 "着，等需要的时候再说。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:908
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:901
 msgid ""
 "Great. Now let’s get back to the caves and start planning the best way teach "
 "those orcs a lesson they will never forget!"
@@ -4992,12 +4968,12 @@ msgstr ""
 "好极了。现在就让我们洞穴去，商议一下怎样才能给那些兽人上一堂永远难忘的课！"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:1012
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:1005
 msgid "Farewell, my friends. I now go to join my fallen brethren."
 msgstr "永别了，朋友们。我去和我死去的弟兄们团聚了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:1017
+#: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:1010
 msgid ""
 "No! If Stalrag dies now none of his men will follow us. We are finished."
 msgstr "如果斯托莱格死了他的人不会跟随我们了。"
@@ -5008,13 +4984,13 @@ msgid "Elvish Princess"
 msgstr "精灵公主"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:20
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:19
 msgid ""
 "After securing the help of the two lich-mages, the party returned to Knalga."
 msgstr "取得了两位法师的帮助后，部队返回了纳尔迦。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:25
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:24
 msgid ""
 "Och, that was a piece o’ good work, lad, getting both the lich-mages and "
 "Stalrag on our side. Now let’s plan our way to bringing Rakshas down..."
@@ -5023,14 +4999,14 @@ msgstr ""
 "克夏斯的方案……"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:27
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:26
 msgid ""
 "The lich-mages sent forth gryphons to scout out the number, formation and "
 "deployment of the orcish forces, and to seek allies as well."
 msgstr "法师派出了狮鹫侦察兽人军队的人数，编制和部署情况，顺便寻找盟友。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:30
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:29
 msgid ""
 "One day a gryphon came screeching into the caves with the news that a large "
 "elvish force approached from the east. Messages were quickly dispatched to "
@@ -5043,7 +5019,7 @@ msgstr ""
 "近的时候，矮人和人类最好躲在自己的洞里。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:33
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:32
 msgid ""
 "Before the humans and dwarves could respond to this message, another gryphon "
 "arrived with the news that the orcs were holding an elvish sorceress "
@@ -5057,7 +5033,7 @@ msgstr ""
 "目，因为它刚刚被重建过，并且由最老练最坚韧的兽人武装把守着。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:36
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:35
 msgid ""
 "Gryphons and a picked force of human woodsmen were sent out that very night, "
 "and less than two days later managed to ambush an orcish messenger on the "
@@ -5069,19 +5045,19 @@ msgstr ""
 "是个至高无上的公主。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:39
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:38
 msgid "The leaders met in council, considering what to do..."
 msgstr "领袖们又开会了，讨论下一步的作战方案……"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:42
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:41
 msgid ""
 "This kidnapped princess explains a great deal. It is not easy to draw the "
 "elves out of their forests."
 msgstr "这个被绑架的公主说明了很多问题。精灵们是不会轻易走出他们的森林的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:44
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:43
 msgid ""
 "Aye, lad. Her kin will have come either to do battle or pay ransom. By the "
 "looks of things, they’ve busked themselves for either."
@@ -5090,14 +5066,14 @@ msgstr ""
 "前的情况来看，他们同时做了这两手准备。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:46
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:45
 msgid ""
 "Pah! Who cares? Let the elves and orcs chop each other into mincemeat. It "
 "will just make things easier for us."
 msgstr "呸！管他呢。就让精灵和兽人打个天翻地覆去吧。这样对我们是有好处的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:48
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:47
 msgid ""
 "Hah! Yer brain has rotted awa’ entire. Think on it, skull-head, what would "
 "happen if the elves dinna’ fight and pay the ransom instead?"
@@ -5106,19 +5082,19 @@ msgstr ""
 "金，会怎么样？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:50
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:49
 msgid "Do you want to die, dwarf?"
 msgstr "小矮人，你想死吧？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:52
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:51
 msgid ""
 "Peace, peace! If you two want to kill something, there are plenty of orcs "
 "outside."
 msgstr "安静，安静！如果你们要出气门口有大量的兽人。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:54
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:53
 msgid ""
 "But you do have a point, Stalrag. That ransom will buy more troops and "
 "weapons for the orcs, and that is bad news for us."
@@ -5127,12 +5103,12 @@ msgstr ""
 "这对我们来说不是什么好消息。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:56
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:55
 msgid "I think we have a chance to make some new allies here..."
 msgstr "我想我们现在有一个结交新盟友的机会了……"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:58
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:57
 msgid ""
 "Allies? I take it we’re to go to them and ask them to join us in return for "
 "our help in rescuing their princess? You heard their message — those elves "
@@ -5144,19 +5120,19 @@ msgstr ""
 "不上我们。他们不会和像我们这样的人结盟的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:60
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:59
 msgid ""
 "Of course we won’t do that. As a matter of fact I think it’s best that we "
 "don’t say anything to the elves at all."
 msgstr "我们当然不要那么做。其实，我觉得我们最好什么也别对精灵说。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:62
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:61
 msgid "Why d’ye say that?"
 msgstr "这话从何说起？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:64
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:63
 msgid ""
 "Well, suppose we do join up with the elves — assuming they will let us — and "
 "we make a combined raid on the fortress, what will the orcs most likely do "
@@ -5166,14 +5142,14 @@ msgstr ""
 "联合突袭，如果兽人快要装进口袋的赎金溜走了，他们最可能会怎么做？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:66
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:65
 msgid ""
 "Kenning the way of orcs, they’d kill the princess, especially if it seems "
 "the rescue ha’ any chance of succeeding."
 msgstr "按照兽人的行事方式，他们会杀死公主，尤其是在营救有可能成功的情况下。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:68
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:67
 msgid ""
 "Exactly. On the other hand, if we raided the fortress while the orcs were "
 "talking ransom with the elves, the orcs might hesitate just long enough for "
@@ -5183,7 +5159,7 @@ msgstr ""
 "手不及，使得我们可以把她就出来。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:70
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:69
 msgid ""
 "Hmmm... I think you’ve the right of it, lad. Most orcs being thicker than a "
 "wood-knot, I’d lay odds on Rakshas giving strict orders that she not be "
@@ -5193,7 +5169,7 @@ msgstr ""
 "他的直接命令任何人都不能碰她。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:72
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:71
 msgid ""
 "But it would be unwise to trust that the orcs will stay stupid forever. If "
 "we do go ahead with this raid, we are going to have to be in and out like "
@@ -5203,22 +5179,17 @@ msgstr ""
 
 #. [story]
 #. My shinsplitters are invaluable for this kind of job. They are brave warriors and don't stop fighting until either they or their opponent lies dead. No fortress can stand against them.
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:74
-#, fuzzy
-#| msgid ""
-#| "My Shinsplitters be invaluable for this kind o’ job. They be braw "
-#| "warriors and dinna stop their assault till either they or their opponent "
-#| "lie dae. Nae a fortress ken stand against them."
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:73
 msgid ""
 "My Shinsplitters be invaluable for this kind o’ job. They be braw warriors "
 "and dinna stop their assault till either they or their opponent lie dae. Nae "
 "a fortress can stand against them."
 msgstr ""
-"我们的敢死队正合适。他们是勇敢的武士，在他们或对手倒下之前，他们不会停止攻"
-"击。他们攻无不克。"
+"咱的碎胫者干这活儿最拿手。他们都是勇猛的战士，不把自己或对手放倒就绝不罢休。"
+"没有堡垒能挡得住他们。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:76
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:75
 msgid ""
 "Ha ha, I like this plan! Once we get our hands on this little sorceress the "
 "elves will be forced to do whatever we want them to!"
@@ -5226,7 +5197,7 @@ msgstr ""
 "哈哈，我喜欢这个计划！当我们把这个公主掌握在自己手里时，精灵就不得不低头！"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:78
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:77
 msgid ""
 "Remember, Ro’Arthian, we need willing allies rather than resentful lackeys "
 "that would turn on us at the first chance. If we rescue their princess, the "
@@ -5237,7 +5208,7 @@ msgstr ""
 "还是值得一试的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:80
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:79
 msgid ""
 "Elves are deeply honor-bound, especially in matters that touch their kin. If "
 "we rescue the princess, I am certain the deed will not go without reward."
@@ -5246,19 +5217,19 @@ msgstr ""
 "我们会得到回报的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:82
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:81
 msgid ""
 "And at the very least, the orcs will not be able to raise troops with ransom "
 "money they don’t have."
 msgstr "至少，我们能让兽人拿不到那笔赎金，这样他们就不能用这钱征募军队了。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:84
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:83
 msgid "Bah... weak, soft humans. Have it your way if you must."
 msgstr "呸……软弱的人类。如果你坚持的话，那就按你说的办吧。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:86
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:85
 msgid ""
 "So it shall be, Tallin, I’ll hold the caves here while you and Stalrag’s "
 "Shinsplitters fare to Bitterhold. The orcs still haven’t given up their "
@@ -5268,81 +5239,81 @@ msgstr ""
 "有停止对我们南部隧道的入侵。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:88
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:87
 msgid "Then to arms, men!"
 msgstr "然后，武装起来，战士们！"
 
 #. [side]: type=Orcish Warlord, id=Atul
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:118
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:114
 msgid "Atul"
 msgstr "阿图"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:291
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:287
 msgid "Rescue the Princess"
 msgstr "救出公主"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:297
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:364
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:689
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:293
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:359
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:683
 msgid "Resist for as long as you can"
 msgstr "坚持尽可能久的时间"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:307
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:158
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:391
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:716
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:210
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:432
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:303
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:155
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:386
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:710
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:206
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:428
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:570
 msgid "Death of Ro’Arthian"
 msgstr "若·艾瑟恩死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:311
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:162
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:395
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:720
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:214
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:436
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:307
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:159
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:390
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:714
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:210
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:432
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:574
 msgid "Death of Ro’Sothian"
 msgstr "若·索瑟恩死亡"
 
 #. [note]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:321
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:317
 msgid "Even if your rescue fails, you will still advance to the next scenario."
 msgstr "即使你的营救失败了，你也仍然会进入下幕场景。"
 
 #. [note]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:324
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:320
 msgid ""
 "You will win this scenario immediately upon moving onto the hex containing "
 "the Princess’s cage."
 msgstr "进入包含关押公主的囚笼的六角格时，你将立即赢得此场景的胜利。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:335
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:331
 msgid ""
 "Upon emerging from the mouth of a hidden tunnel near the fortress, Tallin "
 "and his men surveyed the scene before them."
 msgstr "从要塞附近的一个隐秘的隧道口，塔林和部下们看清了周围的情况。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:340
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:336
 msgid ""
 "There’s the fortress of Bitterhold. A grim and impressive pile indeed..."
 msgstr "那就是苦门关要塞。确实是座冷酷的令人印象深刻的建筑……"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:345
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:341
 msgid "They have dammed the river to make a moat for their castle."
 msgstr "他们在城堡附近挖了一条护城河。"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:350
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:346
 msgid ""
 "Are we here to sight-see or to rescue this blasted sorceress? If you really "
 "want to sight-see, then check out that orcish encampment south of us."
@@ -5351,7 +5322,7 @@ msgstr ""
 "的兽人营地吧。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:355
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:351
 msgid ""
 "Just our luck to be here when they’re mustering a field force — probably to "
 "attack the caves. Avoid them if you can, kill them if you can’t."
@@ -5360,30 +5331,30 @@ msgstr ""
 "躲开他们，如果躲不开就杀死他们。"
 
 #. [message]: speaker=Atul
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:360
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:356
 msgid "INTRUDERS! KILL THEM!!"
 msgstr "入侵者！杀死他们！！"
 
 #. [unit]: type=Elvish Sorceress, id=Eryssa
 #. [modify_side]
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:388
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:120
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:379
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:384
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:117
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:375
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:430
 #: data/campaigns/Northern_Rebirth/utils/utils.cfg:192
 msgid "Eryssa"
 msgstr "伊蕊莎"
 
 #. [message]: race=orc
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:400
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:396
 msgid ""
 "The intruders are breaking in! Get to the walls and defend the fortress! And "
 "where did that elvish princess go?"
 msgstr "入侵者正在闯入！上城墙去，保卫要塞！精灵公主去哪了？"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:405
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:401
 msgid ""
 "(<i>hushed</i>) Thank you, my saviors. Who has come to rescue me from vile "
 "captivity?"
@@ -5392,7 +5363,7 @@ msgstr ""
 "谁？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:411
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:406
 msgid ""
 "(<i>whispering</i>) Later, my lady, first let’s get outta — uh, let us take "
 "our leave of this place as swiftly as may be!"
@@ -5400,19 +5371,19 @@ msgstr ""
 "(<b>低语</b>) 以后再说，公主。现在让我们快溜——呃，让我们尽快离开这个地方吧！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:416
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:411
 msgid "Lead; I will follow."
 msgstr "带路，我跟你走。"
 
 #. [message]: race=orc
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:437
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:432
 msgid ""
 "Hey, those intruders are going to free the elf! We can’t let that happen! "
 "Kill her! Kill the elf!"
 msgstr "嘿，那些入侵者是来救那个精灵的！我们不能让她跑了！杀了她！杀了那精灵！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:442
+#: data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg:437
 msgid "Darn it! We weren’t fast enough."
 msgstr "该死！我们太慢了。"
 
@@ -5422,39 +5393,39 @@ msgid "Introductions"
 msgstr "介绍"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:149
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:146
 msgid "Move Tallin to the Signpost in the north"
 msgstr "移动塔林至北方路标处"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:166
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:399
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:724
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:218
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:163
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:394
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:718
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:214
 msgid "Death of Eryssa"
 msgstr "伊蕊莎死亡"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:185
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:182
 msgid ""
 "After rescuing the Princess, Tallin and his allies quickly withdrew into the "
 "caves."
 msgstr "救出公主后，塔林一行迅速撤回洞穴中。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:190
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:187
 msgid ""
 "Now that we are well shot of that dungeon, do you mind telling me who you "
 "are?"
 msgstr "现在我们已经离开了那个监狱，你能告诉我你是谁吗？"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:200
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:197
 msgid "Sister! Don’t you recognize me?"
 msgstr "妹妹！你认不出我了？"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:205
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:202
 msgid ""
 "Gods of Light! Elenia! It’s you! It has been years! What in the world "
 "happened to you? We all had thought you dead!"
@@ -5463,19 +5434,19 @@ msgstr ""
 "了！"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:210
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:207
 msgid ""
 "Yes, I was afraid that would be your conclusion. What actually happened was "
 "that I was captured by an old bonebag of a lich."
 msgstr "是的，我担心那会是你们的结论。实际上我被一个老骷髅巫妖抓住了。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:215
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:212
 msgid "You mean Malifor?"
 msgstr "你是说玛利弗？"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:220
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:217
 msgid ""
 "None other. I was his prisoner for many years until these brave people "
 "rescued me. With all these orcs about it was far too dangerous to travel "
@@ -5486,29 +5457,29 @@ msgstr ""
 "独自回到精灵森林太危险了。而且为了报答这些勇敢的人，我从此一直跟随着他们。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:225
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:222
 msgid "Really, and who are these people?"
 msgstr "真的，那他们是些什么人？"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:230
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:227
 msgid "Here we have our leader and hero, Lord Tallin."
 msgstr "这是我们的领袖和大英雄，塔林领主。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:240
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:237
 msgid ""
 "He is the one who led his people in revolt against the orcs armed with "
 "nothing but pitchforks."
 msgstr "就是他领导众人用耙子抵抗兽人的统治。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:245
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:242
 msgid "Wow!"
 msgstr "喔！"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:250
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:247
 msgid ""
 "Then they scrounged up bows and cudgels from the dead orcs, and marched into "
 "the caves and broke the dwarves out from their encirclement by the undead "
@@ -5518,39 +5489,34 @@ msgstr ""
 "人。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:255
-#, fuzzy
-#| msgid ""
-#| "Then Tallin and his band hunted down Malifor and destroyed him. Now Lord "
-#| "Tallin is building an alliance of humans, dwarves, dead mages and "
-#| "whatever critters he can find to crush the orcs."
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:252
 msgid ""
 "Then Lord Tallin and his band hunted down Malifor and destroyed him. He is "
 "now building an alliance of humans, dwarves, dead mages and whatever "
 "critters he can find to crush the orcs."
 msgstr ""
-"塔林和他的部下又追捕并消灭了玛利弗。现在塔林领主建立了由人类，矮人，死灵法师"
-"组成的反对兽人的同盟军。"
+"而后，塔林领主和他的部下继续追猎玛利弗，并摧毁了他。塔林领主现在正在组建一个"
+"由人类、矮人、亡灵法师以及他能找到的随便什么生物组成的联盟，以击溃兽人。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:260
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:257
 msgid "You’re right, Elenia, Tallin is truly a hero."
 msgstr "你说的对，伊莱妮雅，塔林是个大英雄。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:265
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:262
 msgid ""
 "Not at all, Your Highness. I am no more than a humble peasant trying to free "
 "my people from enslavement."
 msgstr "过奖了，殿下。我只是个低微的农民，只想让乡亲们逃离奴役，获得自由罢了。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:270
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:267
 msgid "And a modest one too!"
 msgstr "他还是个谦逊的人！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:280
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:277
 msgid ""
 "Tallin, not only have you freed me and my sister from captivity, but you "
 "have defeated Malifor, who has long been a scourge to my people. By "
@@ -5560,12 +5526,12 @@ msgstr ""
 "中帮了北方所有的精灵。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:285
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:282
 msgid "Ahh, it was nothing, my lady."
 msgstr "啊，这算不上什么，公主。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:290
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:287
 msgid ""
 "No, it was far from nothing, Tallin. The Northern Elves will always be in "
 "your debt. Tell me, what can we do to repay you?"
@@ -5574,7 +5540,7 @@ msgstr ""
 "你？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:295
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:292
 msgid ""
 "As Elenia has said, we are currently locked in a death-struggle with the "
 "orcs led by a warlord named Rakshas. You could help us most by joining us in "
@@ -5584,7 +5550,7 @@ msgstr ""
 "们，最好的办法便是与我们一同作战，一劳永逸地消灭这个威胁。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:300
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:297
 msgid ""
 "That could hardly count as repayment of our debt to you, Tallin. This "
 "Rakshas is an enemy to every Northern Elf as well. Why, it can’t have been "
@@ -5597,7 +5563,7 @@ msgstr ""
 "是为了你们，也是为了我们自己。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:305
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:302
 msgid ""
 "My lady, we are not seeking to do business here: <i>“I do this for you, and "
 "you do this for me.”</i> No, we seek to build everlasting friendships which "
@@ -5609,7 +5575,7 @@ msgstr ""
 "和报答了。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:310
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:307
 msgid ""
 "Well and nobly spoken, Tallin. Very well, I shall join you in your quest to "
 "crush this orcish menace. Let gryphons immediately be sent to our people; I "
@@ -5620,7 +5586,7 @@ msgstr ""
 "我将用上我所有的影响力，为前方的战斗组建精灵部队。"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:316
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:312
 msgid ""
 "Er, Eryssa... there is a large elvish force moving this direction. By now "
 "they cannot be more than two days’ march from here. It seems that our father "
@@ -5630,7 +5596,7 @@ msgstr ""
 "们的父亲派他们来解救你，或者是赎你回来的。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:321
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:317
 msgid ""
 "Why did you not speak of this before? Let us immediately send out the "
 "gryphons with my personal seal telling them that I shall be taking command "
@@ -5640,12 +5606,12 @@ msgstr ""
 "我。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:326
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:322
 msgid "Sounds good— I mean, let it be so."
 msgstr "太好了——我的意思是，就这么办。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:334
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:330
 msgid ""
 "Not at all. I am Tallin, from the human town of Dwarven Doors. Together with "
 "the Dwarvish Lord Hamel and the mage Ro’Arthian and his brother, we are "
@@ -5655,12 +5621,12 @@ msgstr ""
 "以及他的弟弟，希望能够重建纳尔迦的和平与自由。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:339
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:335
 msgid "Uh huh. Good for you."
 msgstr "啊哈。很好嘛。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:344
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:340
 msgid ""
 "The only problem — or the major one, anyway — is these blasted orcs. They "
 "all have united under the leadership of this guy called Rakshas and are "
@@ -5672,12 +5638,12 @@ msgstr ""
 "和别的东西。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:349
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:345
 msgid "So what does this have to do with me?"
 msgstr "那么这和我有什么关系？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:354
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:350
 msgid ""
 "There is a large elvish force not far from here who — we believe anyway — "
 "has been sent to free you. We were hoping if we could secure your release "
@@ -5687,24 +5653,24 @@ msgstr ""
 "希望，要是我们能把你救出来，你可以帮我们摧毁兽人群。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:360
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:355
 msgid "Pff, foolish human. What in the world gave you that idea?"
 msgstr "呵呵，愚蠢的人类。你怎么会有这种想法？"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:365
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:360
 msgid "Ungrateful minx! I’m sorely tempted to break your neck!"
 msgstr "不知感恩的臭丫头！我真想把你的脖子拧断！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:370
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:365
 msgid ""
 "Make one move towards me, lich, and you’ll find yourself dangling off the "
 "end of a vine."
 msgstr "要是你敢动我，巫妖，你会发现你正往自己脖子上套绳圈。"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:375
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:370
 msgid ""
 "Leave her alone, lich! Rescuing her was a fool’s quest to begin with and "
 "attacking her won’t make the situation better. Especially an attack from an "
@@ -5714,97 +5680,97 @@ msgstr ""
 "了。特别是像你这样无能的人来袭击她！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:380
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:375
 msgid "Peace! Peace!"
 msgstr "镇定！镇定！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:385
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:380
 msgid ""
 "Well, what about the orcs then, <i>Princess</i>? Don’t you wish to be rid of "
 "them?"
 msgstr "好吧，那兽人怎么办，<b>公主</b>？你不想摆脱他们吗？"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:390
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:385
 msgid "How we deal with the orcs is none of your concern!"
 msgstr "怎么处理兽人轮不到你管！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:401
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:395
 msgid "What a little priss. She makes me want to fry her!"
 msgstr "这小妮子真娇气。我都想把她给炸了！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:406
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:400
 msgid "Mind your betters, mage!"
 msgstr "注意你的行为，法师！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:411
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:405
 msgid "Mind your tongue, elf!"
 msgstr "注意你的言语，精灵！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:418
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:412
 msgid ""
 "Frankly, my lady, I am disappointed. I was always under the impression that "
 "elves were an honorable lot who took their debts seriously."
 msgstr "坦白说，公主，我很失望。我的印象里，精灵是高贵的，把恩情看得很重要。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:423
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:417
 msgid ""
 "Who said that I wasn’t going to repay you? When I get back to the elves, we "
 "will give you five thousand gold for your trouble."
 msgstr "谁说我不会报答你们了？我回去之后，我们会付给你们五千金币作为辛苦费。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:428
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:422
 msgid "We already have a hoard of gold! We don’t need more!"
 msgstr "我们已经有了很多钱！我们不稀罕钱！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:433
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:427
 msgid "That is your concern, not mine, human."
 msgstr "那是你的事，和我无关，人类。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:438
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:432
 msgid "(<i>Sigh</i>) Oh well. It isn’t as if we weren’t expecting this."
 msgstr "（<b>叹息</b>）喔好吧。我们好像想到过会变成这样。"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:443
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:437
 msgid "See, I told you so!"
 msgstr "是吧，我早告诉你会这样了！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:448
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:442
 msgid ""
 "I know, you were right. I am sorry, Ro’Arthian. I should have listened to "
 "you."
 msgstr "我知道，你是对的。我很抱歉，若·艾瑟恩。我早该听你的话。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:453
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:447
 msgid "Well, it’s pointless to linger here. Let’s get back to Knalga."
 msgstr "好了，在这里逗留也没用。我们回纳尔迦吧。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:473
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:467
 msgid "Hey look, it’s a troll!"
 msgstr "嘿看呐，巨魔！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:478
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:472
 msgid ""
 "A troll? What in the world are trolls doing this close to Knalga? "
 "Something’s wrong, let’s hurry back."
 msgstr "巨魔？巨魔靠纳尔迦这么近是想干什么？出事了，我们赶快回去。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:497
+#: data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg:491
 msgid "I can see the dwarvish defenses just ahead. Let’s go!"
 msgstr "我看到矮人的防御工事就在前面不远处了。我们走！"
 
@@ -5814,7 +5780,7 @@ msgid "Stolen Gold"
 msgstr "金币失窃"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:29
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:27
 msgid ""
 "Puzzled by the presence of trolls so close to the dwarvish defenses, the "
 "party quickly made their way back to Knalga."
@@ -5823,7 +5789,7 @@ msgstr ""
 "迦。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:35
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:33
 msgid ""
 "Upon arriving there something seemed to be wrong. Instead of being "
 "boisterously hailed by the dwarves as before, they were met by silent guards "
@@ -5833,45 +5799,45 @@ msgstr ""
 "卫目光沮丧，沉默不语。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:38
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:36
 msgid "Fearing the worst, Tallin rushed to find Hamel."
 msgstr "塔林非常担心，他火速找到了哈梅尔。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:41
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:39
 msgid "Hamel, what is wrong?! Why is everyone acting so strangely?"
 msgstr "哈梅尔，怎么了？！为什么每个人看起来都怪怪的？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:43
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:41
 msgid ""
 "We are deeply ashamed of ourselves, Tallin. We ha’ failed the trust that ye "
 "gave us."
 msgstr "我们感到很惭愧，塔林。我们辜负了你的信任。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:45
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:43
 msgid "What do you mean?"
 msgstr "什么意思？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:47
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:45
 msgid "Yer gold, Tallin, we failed to protect it."
 msgstr "那些金币，塔林，我们没能保护好。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:49
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:47
 msgid "My gold!? Why, what happened? Start from the beginning."
 msgstr "我的金币！？发生了什么事？从头说起。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:51
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:49
 msgid ""
 "No sooner had ye left then the orcs once again launched a massive assault."
 msgstr "在你走后没多久，兽人就发动了一场大规模的突袭。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:53
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:51
 msgid ""
 "Such a massive and fierce assault it was that we had to call upon all our "
 "reserves. When that proved insufficient, we had nae other choice then to "
@@ -5881,7 +5847,7 @@ msgstr ""
 "所以只能放弃一些防御工事。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:55
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:53
 msgid ""
 "It was a ploy. Nae sooner than we ha’ thinned the ranks of the northern "
 "defenders, a small force of trolls smashed through the defenses and made "
@@ -5891,54 +5857,54 @@ msgstr ""
 "你的金币而去。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:57
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:55
 msgid ""
 "We beat them back, but not before they made off with your entire stock of "
 "gold."
 msgstr "我们击退了他们，但那是在他们抢走了你所有的金币储备之后。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:59
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:57
 msgid ""
 "I am sorry, Tallin, we did all that we could. I would we could ha’ done more."
 msgstr "对不起，塔林，我们尽了最大的努力。我们做了所有我们能做的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:61
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:59
 msgid "Oh no! Rakshas will raise many troops with that gold!"
 msgstr "噢，不！拉克夏斯会用那些金币扩充军力！"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:63
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:61
 msgid "Aye. Well I ken it, Tallin."
 msgstr "呃。这我知道，塔林。"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:70
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:68
 msgid ""
 "See, you wretched human! At least now you will appreciate the generosity of "
 "the elves."
 msgstr "看吧，可怜的人类！现在你们应该感谢精灵的慷慨了吧。"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:72
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:70
 msgid ""
 "Shut up, you little snot! If it wasn’t for you we wouldn’t have lost our "
 "gold in the first place!"
 msgstr "闭嘴，你这个讨厌的小鬼！如果不是为了你，我们的黄金怎么会丢！"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:74
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:72
 msgid "I wasn’t talking to you, lich! Learn to keep your mouth shut."
 msgstr "我没跟你说话，巫妖！你给我闭上嘴巴。"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:76
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:74
 msgid "Who is this annoying chit?"
 msgstr "这讨厌的小孩是谁？"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:78
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:76
 msgid ""
 "This is the famous and benevolent Princess Eryssa, in whose rescue we "
 "sacrificed many lives and <i>much</i> gold."
@@ -5947,7 +5913,7 @@ msgstr ""
 "b>金币。"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:80
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:78
 msgid ""
 "That’s it! I have had enough from you worthless rabble. I will soon send a "
 "rider with the promised gold, and in the meantime, I’m leaving!"
@@ -5956,23 +5922,23 @@ msgstr ""
 "现在，我要走了！"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:82
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:80
 msgid "Begone and good riddance, brat!"
 msgstr "滚开，闪边去，小鬼！"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:84
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:82
 msgid ""
 "Back to the issue of the stolen gold, were you able to pursue the trolls?"
 msgstr "回到黄金问题，你们有能力追巨魔吗？"
 
 #. [case]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:89
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:87
 msgid "Were you able to pursue them?"
 msgstr "为什么不去追他们？"
 
 #. [else]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:94
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:92
 msgid ""
 "This isn’t looking good. Not only do we fail to get the Princess but now we "
 "lost all of our gold! Seriously Hamel, I don’t know if we’re gonna make it."
@@ -5981,31 +5947,31 @@ msgstr ""
 "知道我们能不能成功了。"
 
 #. [else]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:96
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:94
 msgid ""
 "Don’t give in to despair, Tallin. At least you prevented the orcs from "
 "getting the ransom money."
 msgstr "不要失望，塔林。起码你让兽人拿不到赎金了。"
 
 #. [else]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:98
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:96
 msgid "Yeah, they ran off with all the rest of our gold instead."
 msgstr "是啊，然后他们带着我们的黄金逃走了。"
 
 #. [else]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:100
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:98
 msgid ""
 "Snap out of it Tallin! We are not in control of fate. We will do all we can "
 "to the best of our ability and leave the results to the gods."
 msgstr "行了，塔林！我们无法掌控命运。我们尽了全力，结果就看天意了。"
 
 #. [else]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:102
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:100
 msgid "You’re right, Hamel, sorry. Were you able to pursue the trolls?"
 msgstr "你说得对，哈梅尔，抱歉。你们去追巨魔了吗？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:106
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:104
 msgid ""
 "Och, we tried, Tallin, but with the orcs still pressing our southern "
 "defenses and trolls trying to break through everywhere, we simply ha’ not "
@@ -6015,17 +5981,17 @@ msgstr ""
 "破，我们实在抽不出人手来。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:108
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:106
 msgid "How long ago did the trolls make off with the gold?"
 msgstr "巨魔劫走金币多久了？"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:110
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:108
 msgid "It couldna’ ha’ been more than a day now."
 msgstr "我想还不到一天时间。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:112
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:110
 msgid ""
 "Then we shall pursue them. Even if we don’t catch them then we might be able "
 "to hit Rakshas before he has had a chance to put that gold to good use."
@@ -6033,32 +5999,32 @@ msgstr ""
 "我们去追吧。如果我们追不上他们，我们就进攻拉克夏斯，让他来不及用掉这些金币。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:114
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:112
 msgid ""
 "Hamel, rally the dwarves and prepare to make an all-out offensive against "
 "the orcs. It’s time to give them some of their own."
 msgstr "哈梅尔，集合矮人，准备对兽人展开全力进攻。让我们给他们一点教训。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:116
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:114
 msgid ""
 "We will follow the trail of the trolls; it should lead us back to Rakshas."
 msgstr "我们要沿着巨魔的脚印走，他会带我们找到拉克夏斯。"
 
 #. [then]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:124
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:122
 msgid "Eryssa, what news of the elves?"
 msgstr "伊蕊莎，精灵那边有什么消息吗？"
 
 #. [then]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:126
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:124
 msgid ""
 "Our gryphons have reached them. They are no more than a few days march from "
 "us."
 msgstr "狮鹫已经找到了精灵的军队，他们不出几日就可以赶到这里了。"
 
 #. [then]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:128
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:126
 msgid ""
 "I will send another message to them asking them to send out scouts to locate "
 "the trolls who took your gold. Mayhap the elves will be able to get between "
@@ -6068,12 +6034,12 @@ msgstr ""
 "接触他们的盟友之前截住他们。"
 
 #. [else]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:131
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:129
 msgid "It is well thought. May the Bright Gods be with you."
 msgstr "好计划，愿英明的神与你同在。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:135
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:133
 msgid ""
 "So it shall be. Hamel, when I make contact with the orcs I’ll send you a "
 "message. When you get it, come at all speed. It is near time for the battle "
@@ -6083,29 +6049,29 @@ msgstr ""
 "们。打一场决定性战役的时候到了。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:137
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:135
 msgid "The axes and hammers o’ every dwarf thirst for the blood of the orcs!"
 msgstr "每个矮人的斧子和铁锤都渴望着兽人的鲜血！"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:139
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:137
 msgid "All right, let’s move out, people!"
 msgstr "好的，伙计们，出发！"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:142
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:140
 msgid "Thus the party set off to the northern tunnels to pursue the trolls."
 msgstr "部队开拔，向北追击巨魔。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:145
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:143
 msgid ""
 "They met but light resistance all along the trail of the trolls, which they "
 "quickly overcame."
 msgstr "追击巨魔的途中只遇到了轻微的阻碍，他们很快就克服了。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:148
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:146
 msgid ""
 "Soon, the trail began to lead east, and then south. A few hours later the "
 "party emerged from the tunnels into dawn’s early light."
@@ -6114,74 +6080,74 @@ msgstr ""
 "隧道，出现在黎明的第一缕光线中。"
 
 #. [side]: type=Troll Warrior, id=Tor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:203
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:198
 msgid "Tor"
 msgstr "托"
 
 #. [side]: type=Troll Hero, id=Bor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:221
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:216
 msgid "Bor"
 msgstr "博"
 
 #. [side]: type=Troll Rocklobber, id=Oof
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:238
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:233
 msgid "Oof"
 msgstr "沃"
 
 #. [side]: type=Troll Hero, id=Glu
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:256
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:251
 msgid "Glu"
 msgstr "格鲁"
 
 #. [side]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:280
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:141
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:261
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:275
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:137
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:257
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:293
 #: data/campaigns/Northern_Rebirth/utils/characters.cfg:79
 msgid "Krash"
 msgstr "克莱什"
 
 #. [objective]: condition=lose
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:408
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:733
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:403
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:727
 msgid "Turns run out"
 msgstr "回合数耗尽"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:428
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:423
 msgid "Upon emerging from the tunnels, the party found themselves surrounded."
 msgstr "走出隧道后，他们发现自己被包围了。"
 
 #. [message]: speaker=Tor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:433
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:428
 msgid "Haha, suckers! We got you now!"
 msgstr "哈哈，笨蛋！上当了吧！"
 
 #. [message]: speaker=Bor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:438
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:433
 msgid "Hahaha! They walked right into our trap."
 msgstr "哈哈哈！他们进了我们的包围圈。"
 
 #. [message]: speaker=Glu
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:443
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:438
 msgid "And we have already sent the gold ahead to the Master!"
 msgstr "我们已经把金币运走了！"
 
 #. [message]: speaker=Oof
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:448
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:443
 msgid "Now let’s make mush out of these puny creatures!"
 msgstr "现在让我们把这些可怜的生物砸碎吧！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:453
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:448
 msgid "Oh no, we are surrounded!"
 msgstr "噢，不，我们被包围了！"
 
 #. [message]: speaker=Tallin
 #. This is an approximate quote from an Anglo-Saxon heroic poem
 #. the Lay of Beorthnoth. Translate appropriately.
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:460
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:455
 msgid ""
 "Courage shall be the harder, heart the keener, and our spirit greater as our "
 "strength lessens. Kill them all!"
@@ -6189,145 +6155,145 @@ msgstr ""
 "拿出更多的勇气，更强的决心。我们力量越小，我们的意志越要坚强。杀死他们！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:467
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:461
 msgid "Yeeahhh! I like it!"
 msgstr "耶耶耶！我喜欢！"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:482
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:476
 msgid "(<i>Sniff sniff</i>)"
 msgstr "（<b>嗅嗅</b>）"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:487
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:481
 msgid "What’s up big guy?"
 msgstr "大家伙，你怎么了？"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:492
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:486
 msgid "(<i>Flap flap flap</i>)"
 msgstr "（<b>拍打翅膀</b>）"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:517
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:511
 msgid "Hey! Where is he going?"
 msgstr "嘿！他要去哪？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:522
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:516
 msgid "Krash man, you’re gonna miss all the fun!"
 msgstr "克莱什，你会错过所有乐趣的！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:527
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:521
 msgid "I think he has decided that it is time to part ways with us."
 msgstr "我想他已经决定离开我们了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:532
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:526
 msgid "Such a fierce yet gentle creature. He will be sorely missed."
 msgstr "多好的家伙。失去他真令人伤心。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:537
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:531
 msgid "Farewell, Krash, may the Lords of Light guide your path."
 msgstr "祝你好运，克莱什，愿光明之神引导你的道路。"
 
 #. [unit]: type=Drake Burner, id=Singe
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:593
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:587
 msgid "Singe"
 msgstr "辛格"
 
 #. [unit]: type=Drake Fighter, id=Bak'man
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:611
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:605
 msgid "Bak’man"
 msgstr "贝克曼"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:622
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:616
 msgid "Hey! Look who’s back!"
 msgstr "嘿！看谁回来了！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:627
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:621
 msgid "And look, he brought his friends too!"
 msgstr "看，他还带来了他的朋友！"
 
 #. [message]: speaker=Bak'man
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:632
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:626
 msgid "GRRRR!"
 msgstr "啊啊啊啊！"
 
 #. [message]: speaker=Singe
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:637
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:631
 msgid "ROOAARRR!!"
 msgstr "吼吼吼！！"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:642
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:636
 msgid "Hurry, friends, let’s set up camp!"
 msgstr "快点，朋友们，建起营地！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:647
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:641
 msgid "Yeah, man! I knew we could count on you!"
 msgstr "呀，伙计！好样的！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:652
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:646
 msgid ""
 "Hmmm, he must have smelled the scent of other drakes and gone to them to "
 "convince them to help us."
 msgstr "他肯定是闻到了附近其他龙人的气味，然后说服他们来帮助我们。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:657
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:651
 msgid "Awww, what a darling!"
 msgstr "哇哇，太可爱了！"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:662
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:656
 msgid "Tell that to the trolls."
 msgstr "让巨魔知道厉害。"
 
 #. [message]: id=Oof,Tor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:667
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:661
 msgid "What?! Drakes?! Fire! Aagghh!"
 msgstr "什么！龙？！火！啊啊啊！"
 
 #. [message]: id=Glu,Bor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:672
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:666
 msgid "Shut your mouth, you coward!"
 msgstr "闭嘴，你这个胆小鬼！"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:698
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:705
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:692
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:699
 msgid "Help Tallin defeat the enemy leaders"
 msgstr "帮助塔林打败敌方首领"
 
 #. [unit]: id=Hidel, type=Elvish Marshal
 #. [unit]: type=Elvish Marshal, id=Hidel
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:764
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1080
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:290
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:758
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1073
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:286
 #: data/campaigns/Northern_Rebirth/utils/utils.cfg:200
 msgid "Hidel"
 msgstr "海达尔"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:786
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:780
 msgid "Your Highness! We have finally found you!"
 msgstr "殿下！我们终于找到你了！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:791
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:785
 msgid "Good work, Hidel! How do your forces march?"
 msgstr "好样的，海达尔！你的人都来了吗？"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:796
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:790
 msgid ""
 "They are all here, my lady! Hand picked by your father — the finest and "
 "bravest elvish troops in the entire Northlands. We will follow you to the "
@@ -6337,74 +6303,74 @@ msgstr ""
 "部队。若是有必要，我们会追随您直到世界的尽头。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:801
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:795
 msgid "Very good. Our first task is to give brave Tallin here full support."
 msgstr "非常好。我们的第一个任务就是全力支持勇敢的塔林。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:806
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:800
 msgid "With pleasure! Quickly, set up a base!"
 msgstr "不胜荣幸！快点，建起营地！"
 
 #. [message]: id=Oof,Glu,Tor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:822
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:816
 msgid ""
 "Oh no! Those blasted elves have joined forces with the humans! This is "
 "hopeless! Flee! Flee!"
 msgstr "不！那些勇猛的精灵也加入到人类的队伍当中了！我们没希望了！快跑吧！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:827
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:874
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:821
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:868
 msgid "Hmmm, should we let the trolls run away or should we finish them now?"
 msgstr "嗯，是让巨魔逃跑还是现在就解决他们？"
 
 #. [option]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:829
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:876
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:823
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:870
 msgid "Hey! Stand your ground, you cowards!"
 msgstr "嘿！站在那别想跑，胆小鬼！"
 
 #. [message]: speaker=Bor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:833
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:827
 msgid "You are a fool, human! We shall crush and destroy you!"
 msgstr "你太傻了，人类！我们完全能够摧毁你们！"
 
 #. [option]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:842
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:889
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:836
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:883
 msgid "Haha! Look at them run!"
 msgstr "哈哈！看他们跑了！"
 
 #. [message]: id=Oof,Glu,Tor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:869
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:863
 msgid ""
 "Oh no! The elves have given the humans a hoard of gold! This is hopeless! "
 "Flee! Flee!"
 msgstr "不！那些精灵给了人类一堆黄金！我们没希望了！快跑！快跑！"
 
 #. [message]: speaker=Bor
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:880
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:874
 msgid "You are a fool, human! We will crush and destroy you!"
 msgstr "你太傻了，人类！我们完全能够摧毁你们！"
 
 #. [unit]: id=Himadrin, type=Elvish Outrider
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:914
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:908
 msgid "Himadrin"
 msgstr "辛玛则林"
 
 #. [message]: speaker=Himadrin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:921
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:915
 msgid "Which one of you rabble is Tallin?"
 msgstr "你们这些暴徒中，谁是塔林？"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:926
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:920
 msgid "I am."
 msgstr "是我。"
 
 #. [message]: speaker=Himadrin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:931
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:925
 msgid ""
 "Princess Eryssa sends you this gold along with the order to stay clear of "
 "any Northern Elf if you know what’s good for you."
@@ -6413,12 +6379,12 @@ msgstr ""
 "远点。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:936
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:930
 msgid "Why? What did I ever do to the Northern Elves?"
 msgstr "为什么？我对北方精灵做了什么吗？"
 
 #. [message]: speaker=Himadrin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:941
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:935
 msgid ""
 "The ill treatment that she received while in your care is an insult to every "
 "Northern Elf. Consequently if you, or any of your henchmen show your face "
@@ -6428,56 +6394,56 @@ msgstr ""
 "个杀一个。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:951
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:945
 msgid ""
 "Tell the Princess to get off her high horse and stop acting like such a "
 "priss!"
 msgstr "告诉公主，别摆什么臭架子，也别再这么娇气了！"
 
 #. [message]: speaker=Himadrin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:956
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:950
 msgid "You dare insult our princess!"
 msgstr "你胆敢对公主无理！"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:961
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:955
 msgid "You better get lost, elf, before we kill you."
 msgstr "你们最好开溜，精灵，免得死在这里。"
 
 #. [message]: speaker=Himadrin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:966
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:960
 msgid ""
 "This insult will forever be remembered by the Northern Elves! The day will "
 "soon come when your race shall regret your folly!"
 msgstr "北方精灵会永远记住这个侮辱的！你们很快就会为自己的行为感到后悔！"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:983
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:976
 msgid "Pff, elves. What a bunch of stuck-up snots!"
 msgstr "呸，精灵。烦人的自命不凡的讨厌鬼！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1017
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1010
 msgid "Phew, they are defeated at last."
 msgstr "啊，终于打败他们了。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1022
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1015
 msgid "Hidel, let me introduce to you my savior: Tallin."
 msgstr "海达尔，让我介绍我的救命恩人：塔林。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1027
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1020
 msgid "It is an honor to meet you, Tallin."
 msgstr "非常荣幸见到你，塔林。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1032
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1025
 msgid "The honor is mine, sir."
 msgstr "我也非常荣幸，先生。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1037
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1030
 msgid ""
 "We have heard much of your intelligence and courage. The number of humans "
 "over the centuries who have earned the respect and admiration of the "
@@ -6488,51 +6454,51 @@ msgstr ""
 "敬与欣赏，而你就是其中一个。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1042
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1134
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1035
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1127
 msgid ""
 "I am honored, sir, and I hope that I will live up to the trust that the "
 "Northern Elves have bestowed upon me."
 msgstr "我很荣幸，先生。我此生都会珍惜北方精灵的这份信任。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1047
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1040
 msgid "I am sure you will, Tallin. The trust of the elves is seldom misplaced."
 msgstr "我相信你会的，塔林。北方精灵不会信错人。"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1052
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1045
 msgid "If you lot are quite finished exchanging pleasantries..."
 msgstr "要是你们已经打完招呼的话……"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1062
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1055
 msgid ""
 "... the road ahead is clear and I am eager to blast some more orcs. Shall we "
 "proceed?"
 msgstr "……前路已经清理完毕，我迫不及待想要多杀几个兽人。我们该前进吗？"
 
 #. [message]: speaker=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1067
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1060
 msgid "Yeah, let’s get on with it!"
 msgstr "好的，我们继续吧！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1072
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1065
 msgid "Right. Onward, men!"
 msgstr "说得对，前进，战士们！"
 
 #. [unit]: type=Elvish Avenger, id=Sisal, gender=female
 #. [side]: type=Elvish Avenger, gender=female, id=Sisal
 #. [modify_side]
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1092
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:141
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1085
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:137
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:449
 msgid "Sisal"
 msgstr "茜萨尔"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1109
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1102
 msgid ""
 "Your Highness! We have finally found you! Thank the Bright Gods you are "
 "free! Your father had originally sent us to rescue you."
@@ -6540,24 +6506,24 @@ msgstr ""
 "殿下！我们终于找到您了！感谢光明之神，您自由了！您的父亲原是派我们来救您的。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1114
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1107
 msgid ""
 "Yes, or so I have heard. You honor me, but this brave man reached the mark "
 "before you."
 msgstr "是的，我听说了。但是这个勇敢的人已经先行把我救出了。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1119
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1112
 msgid "You must be the famous Tallin."
 msgstr "您肯定是著名的塔林。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1124
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1117
 msgid "At your service."
 msgstr "您好。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1129
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1122
 msgid ""
 "We have heard much of your intelligence and courage. The number of humans "
 "over the centuries who have earned the respect and admiration of the "
@@ -6567,7 +6533,7 @@ msgstr ""
 "敬与欣赏，而你就是其中一个。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1139
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1132
 msgid ""
 "I am sure you will, Tallin. The trust of the elves is seldom misplaced. Also "
 "know that the Northern Enclaves will always be open to you."
@@ -6575,17 +6541,17 @@ msgstr ""
 "我相信你会的，塔林。北方精灵很少信错人。我们在北方的领地永远向你敞开大门。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1144
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1137
 msgid "Thank you, sir."
 msgstr "谢谢，先生。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1149
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1142
 msgid "What is the status of our troops, Hidel?"
 msgstr "我们的部队怎样，海达尔？"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1154
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1147
 msgid ""
 "They are all here, my lady! Hand picked by your father — the finest and "
 "bravest elvish troops in the entire Northlands."
@@ -6594,7 +6560,7 @@ msgstr ""
 "部队。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1159
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1152
 msgid ""
 "Excellent! We shall assist Tallin to the fullest in crushing the orcish "
 "host. Not only are we in debt to him but by doing so we will be serving our "
@@ -6604,12 +6570,12 @@ msgstr ""
 "对我们和对他都一样重要。"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1164
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1157
 msgid "As you wish, my lady."
 msgstr "如您所愿，公主。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1169
+#: data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg:1162
 msgid "Very well, people. The road ahead is clear, onward to victory!"
 msgstr "很好，战士们。我们前路坦荡，向胜利进军！"
 
@@ -6626,7 +6592,7 @@ msgid ""
 msgstr "在冲出了包围后，他们继续追赶巨魔。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:24
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:23
 msgid ""
 "Following the bank of a river, they soon entered a valley. At the mouth of "
 "the valley there loomed the massive orcish fortress of Angthurim."
@@ -6635,39 +6601,39 @@ msgstr ""
 "瑟林。"
 
 #. [side]: type=Troll Warrior, id=Gore
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:56
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:52
 msgid "Gore"
 msgstr "格尔"
 
 #. [side]: type=Orcish Warlord, id=Carron
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:82
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:78
 msgid "Carron"
 msgstr "卡伦"
 
 #. [side]: type=Orcish Warlord, id=Rash
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:98
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:94
 msgid "Rash"
 msgstr "拉什"
 
 #. [side]: type=Orcish Warlord, id=Al'Mar
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:114
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:110
 msgid "Al’Mar"
 msgstr "沃莫"
 
 #. [side]: type=Orcish Warlord, id=Ha'Tang
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:130
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:126
 msgid "Ha’Tang"
 msgstr "哈唐"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:272
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:268
 msgid ""
 "Gods of Light, look at that fortress! The castle Angthurim is even grimmer "
 "than its reputation!"
 msgstr "光明之神，看看那个要塞！安格瑟林远比他的名气可怕！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:283
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:279
 msgid ""
 "I was not idle in my captivity; I watched, and listened, and learned. The "
 "hints I got from my guards’ boastings and foul jests have been confirmed by "
@@ -6679,7 +6645,7 @@ msgstr ""
 "如果我们拿下它，兽人的防御体系就会接近崩溃了。"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:298
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:294
 msgid ""
 "Fitting. My gryphons tell me Angthurim is the keystone of their entire "
 "eastern flank. If we can destroy it their defense will be near to collapse."
@@ -6688,27 +6654,27 @@ msgstr ""
 "线就濒临崩溃了。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:305
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:301
 msgid "Hey, look who is here!"
 msgstr "看，谁在这！"
 
 #. [message]: speaker=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:311
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:307
 msgid "Where is my gold?!"
 msgstr "我的金币呢？！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:316
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:312
 msgid "It’s Rakshas!"
 msgstr "是拉克夏斯！"
 
 #. [message]: speaker=Gore
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:321
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:317
 msgid "Right here, Master."
 msgstr "这呢，主人。"
 
 #. [message]: speaker=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:326
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:322
 msgid ""
 "Ahhhhh, very good, my loyal servant. You will be richly rewarded for this! "
 "Tell me, what news do you have on that human vermin that has so persistently "
@@ -6718,36 +6684,36 @@ msgstr ""
 "吗？"
 
 #. [message]: speaker=Gore
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:331
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:327
 msgid ""
 "We trapped him and his pitiful band of followers. By now they will have been "
 "mashed to paste and fed to the whelps."
 msgstr "我们设立个圈套，他们中计了。他们现在应该已经成为一堆白骨了。"
 
 #. [message]: speaker=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:336
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:332
 msgid "Hahahaha! Very g—"
 msgstr "哈哈哈哈！非常——"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:341
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:337
 msgid "<big>RAKSHAS!!</big>"
 msgstr "<big>拉克夏斯！！</big>"
 
 #. [message]: speaker=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:346
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:342
 msgid ""
 "What?! YOU! YOU ANNOYING, DISGUSTING LITTLE VERMIN! DON’T YOU KNOW HOW TO "
 "DIE?!"
 msgstr "什么？！是你！你这个烦人的，恶心的小臭虫！你怎么还不死？！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:351
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:347
 msgid "Foul one, the only one who will be dying here is you. Stand and fight!"
 msgstr "傻瓜，该死的是你。起身战斗！"
 
 #. [message]: speaker=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:356
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:352
 msgid ""
 "Bah! I have better things to do than stamp out your insignificant life. "
 "Generals, bring me his head!"
@@ -6756,7 +6722,7 @@ msgstr ""
 "我！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:393
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:389
 msgid ""
 "Blast it! The coward has fled. Eryssa, your elves are good at moving quickly "
 "through the forests. Do you think they can overtake him while we deal with "
@@ -6766,94 +6732,94 @@ msgstr ""
 "这个要塞的时候，他们能追上他吗？"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:398
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:394
 msgid "Hidel?"
 msgstr "海达尔？"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:403
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:399
 msgid ""
 "Easily, Your Highness. We shall move unseen through the trees, overtake him, "
 "and put an end to his flight."
 msgstr "这不难，殿下。我们可以在树之间匿踪行进，追上他，给他的征程画上终止符。"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:408
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:404
 msgid ""
 "Then do it. I shall stay with Tallin and... um... because he could use my "
 "assistance."
 msgstr "去做吧。我会留下来和塔林在一起……嗯……他可能需要我的帮助。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:413
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:409
 msgid "(<i>Blushes slightly</i>)"
 msgstr "（<b>面颊微微羞红</b>）"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:418
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:414
 msgid "(<i>Wink wink</i>)"
 msgstr "（<b>眨眼眨眼</b>）"
 
 #. [message]: speaker=Hidel
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:423
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:419
 msgid "(<i>Raises eyebrow</i>) Very well, my lady."
 msgstr "（<b>挑了挑眉毛</b>）遵命，公主。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:455
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:451
 msgid ""
 "Blast it. The coward has fled. Quickly men, we must storm this fortress "
 "before he can spend that gold."
 msgstr "该死。那个胆小鬼跑了。快点，在他动用那笔金币之前我们必须攻下城堡。"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:461
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:457
 msgid "Aye! Down wi’ the orcs!"
 msgstr "没错！拿下兽人！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:468
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:464
 msgid "Ro’Arthian, send a message to Hamel. Tell him it’s time."
 msgstr "若·艾瑟恩，给哈梅尔传信。让他行动。"
 
 #. [message]: speaker=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:492
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:488
 msgid "It’s done."
 msgstr "好了。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:497
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:493
 msgid "Very well. Forward! Victory or death!"
 msgstr "很好。前进！取胜或战死沙场！"
 
 #. [message]: speaker=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:502
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:498
 msgid "Come on boys, let’s give it to ’em!"
 msgstr "来吧，让他们去死！"
 
 #. [message]: speaker=Gore
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:511
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:507
 msgid "Move, you stupid orcs! I am trying to recruit here!"
 msgstr "快点，你们这些傻瓜兽人！我要在此征募新兵！"
 
 #. [message]: speaker=Rash
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:516
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:512
 msgid "Suit yourself, you dumb troll!"
 msgstr "管好你自己，多嘴的巨魔！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:521
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:517
 msgid ""
 "Awww, aren’t they the most loving, sharing bunch of orcs you have ever seen?"
 msgstr "噢，他们是不是你们见过的最有爱，最喜欢分享的兽人？"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:536
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:532
 msgid "We have torn the heart from their eastern defenses."
 msgstr "我们已经从东部防线撕开了他们的心脏。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:546
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:542
 msgid ""
 "Now let us make haste to rescue Hidel. I am uneasy for him; some of those "
 "bodyguards Rakshas keeps are fell fighters."
@@ -6861,7 +6827,7 @@ msgstr ""
 "我们快去协助海达尔。我很担心他。拉克夏斯卫队中的一些人是十分勇猛的战士。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:557
+#: data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg:553
 msgid "Now to settle scores with Rakshas once and for all!"
 msgstr "现在是以牙还牙报复拉克夏斯的时候了！"
 
@@ -6871,14 +6837,14 @@ msgid "Get the Gold"
 msgstr "夺回金币"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:26
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:25
 msgid ""
 "After conquering Castle Angthurim, the party set off after Rakshas, hoping "
 "that Hidel’s elves had been able to hold him."
 msgstr "攻陷安格瑟林城堡后，部队继续追击拉克夏斯，希望海达尔的精灵能够抓住他。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:30
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:29
 msgid ""
 "Orcs are heavy-footed creatures; Rakshas’s trail was readily followed. But "
 "an ominous silence, broken only by the cawing of ravens, brooded over the "
@@ -6888,7 +6854,7 @@ msgstr ""
 "鸦飞过，凄厉的叫声划破了这安静。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:33
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:32
 msgid ""
 "Soon they encountered the wrack of a great battle. Bodies of elves and orcs "
 "lay everywhere. Broken weapons and smashed armor were strewn about and "
@@ -6899,7 +6865,7 @@ msgstr ""
 "盔甲散落一地，精灵的箭和兽人的弩插在树上。大地被鲜血染红了。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:36
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:35
 msgid ""
 "There were some survivors. Father Morvin oversaw their healing, while Tallin "
 "followed Eryssa as she anxiously walked among the dead."
@@ -6907,14 +6873,13 @@ msgstr ""
 "有一些幸存者。莫文神父负责他们的治疗，而在伊蕊莎焦虑不安地在死者间走着时，塔"
 "林跟随着她。"
 
-# Translated by ollama with model glm4
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:39
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:38
 msgid "Suddenly, Eryssa cried out. In front of her lay Hidel."
 msgstr "突然，伊蕊莎尖叫起来。在她面前躺着海达尔。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:42
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:41
 msgid ""
 "Scattered around him were the bodies of at least three orcish warlords, and "
 "nearly a score of grunts, warriors and crossbowmen. His weapons were notched "
@@ -6927,7 +6892,7 @@ msgstr ""
 "争。他的勇敢值得同族人永远传诵。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:46
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:45
 msgid ""
 "With tears streaming down her face, Eryssa knelt and cradled his head in her "
 "lap. As she stroked his face, his eyes fluttered open."
@@ -6936,7 +6901,7 @@ msgstr ""
 "睛慢慢睁开了。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:49
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:48
 msgid ""
 "I am sorry, my lady... We held him for... as long as we could... but his "
 "bodyguards... were... just too many and powerful... And then... the "
@@ -6946,7 +6911,7 @@ msgstr ""
 "援部队到了……"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:52
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:51
 msgid ""
 "Her face streaked with tears, Eryssa gazed imploringly at Father Morvin and "
 "Sister Thera. They sighed and shook their heads. In a broken voice Eryssa "
@@ -6956,19 +6921,19 @@ msgstr ""
 "蕊莎哭着对他说："
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:55
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:54
 msgid "Hidel, I am sorry. I have sent you to your death."
 msgstr "海达尔，对不起，是我害死你的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:57
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:56
 msgid ""
 "... Don’t tax yourself... Eryssa... I have died... a warrior’s death... You "
 "should be proud..."
 msgstr "……别责备自己……伊蕊莎……作为一名武士……我死得其所……您应该感到骄傲……"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:59
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:58
 msgid ""
 "... But... there is... one thing... we... could do. We... managed to... "
 "recover the gold... Sisal... took it and... retreated south..."
@@ -6977,7 +6942,7 @@ msgstr ""
 "了……"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:61
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:60
 msgid ""
 "I held out as... long as... I could... but they... defeated us... Rakshas "
 "went... east and the... rest... went... after... Sisal..."
@@ -6986,7 +6951,7 @@ msgstr ""
 "着……茜萨尔去了……"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:63
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:62
 msgid ""
 "Now... uphold the honor... of the Northern... Elves... Recover... the "
 "gold... slay this monster... and bring peace... to the... Northlands... "
@@ -6996,19 +6961,19 @@ msgstr ""
 "北陆……塔林？"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:66
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:65
 msgid ""
 "At Hidel’s call Tallin approached. He knelt beside, bowing his head in "
 "respect."
 msgstr "听到海达尔的呼唤，塔林走了过去。他跪在旁边，尊敬地低下头。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:69
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:68
 msgid "At your service, sir."
 msgstr "愿意为你效劳，先生。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:71
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:70
 msgid ""
 "Eryssa has been... my charge ever... since she was born... I now return... "
 "to the earth... from which... I sprang... Please take care... of her."
@@ -7017,31 +6982,31 @@ msgstr ""
 "好……她。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:73
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:72
 msgid "I will."
 msgstr "我会的。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:75
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:74
 msgid ""
 "Thank you... Tallin... Now I may rest... in... peace... May you... be "
 "victorious..."
 msgstr "谢谢你……塔林……我现在……要休息了……祝你……取得胜利……"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:78
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:77
 msgid "Then Hidel closed his eyes and took one last breath."
 msgstr "然后海达尔闭上眼睛，吸了最后一口气。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:82
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:81
 msgid ""
 "Slowly Tallin approached her. He hesitated before wrapping her gently in his "
 "arms."
 msgstr "慢慢地，塔林靠近她。他犹豫了一下，将她温柔地拥入怀中。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:86
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:85
 msgid ""
 "Sobbing against Tallin’s chest, Eryssa told him of the many ways Hidel had "
 "cherished and warded her and her sister. How he had comforted their "
@@ -7053,16 +7018,17 @@ msgstr ""
 "的故事。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:89
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:88
 msgid ""
 "The torrent of childhood memories and the depth of her grief left her unable "
-"to speak. She and Tallin sat together silently holding each-other for some "
+"to speak. She and Tallin sat together silently holding each other for some "
 "time."
 msgstr ""
-"童年的记忆滔滔不绝涌上心头，但悲伤让她无法开口，她和塔林静静的拥抱了一会儿。"
+"童年记忆的涌流与深沉的悲伤，让她无法开口。她和塔林静静地坐在一起，拥抱了一会"
+"儿。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:92
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:91
 msgid ""
 "As Tallin comforted Eryssa, the surviving elves gathered all of the fallen "
 "warriors, and with the humans’ help, laid them to rest. For Hidel, the "
@@ -7074,7 +7040,7 @@ msgstr ""
 "们来到塔林和伊蕊莎面前。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:95
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:94
 msgid ""
 "My lady... it is a hard thing, I know, but you must put your grief behind "
 "you. Or at least, put it aside for a little while. We must go quickly to the "
@@ -7084,14 +7050,14 @@ msgstr ""
 "们必须赶去帮助茜萨尔，并找回金币。"
 
 #. [story]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:97
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:96
 msgid ""
 "Forge your sorrow into rage, girl, and visit it on the slayers of your "
 "kinsmen. Teach them what happens to those who make an enemy of an elf."
 msgstr "把悲伤忘掉吧，孩子，我们要去找杀人凶手报仇。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:100
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:99
 msgid ""
 "At these words, Eryssa arose and wiped away her tears. She took command of "
 "the surviving elvish forces, for all knew she was a princess of high rank "
@@ -7105,7 +7071,7 @@ msgstr ""
 
 #. [part]
 #. "espied" is correct here, it's a deliberate archaism
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:105
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:104
 msgid ""
 "Moments later a gryphon swooped down from overhead and reported battle in a "
 "forest just a few leagues south of their position. The remainder of the "
@@ -7115,56 +7081,56 @@ msgstr ""
 "精灵正在和兽人惨烈地战斗着。"
 
 #. [part]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:108
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:107
 msgid ""
 "It seemed to the gryphon that the elves were sore beset. The party quickly "
 "turned south and plunged into the forest."
 msgstr "看来那些精灵被围攻了。部队迅速转向南部，钻进了森林。"
 
 #. [side]: type=Orcish Warlord, id=Ha'Tuil
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:187
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:183
 #: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:110
 msgid "Ha’Tuil"
 msgstr "哈图尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:424
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:420
 msgid "Defeat the orcs"
 msgstr "击败兽人"
 
 #. [note]
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:443
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:439
 msgid "You will not receive any gold if Sisal dies."
 msgstr "如果茜萨尔死亡，你将不会得到任何金币。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:459
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:455
 msgid ""
 "After several hours of hard travel the party arrived at the battle scene."
 msgstr "经过几个小时的艰苦跋涉，部队赶到了战场。"
 
 #. [message]: id=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:464
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:460
 msgid "Sisal, how do you fare?"
 msgstr "茜萨尔，进展如何？"
 
 #. [message]: id=Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:469
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:465
 msgid "Your Highness! You are here! How fares Hidel?"
 msgstr "殿下！您来了！海达尔怎样了？"
 
 #. [message]: id=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:474
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:470
 msgid "(<i>Sheds a tear</i>)"
 msgstr "（<b>流下了泪</b>）"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:479
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:475
 msgid "Hidel... died a hero’s death, one worthy to be sung forever."
 msgstr "海达尔……牺牲了，他是个英雄，我们要永远地歌颂他。"
 
 #. [message]: id=Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:484
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:480
 msgid ""
 "The dung-spawned bastards! Verily, had it not been for Hidel we would all be "
 "dead and Rakshas would be gleefully counting his gold."
@@ -7173,7 +7139,7 @@ msgstr ""
 "斯现在正开心地数着金币。"
 
 #. [message]: id=Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:489
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:485
 msgid ""
 "Hidel and a handful of elves held off the orcs for more than an hour. That "
 "was enough time for us to make off with the gold and rally here at these "
@@ -7181,60 +7147,60 @@ msgid ""
 msgstr "海达尔和他的部下拖住了兽人一个多小时，我们才得以带着金币逃到这里碰面。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:494
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:490
 msgid "So you have the gold?"
 msgstr "那就是说，你拿到金币了？"
 
 #. [message]: id=Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:499
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:495
 msgid ""
 "We have the gold, and now we shall have the blood of these orcs! IN HIDEL’S "
 "NAME!"
 msgstr "我们拿到了金币，现在我们要向兽人索回血债！为海达尔报仇！"
 
 #. [message]: id=Ha'Tuil
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:505
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:500
 msgid ""
 "Grrr, Ha’Tuil has never failed in his mission. I will soon lay your severed "
 "heads at the feet of the Master!"
 msgstr "叽，哈图尔执行任务从未失败过。我很快就会把你们的头摆在主人脚边！"
 
 #. [message]: id=Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:510
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:505
 msgid ""
 "You will eat cold steel and whimper your way to hell, foul wretch of an orc!"
 msgstr "我们要杀死所有的兽人！"
 
 #. [message]: id=Ha'Tuil
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:523
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:518
 msgid "Argh! I have failed!"
 msgstr "啊！我失败了！"
 
 #. [message]: id=Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:528
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:523
 msgid ""
 "Cheer up — you won’t have to live with your failure for long... (<i>Snicker</"
 "i>)"
 msgstr "高兴点儿——你那失败的人生就快要结束了……（<b>窃笑</b>）"
 
 #. [message]: id=Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:543
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1079
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:538
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1078
 msgid "Ahhhh! Farewell, friends. I now go to join Hidel."
 msgstr "啊！再见了，朋友们。我现在去见海达尔了。"
 
 #. [message]: id=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:548
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:543
 msgid "Sisal! Noooo!"
 msgstr "茜萨尔！不！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:553
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:548
 msgid "Haha! We got the gold now!"
 msgstr "哈哈！我们现在得到了金币！"
 
 #. [message]: id=Ha'Tuil
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:558
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:553
 msgid ""
 "Hahaha! Mission accomplished! I’ll send a wolf to the Master to deliver the "
 "gold. Now let’s crush the rest of this scum!"
@@ -7243,7 +7209,7 @@ msgstr ""
 "吧！"
 
 #. [message]: id=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:570
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:565
 msgid ""
 "I don’t think so, you bastard orcs! That gold belongs to us. Besides, we now "
 "have a few scores to settle with you. Take them, troops! I want no orc left "
@@ -7253,7 +7219,7 @@ msgstr ""
 "账要算。干掉他们，战士们！一个活的兽人都不要留下！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:584
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:579
 msgid ""
 "Thanks to Hidel and the elves, we have recovered our gold. Now let’s run "
 "down Rakshas and end this once and for all."
@@ -7262,7 +7228,7 @@ msgstr ""
 "束这一切。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:590
+#: data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg:585
 msgid ""
 "Hidel’s death was a grievous loss; our thirst for vengeance must do what the "
 "stolen gold cannot. Now let’s run down Rakshas and settle this once and for "
@@ -7447,7 +7413,7 @@ msgid "We don’t have any eyeballs, you idiot!"
 msgstr "我们没有眼珠，白痴！"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:870
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:869
 msgid ""
 "PAH! You fools, know that you shall soon be outnumbered and surrounded. At "
 "this very moment my entire western army is marching this way. They will soon "
@@ -7457,74 +7423,74 @@ msgstr ""
 "日就来了！"
 
 #. [message]: id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:924
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:923
 msgid "Will they, now?"
 msgstr "他们真的回来吗？"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:928
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:927
 msgid "<i>What</i>?!"
 msgstr "<b>什么</b>？！"
 
 #. [message]: id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:932
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:931
 msgid ""
 "Your western army has been slaughtered, Rakshas, and <i>you</i> will soon "
 "join them!"
 msgstr "你的西部大军已经被消灭了，拉克夏斯，<b>你</b>很快就能和他们相见了！"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:936
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:935
 msgid "But... but... how can this be?"
 msgstr "这……这……怎么会这样？"
 
 #. [message]: id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:940
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:939
 msgid "It’s called ‘The End’, foul orc. Forward! FOR KNALGA!!"
 msgstr "这就叫“穷途末路”，笨兽人。进攻！<b>为了纳尔迦！！</b>"
 
 #. [message]: id=Krash
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:944
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:943
 msgid "FOR FRIENDSHIP!!"
 msgstr "<b>为了友谊！！</b>"
 
 #. [message]: id=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:948
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:947
 msgid "FOR PEACE!!"
 msgstr "<b>为了和平！！</b>"
 
 #. [message]: id=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:953
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:952
 msgid "FOR FUN!"
 msgstr "<b>为了乐趣！</b>"
 
 #. [message]: id=Eryssa,Sisal
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:957
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:956
 msgid "FOR HIDEL!!"
 msgstr "<b>为了海达尔！！</b>"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:961
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:960
 msgid "FOR DWARVEN DOORS!!"
 msgstr "<b>为了矮人之门！！</b>"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:965
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:964
 msgid "FOR THE FREE PEOPLES OF THE NORTH! FALL ON THEM, MEN!!"
 msgstr "<b>为了北方的自由的人民！兄弟们，打败他们！！</b>"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:974
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:973
 msgid "Sweet gods, look at all those orcs pouring out of that fortress."
 msgstr "老天爷啊，看看那些从要塞里倾巢而出的兽人。"
 
 #. [message]: id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:978
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:977
 msgid "Aye, and not just grunts either, those are all hardened veterans!"
 msgstr "是啊，而且他们不只是咕噜兵，那些都是久经战阵的老兵！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:982
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:981
 msgid ""
 "Yeah. Obviously this is going to take some time. If necessary we can sit "
 "tight in our fortifications and besiege them until they starve!"
@@ -7533,58 +7499,58 @@ msgstr ""
 "他们，直到他们弹尽粮绝！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:994
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:993
 msgid ""
 "Die, you murderous beast! No longer shall you terrorize the people of the "
 "North!"
 msgstr "去死吧，你这个杀人不眨眼的野兽！你再也不能让北方的人民感到恐惧了！"
 
 #. [message]: id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:998
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:997
 msgid "Learn the fate of one who offends the Dwarves of Knalga."
 msgstr "这就是你冒犯纳尔迦矮人的下场。"
 
 #. [message]: id=Eryssa,Sisal,Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1003
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1002
 msgid "Or the elves of the Northern Forests."
 msgstr "还有北方森林中的精灵。"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1007
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1006
 msgid "Or the humans of Dwarven Doors."
 msgstr "还有矮人之门的人类。"
 
 #. [message]: id=Rakshas
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1011
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1010
 msgid "(<i>Gurgle</i>) No...! This... cannot... be... happening... to... me..."
 msgstr "（<b>汩汩</b>）不！这……不可能……发生……在……我身上……"
 
 #. [message]: id=Sister Thera
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1015
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1014
 msgid "Such were the last words of Rakshas the great!"
 msgstr "这就是拉克夏斯大帝的最后遗言！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1028
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1027
 msgid ""
 "At last! Rakshas has been slain, and the orcish host has been crushed. Peace "
 "and prosperity will come to the Northlands once again!"
 msgstr "最后！拉克夏斯被战胜了，兽人的据点也毁了。和平和繁荣将再次降临北陆！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1032
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1031
 msgid ""
 "At these words all the allied forces gave out a combined and thunderous "
 "cheer. The war was finally over."
 msgstr "这句话引发了所有人的欢呼雀跃。战争终于结束了。"
 
 #. [message]: id=Camerin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1037
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1036
 msgid "(<i>Small voice lost in the uproar</i>) Awww, is it done already?"
 msgstr "（<b>喧嚣中有个微弱的声音</b>）噢，一切都结束了吗？"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1041
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1040
 msgid ""
 "Father Morvin and his wife saw to the wounded as the rest set about "
 "preparing a victory feast."
@@ -7592,22 +7558,22 @@ msgstr "莫文神父和他的妻子照顾伤员，其他人则开始准备胜利
 
 #. [message]: id=Hamel
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1058
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:494
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:506
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:530
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1057
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:492
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:504
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:528
 msgid "Argh!"
 msgstr "啊！"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1062
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1061
 msgid ""
 "Hamel! Blast it, without the dwarves to hold the western flank we are as "
 "good as defeated."
 msgstr "哈梅尔！坚持住，没有矮人把守西面防线，我们几乎就算是被打败了。"
 
 #. [message]: id=Eryssa,Elenia
-#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1083
+#: data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg:1082
 msgid "Sisal! Noooo! Not you too!"
 msgstr "茜萨尔！不！你不能也——！"
 
@@ -7959,19 +7925,19 @@ msgid "Abhai, your assistance has also been a great help to us."
 msgstr "安彼海，你的帮助对我们意义重大。"
 
 #. [message]: id=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:323
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:322
 msgid ""
 "Pah, think nothing of it. It will sure make an interesting story to tell the "
 "folks back home."
 msgstr "不要放在心上。我想把这些当成有趣的故事讲给家乡的人听。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:327
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:326
 msgid "So you would like to return to your home?"
 msgstr "所以说你想要回家吗？"
 
 #. [message]: id=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:331
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:330
 msgid ""
 "Yes. The dead should stay in the Land of the Dead. It is against the laws of "
 "nature for it to be otherwise. There is just one problem; Malifor forced me "
@@ -7981,26 +7947,26 @@ msgstr ""
 "我禁锢在这个躯体里，我不知道怎样才能摆脱。"
 
 #. [message]: id=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:335
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:334
 msgid ""
 "I believe Thera and I can help you with that, Abhai. Have no worries, you "
 "shall soon be home."
 msgstr "我想席拉和我能帮助你，安彼海。不要担心，你很快就能回家了。"
 
 #. [message]: id=Abhai
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:339
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:338
 msgid ""
 "Thank you, Father, and thank you again, Tallin, for all that you have done, "
 "both for the world of the living and the dead."
 msgstr "谢谢你，神父。再次感谢你，塔林，谢谢你为生者和死者的世界所做的一切。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:343
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:342
 msgid "My thanks to you as well, Abhai. May you rest in peace."
 msgstr "我也感谢你，安彼海。愿你安息。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:349
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:348
 msgid ""
 "Ro’Arthian and Ro’Sothian, you two have also been of staunch allies. As per "
 "our agreement, you may return to Highbrook Pass, and I will see to it that "
@@ -8011,7 +7977,7 @@ msgstr ""
 "谷，我会在道路两端张贴告示阻止任何未经你们允许的人进入，擅入者将自寻死路。"
 
 #. [message]: id=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:353
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:352
 msgid ""
 "Thank you, Tallin. Our old bones are weary of being animated long past their "
 "time. Now we will finally be able to rest in peace. However, as we have "
@@ -8022,7 +7988,7 @@ msgstr ""
 "辛至今，当然不会让自己的努力白费。如果北陆真的需要我们，我们就会再次站出来。"
 
 #. [message]: id=Ro'Arthian
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:362
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:361
 msgid ""
 "Stalrag, for years now we have fought each other, but recent events have "
 "made us allies. I go now to eternal sleep; may we part as friends."
@@ -8031,12 +7997,12 @@ msgstr ""
 "我们还算朋友。"
 
 #. [message]: id=Stalrag
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:366
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:365
 msgid "May your rest be peaceful and undisturbed, Ro’Arthian."
 msgstr "愿你不受打扰地安息，若·艾瑟恩。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:377
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:376
 msgid ""
 "And Eryssa... I may be rash and bold to ask this but... (<i>Goes to his "
 "knees in front of Eryssa and takes her hand</i>) Will you marry me?"
@@ -8045,12 +8011,12 @@ msgstr ""
 "</b>）你愿意嫁给我吗？"
 
 #. [message]: id=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:381
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:380
 msgid "(<i>Struck speechless</i>)"
 msgstr "（<b>震惊得无言以对</b>）"
 
 #. [message]: id=Hamel
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:385
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:384
 msgid ""
 "Tallin, are you sure? Elves have a very long lifespan compared to humans. "
 "She will live for at least another century and a half while you have hardly "
@@ -8060,7 +8026,7 @@ msgstr ""
 "只能再活七十年……最多七十年。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:389
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:388
 msgid ""
 "(<i>Eyes on Eryssa</i>) I know, Hamel. Then may the coming seventy years be "
 "the most happiest and fulfilling years in our lives. Should we deny "
@@ -8070,17 +8036,17 @@ msgstr ""
 "幸福最充实的日子吧。难道我们要仅仅因为害怕失去，就拒绝了自己的幸福吗？"
 
 #. [message]: id=Father Morvin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:393
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:392
 msgid "Well spoken!"
 msgstr "说得好！"
 
 #. [message]: id=Eryssa
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:397
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:396
 msgid "I may be foolish to say this, Tallin, but... yes."
 msgstr "我这样说可能很蠢，塔林，但是……我答应。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:401
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:400
 msgid ""
 "The joy of the multitude could not be contained, and the ensuing celebration "
 "lasted for a full five days. At that time Tallin and Eryssa were duly "
@@ -8090,7 +8056,7 @@ msgstr ""
 "父和席拉修女的主持下成婚了。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:406
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:405
 msgid ""
 "After the wedding, Tallin and Eryssa went back to Dwarven Doors where they "
 "founded the Council of Warders of the Northern Alliance, a body dedicated to "
@@ -8102,8 +8068,8 @@ msgstr ""
 "力于维护北陆的和平与公正。不久以后，北方联盟的总部选在了新的矮人之门城中。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:411
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:432
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:410
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:431
 msgid ""
 "On Father Morvin’s advice, the Council approached all the different orcish "
 "tribes and made treaties with them. If a chieftain refused to cooperate with "
@@ -8114,7 +8080,7 @@ msgstr ""
 "领拒绝和理事会合作，那他就会被用武力赶下台，有个合作些的会被换上来代替他。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:416
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:415
 msgid ""
 "Although Tallin faced many challenges as the head of the Northern Alliance, "
 "his marriage with Eryssa was serene and filled with happiness. Together they "
@@ -8124,7 +8090,7 @@ msgstr ""
 "的。他们后来有了一个儿子，他们的儿子也书写了很多传奇。"
 
 #. [message]: id=Tallin
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:423
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:422
 msgid ""
 "Once again I thank all of you. For those of you who are leaving, may the "
 "Lords of Light — or Darkness — guide you on your path. For those of you who "
@@ -8134,7 +8100,7 @@ msgstr ""
 "们的道路。对于你们之中要留下来的伙计们，来吧，我们还有很多事情要做。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:427
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:426
 msgid ""
 "Thus, Tallin and his friends went back to Dwarven Doors where they founded "
 "the Council of Warders of the Northern Alliance, a body dedicated to "
@@ -8146,7 +8112,7 @@ msgstr ""
 "与公正的机构。不久以后，北方联盟的总部选在了新的矮人之门城中。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:439
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:438
 msgid ""
 "In time, Knalga’s caverns were restored and became a busy and prosperous "
 "home to many dwarves. Under the protection of the Northern Alliance, people "
@@ -8158,7 +8124,7 @@ msgstr ""
 "和纳尔迦的矮人们进行贸易。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:444
+#: data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg:443
 msgid ""
 "Thus, from a small, enslaved community, the people of Dwarven Doors — by "
 "their fortitude, valor, and wisdom — brought the Northlands out of the "
@@ -8279,32 +8245,32 @@ msgstr "你们这些怪物觉得自己很结实是不是？那就尝尝这个。
 #. [message]: speaker=Father Morvin
 #. [message]: speaker=Sister Thera
 #: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:243
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:499
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:497
 msgid "You incompetent fools, you think you can kill us? Good luck!"
 msgstr "你们这些无能的白痴，你们以为可以杀死我们？祝各位好运！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:251
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:250
 msgid "Ack! Stupid slobbering beast!"
 msgstr "啊！愚蠢的流口水的畜生！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:256
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:255
 msgid "Your efforts to destroy us are in vain, you foul creature."
 msgstr "你们的攻击是徒劳的，白痴。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:268
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:267
 msgid "Oh no, Morvin! We have failed in our mission to help Tallin!"
 msgstr "哦，不，莫文！我们没有完成帮助塔林的任务！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:273
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:272
 msgid "Failed? Never! The word failure is not in our dictionary."
 msgstr "失败？不！我们的字典里就没这个词。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:282
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:281
 msgid ""
 "Alas! I am dying! Morvin darling, I wish you were beside me so that I may "
 "die in your arms! So that I may feel the kiss of your lips on mine one last "
@@ -8314,152 +8280,152 @@ msgstr ""
 "这样我就能在最后的时刻感觉到你双唇的亲吻了！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:291
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:290
 msgid "(<i>Rolls eyes</i>) Thera, do you always have to be so dramatic?"
 msgstr "（<b>转动眼珠</b>）席拉，你一定要演得这么夸张吗？"
 
 #. [message]: role=Supporter
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:296
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:295
 msgid "Um... Father? Your wife just got killed..."
 msgstr "呃……神父？你的妻子刚刚被杀了啊……"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:301
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:300
 msgid "Oh right. I CALL UPON THE LORDS OF LIGHT TO GRANT YOU LIFE!"
 msgstr "好的。我现在就请光明之神重新赐予你生命！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:310
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:309
 msgid ""
 "You cruel creature! How dare you use your brute strength against such a "
 "frail creature as me."
 msgstr "你们这些可恶的家伙！竟然用如此残暴的方式来对付柔弱的我。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:315
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:314
 msgid ""
 "Don’t worry, Thera, you will have plenty of opportunities to set him "
 "straight."
 msgstr "别担心，席拉，你有大把的机会来让他走上正道。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:333
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:332
 msgid ""
 "Thera, when this is all over, you should paint your face and join a theater."
 msgstr "席拉，等这一切结束了，你可以化个妆，然后加入剧团了。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:338
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:337
 msgid "Hey, don’t you always say that life is nothing but a drama?"
 msgstr "嘿，不是你说的，生命就像一场戏吗？"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:343
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:342
 msgid "Yes, it may be a drama, but that’s no excuse for overacting!"
 msgstr "是的，是像一场戏，但这不能是演得太夸张的理由啊！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:348
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:347
 msgid "(<i>Giggle</i>) Who needs an excuse for overacting?"
 msgstr "（<b>咯咯笑</b>）夸张的表演需要理由吗？"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:357
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:356
 msgid "Whoa! That trick is a bit hard on the constitution."
 msgstr "哇！剧本上的这个骗术有点难啊。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:366
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:365
 msgid "Well, be grateful that you are alive."
 msgstr "谢天谢地，你还活着。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:371
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:370
 msgid "(<i>Giggle</i>) Thank you, honey."
 msgstr "（<b>咯咯笑</b>）谢谢你，亲爱的。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:376
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:375
 msgid "Thank the Lords of Light, not me!"
 msgstr "谢谢光明之神吧，别谢我！"
 
 #. [message]: speaker=Sister Thera
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:385
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:585
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:384
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:582
 msgid "Ouch! That hurts. Let’s try not to do that again, shall we?"
 msgstr "噢！好痛。我们不要再这么做了，好吗？"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:392
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:391
 msgid "There we go, payback time!"
 msgstr "我们回来了，重新开始！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:399
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:398
 msgid "There we go. Let’s give this one more shot!"
 msgstr "我们上。让我们给那家伙一些教训！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:404
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:403
 msgid "Just try not to kill yourself again."
 msgstr "别再弄伤自己了。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:417
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:415
 msgid ""
 "Thera, you should know by now that it is very unclerical to make such a "
 "spectacle of yourself."
 msgstr "席拉，你应该知道，你这么卖弄自己是很不淑女的。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:422
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:420
 msgid "Come on, honey! Those were my dying words, after all!"
 msgstr "拜托，亲爱的！这是我的临终遗言啊！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:427
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:425
 msgid "(<i>Rolls eyes</i>) Women!"
 msgstr "（<b>转眼睛</b>）女人就是这样！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:441
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:439
 msgid "That’s darned right!"
 msgstr "你说对了！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:446
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:444
 msgid ""
 "Thera! Language like that coming from you! You should really stop hanging "
 "around the dwarves so much."
 msgstr "席拉！你别这样说话！你别到处闲逛。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:482
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:480
 msgid "Alas! So... close."
 msgstr "哎呀！很……近了。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:487
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:485
 msgid ""
 "Hey, that’s not right. The good guys aren’t supposed to die. Oh well, I’ll "
 "fix that."
 msgstr "嘿，这不对。好人是不该死的。哦来吧，我来搞定。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:511
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:509
 msgid ""
 "Oh dear. Did you just go and get yourself killed again, Morvin? Well, I’ll "
 "fix that."
 msgstr "噢亲爱的。你是不是故意过去让自己被杀掉啊，莫文？好吧，我来搞定。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:518
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:516
 msgid "The forces of good can never be defeated by the likes of you!"
 msgstr "正义的力量是决不会被你这样的货色打败的！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:523
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:521
 msgid ""
 "Yeah, try taking a bath and you <i>might</i> be able to kill him for good "
 "(<i>Wink wink</i>). But for the time being, abracadabra!"
@@ -8468,107 +8434,107 @@ msgstr ""
 "过现在，阿布拉卡达布拉！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:535
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:533
 msgid ""
 "Stupid troll, maybe next time you should try killing someone who can be "
 "killed."
 msgstr "傻瓜巨魔，你们根本杀不了我们，下次找好了对象再攻击。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:542
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:540
 msgid "Argh! I’ll just come back and finish you in my next life."
 msgstr "啊！等我复活之后再回来收拾你。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:547
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:545
 msgid "Which might be sooner than you think."
 msgstr "那可能比你想的更快。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:554
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:552
 msgid "Ack! I have been brained!"
 msgstr "啊！我的头被打破了！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:560
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:557
 msgid "Eew! Gross! Ahh never mind, I’ll get you cleaned up good."
 msgstr "哟！冒失鬼！啊别介意，我会把你治好的。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:578
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:575
 msgid "Ahh yes, that’s better."
 msgstr "啊没错，好多了。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:597
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:594
 msgid "Morvin! You bad boy, always getting into trouble."
 msgstr "莫文！你这坏孩子，总是惹麻烦。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:602
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:599
 msgid "Sorry, won’t do it again. Promise!"
 msgstr "对不起，不会有下一次了。我保证！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:616
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:613
 msgid "I heard that, Thera."
 msgstr "这话我已经听腻了，席拉。"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:621
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:618
 msgid "Hey, just trying to give him an incentive to drown himself."
 msgstr "嘿，给他点鼓励让他得意一下。"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:639
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:636
 msgid "Now where did he go?!"
 msgstr "他去哪里了？！"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:651
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:648
 msgid "Ahhh, Thera, you would make such a good housewife!"
 msgstr "啊，席拉，你真是个贤妻！"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:657
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:653
 msgid "Yes, if you would ever buy me a house! (<i>Pouty face</i>)"
 msgstr "当然，如果你给我买套房子就更好了！（<b>撅起嘴</b>）"
 
 #. [message]: speaker=Father Morvin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:662
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:658
 msgid ""
 "Thera, don’t you think that this isn’t really a good time to talk about that?"
 msgstr "席拉，难道你不觉得现在不是说这个的时候吗？"
 
 #. [message]: speaker=Sister Thera
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:667
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:663
 msgid "(<i>Giggle</i>) Sorry!"
 msgstr "（<b>咯咯笑</b>）对不起！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:729
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:724
 msgid "I have had enough! Come on brother, let’s get outta here."
 msgstr "我已经受够了！来吧兄弟！我们离开这里。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:743
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:738
 msgid ""
 "Dang it! They’re gone, and the creatures they control are leaving too. "
 "Without them, this is hopeless."
 msgstr "糟糕！他们走了，他们控制的生物也要走了。没有他们，我们就没有希望了。"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:763
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:758
 msgid "Farewell, my friends. I now go to join my fallen brothers."
 msgstr "再见，我的朋友们。我要去见我死去的弟兄们了。"
 
 #. [message]: role=Shinsplitter
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:783
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:778
 msgid "No, Stalrag! Without you what will become of the Shinsplitters?"
 msgstr "不，斯托莱格！没有你敢死队怎么办？"
 
 #. [message]: speaker=Stalrag
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:788
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:783
 msgid ""
 "Shinsplitters... join Tallin... He is your new... leader... trust... and... "
 "serve... him... as... you... have... served... me."
@@ -8577,116 +8543,26 @@ msgstr ""
 "我……一样。"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:793
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:788
 msgid "Your death shall not go unavenged, brave Stalrag. DEATH TO THE ORCS!!"
 msgstr "你的仇我们一定会报，勇敢的斯托莱格。兽人去死吧！！"
 
 #. [message]: role=Shinsplitter
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:798
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:793
 msgid "DIE, YOU FOUL SCUM!!"
 msgstr "去死吧，你这愚蠢的垃圾！！"
 
 #. [message]: speaker=Eryssa
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:815
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:810
 msgid "Alas, you must continue your mission without me!"
 msgstr "呀，即使没有我你们也要坚持下去！"
 
 #. [message]: speaker=Elenia
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:825
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:820
 msgid "Eryssa, no! Please don’t die!"
 msgstr "伊蕊莎，不！别死！"
 
 #. [message]: speaker=Tallin
-#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:832
+#: data/campaigns/Northern_Rebirth/utils/herodeaths.cfg:827
 msgid "How could this happen? We can’t possibly go on without her..."
 msgstr "怎么会这样？没有她我们不可能继续前进了……"
-
-#~ msgid ""
-#~ "The old door crumbles away, revealing an old tunnel on the other side."
-#~ msgstr "老旧的门碎裂了，门后显出一条老旧的隧道。"
-
-#~ msgid ""
-#~ "The Water Serpent is a foe dire enough when encountered in the rivers and "
-#~ "seas of the sunlit world, but his rare cave-dwelling kin are yet more "
-#~ "terrible. Though their eyes are of little use in the stygian darkness of "
-#~ "the deep caves where they dwell, they have become sensitive to even the "
-#~ "tiniest sound that might indicate unwary prey in their domain, and will "
-#~ "home in on it with remorseless efficiency."
-#~ msgstr ""
-#~ "在阳光下的世界中，在河里或是海里遇到深水巨蛇绝对是一个悲剧，而它们罕见的穴"
-#~ "居的亲戚则更为可怕。虽然它们的眼睛在它们居住的昏暗的深洞里面派不上什么用"
-#~ "处，但它们的感知力非常强，即使是领地里最微小的声音也能让它们感觉到冒失的猎"
-#~ "物的到来，然后它们会以极高的效率追踪上猎物。"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid "Prose, Grammatical and WML Assistance"
-#~ msgstr "散文，语法和WML辅助"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid ""
-#~ "The raids were mere probes, at first, and the orcs mere rabble. But they "
-#~ "grew more numerous, and threatening, and the raiding parties became war-"
-#~ "bands and then companies. Then there arose a great warlord among the "
-#~ "Bloody Sword tribe, the chieftain called Khazg Black-Tusk; and he raised "
-#~ "an army, and besieged Dwarven Doors."
-#~ msgstr ""
-#~ "袭击最初只是试探，奥克们只是一群乌合之众。但他们的数量越来越多，威胁也越来"
-#~ "越大，劫掠队变成了战团，然后是军团。随后在血剑部族中涌现出一位伟大的战争首"
-#~ "领，名叫哈兹格·黑牙的酋长；他召集了一支军队，围攻矮人城门。"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid "Good luck, my friend."
-#~ msgstr "祝你好运，我的朋友。"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid "Then to arms, men! For Knalga and the Princess!"
-#~ msgstr "然后，拿起武器，男人们！为了克拉加和公主！"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid "You are a fool, human! Watch how we will crush and destroy you!"
-#~ msgstr "你是个傻瓜，人类！看我们怎么碾碎你，摧毁你！"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid ""
-#~ "They paused for scant minutes to bind the wounds of a few surviving elves "
-#~ "and leave them a small guard. Then they pressed onward to rescue Hidel — "
-#~ "and they found him."
-#~ msgstr ""
-#~ "他们停留了极短的时间，为几个幸存的精灵包扎伤口并留下少量守卫。然后他们继续"
-#~ "前进去营救希德尔——他们找到了他。"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid ""
-#~ "Rest assured, sir, I will place myself between Eryssa and any ill that "
-#~ "strength or love may counter."
-#~ msgstr "放心吧，大人，我会在伊蕊莎与任何由力量或爱情带来的恶势力之间站岗。"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid ""
-#~ "With these words Hidel closed his eyes and breathed his last. As Eryssa "
-#~ "wept with Hidel’s head in her lap, Tallin approached her, hesitating, and "
-#~ "then wrapped her gently in his arms."
-#~ msgstr ""
-#~ "用这些话，希德尔闭上眼睛，呼吸最后。艾瑞莎抱着希德尔的头哭泣，塔林犹豫地走"
-#~ "近她，然后温柔地将她抱在怀里。"
-
-# Translated by ollama with model glm4
-#, fuzzy
-#~ msgid ""
-#~ "As Tallin comforted Eryssa, the rest of the party spread out and rallied "
-#~ "the scattered elves, and tending to the wounded. This being done, they "
-#~ "once again came before Tallin and Eryssa."
-#~ msgstr ""
-#~ "当塔林安慰伊蕊莎时，其余的队伍分散开来召集散落的精灵，并照顾受伤者。这件事"
-#~ "完成后，他们再次来到塔林和伊蕊莎面前。"
-
-#~ msgid "Arthian"
-#~ msgstr "艾瑟恩"


### PR DESCRIPTION
对wesnoth-lib、low、nr：

1. 同步了官方pot文件，并翻译完成；
2. 更新了元数据（如版权行中的年份、历史译员清单（加入vimacs）、Project-Id-Version）；
3. 移除了过时翻译条目。
