### PR TITLE
master版本的wesnoth-sota、sotbe、tb翻译更新

### DIFF
--- a/translations/wesnoth/po/wesnoth-sota/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-sota/zh_CN.po
@@ -1,5 +1,5 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
@@ -9,10 +9,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.16\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-10-28 17:38 UTC\n"
-"PO-Revision-Date: 2023-09-10 09:10+0800\n"
+"POT-Creation-Date: 2026-08-18 15:18 UTC\n"
+"PO-Revision-Date: 2026-08-27 19:57+0800\n"
 "Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
@@ -20,12 +20,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=Secrets of the Ancients
 #. [editor_group]: id=sota
 #: data/campaigns/Secrets_of_the_Ancients/_main.cfg:10
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:69
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:71
 msgid "Secrets of the Ancients"
 msgstr "古人之密"
 
@@ -35,37 +35,37 @@ msgid "SotA"
 msgstr "SotA"
 
 #. [campaign]: id=Secrets of the Ancients
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:18
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:19
 msgid "Normal"
 msgstr "普通"
 
 #. [campaign]: id=Secrets of the Ancients
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:18
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:19
 msgid "Unpleasant"
 msgstr "令人不适"
 
 #. [campaign]: id=Secrets of the Ancients
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:19
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:20
 msgid "Challenging"
 msgstr "挑战"
 
 #. [campaign]: id=Secrets of the Ancients
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:19
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:20
 msgid "Corrupt"
 msgstr "腐败不堪"
 
 #. [campaign]: id=Secrets of the Ancients
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:20
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:21
 msgid "Diabolic"
 msgstr "群魔乱舞"
 
 #. [campaign]: id=Secrets of the Ancients
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:20
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:21
 msgid "Difficult"
 msgstr "困难"
 
 #. [campaign]: id=Secrets of the Ancients
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:22
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:23
 msgid ""
 "Rediscover the secrets known by the lich lords of the Green Isle. They knew "
 "how to live forever, so why can’t you?\n"
@@ -77,17 +77,17 @@ msgstr ""
 "（困难级别，21幕场景。）\n"
 
 #. [about]
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:29
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:30
 msgid "Campaign Design, Programming, and Artwork"
 msgstr "战役设计，编程及美工"
 
 #. [about]
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:35
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:36
 msgid "Campaign Maintenance"
 msgstr "战役维护"
 
 #. [about]
-#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:42
+#: data/campaigns/Secrets_of_the_Ancients/_main.cfg:43
 msgid "Additional Artwork"
 msgstr "额外美工"
 
@@ -273,35 +273,35 @@ msgstr ""
 "或许我不会。"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:175
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:172
 msgid "Move Ardonna to the signpost"
 msgstr "移动阿冬娜至路标处"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:187
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:256
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:184
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:253
 msgid "This scenario takes place entirely at night."
 msgstr "此场景完全发生在夜间。"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:190
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:187
 msgid ""
 "Ardonna can climb over a fence for 2 movement points, but wild animals "
 "cannot."
 msgstr "阿冬娜可以消耗2点移动点来翻越篱笆，但野生动物不行。"
 
 #. [label]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:196
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:193
 msgid "Llorvin"
 msgstr "洛温"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:308
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:305
 msgid "I suspected some of the rats would show themselves."
 msgstr "我怀疑这里有不少老鼠。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:318
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:315
 msgid ""
 "<span color='cyan'>Special Note: </span>In this campaign, if a unit is "
 "killed and not immediately raised as a corpse, its corpse type will be "
@@ -311,7 +311,7 @@ msgstr ""
 "立即被征募，那么它会被添加到征募列表中。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:327
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:324
 msgid ""
 "I should get off the island in case the ethics committee is concerned about "
 "a rogue mage. I shall not be dragged back in disgrace! I should be able to "
@@ -324,7 +324,7 @@ msgstr ""
 "为此我需要一些旅行资金，来吧，我的蝙蝠朋友们，帮我找点儿金币回来！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:331
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:328
 msgid ""
 "It would be good to have even more bats as well. There was a colony in that "
 "ruined castle where we practiced conjuring fire, so I will try to find that. "
@@ -337,7 +337,7 @@ msgstr ""
 "们。但我只能用冰，我还从来没学会熟练用火。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:343
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:340
 msgid ""
 "A wolf! This journey may be more dangerous than I thought. If we need to, I "
 "suppose we could rest inside a farmer’s or woodcutter’s fence."
@@ -346,7 +346,7 @@ msgstr ""
 "建的篱笆里面休息。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:366
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg:363
 msgid ""
 "The morning has come, and I am still in the open. I will be caught for sure!"
 msgstr "清晨来临了，而我却还在开阔地里。我肯定会被抓住的！"
@@ -371,47 +371,47 @@ msgstr ""
 "篷，看上去像是哀悼者，而且我还戴着兜帽，没人能看到我的头发。"
 
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:69
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:67
 msgid "Guards"
 msgstr "卫兵"
 
 #. [set_variable]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:92
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:90
 msgid "Raise Walking Corpse (8 Gold)"
 msgstr "征募陆行僵尸（8枚金币）"
 
 #. [set_variable]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:99
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:97
 msgid "Raise Skeleton (15 Gold)"
 msgstr "征募骷髅战士（15枚金币）"
 
 #. [set_variable]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:106
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:104
 msgid "Raise Skeleton Archer (14 Gold)"
 msgstr "征募骷髅弓箭手（14枚金币）"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:159
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:157
 msgid "You don’t have enough gold to raise that unit."
 msgstr "你的金币不足以征募该单位。"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:238
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:235
 msgid "Kill all the guards, and capture the guardhouse"
 msgstr "击杀所有卫兵，并占领卫兵室"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:250
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:247
 msgid "Right-click on a grave adjacent to your leader to raise a unit."
 msgstr "鼠标右键单击主人公身旁的坟墓可以征募一个单位。"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:253
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:250
 msgid "Each grave can be used only once."
 msgstr "每座坟墓只能使用一次。"
 
 #. [label]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:262
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:259
 msgid "Guardhouse"
 msgstr "卫兵室"
 
@@ -419,7 +419,7 @@ msgstr "卫兵室"
 #. In English, this label bled into the two hexes on either side, and obscured
 #. the units there, which is why it's split across two lines. The extra spaces
 #. before "Temple" are to center that word above the others.
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:274
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:271
 msgid ""
 "  Temple\n"
 "of Healing"
@@ -428,80 +428,80 @@ msgstr ""
 "之神庙"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:283
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:280
 msgid "Gwyllin"
 msgstr "格威尔林"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:284
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:281
 msgid "Veomyr"
 msgstr "维欧米尔"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:285
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:282
 msgid "Syrillin"
 msgstr "希里林"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:286
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:283
 msgid "Glant"
 msgstr "格朗特"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:289
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:286
 msgid "Renvan"
 msgstr "仁凡"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:290
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:287
 msgid "Vin"
 msgstr "温"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:294
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:296
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:291
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:293
 msgid "Caradoc"
 msgstr "卡拉多克"
 
 #. [message]: speaker=Ardonna
 #. She's speaking to a bat from scenario 1
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:399
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:396
 msgid "Oh, hello friend! I didn’t know you were hiding in there."
 msgstr "哦，你好啊朋友！我不知道你躲在这儿。"
 
 #. [message]: speaker=Ardonna
 #. She's speaking to a bat that she hasn't met before
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:406
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:403
 msgid "Oh, hello! You’re a handsome one."
 msgstr "哦，你好啊！你长得还挺帅的。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:423
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:420
 msgid "Hey, come back! I didn’t mean to frighten you."
 msgstr "嘿，回来！我不是故意要吓唬你的。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:427
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:424
 msgid "Maybe I could attract it if I jingled some coins."
 msgstr "要是我用金币弄出叮当声，也许就能吸引到它了。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:450
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:447
 msgid "Right-click adjacent to your leader to summon the bat."
 msgstr "鼠标右键单击主人公身旁的空格可以召唤蝙蝠。"
 
 #. [set_menu_item]: id=summon_bat
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:458
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:455
 msgid "Summon the Bat (20 gold)"
 msgstr "召唤蝙蝠（20金币）"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:498
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:495
 msgid "You don’t have enough gold to summon the bat."
 msgstr "你的金币不足以召唤蝙蝠。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:580
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:577
 msgid ""
 "You can now recruit skeletons and skeleton archers! You will lose this "
 "ability if the guardhouse is retaken by the guards!"
@@ -509,66 +509,66 @@ msgstr ""
 "你现在可以征募骷髅兵和骷髅弓箭手了！如果卫兵室被卫兵夺回，你将无法征募它们！"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:634
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:630
 msgid "Blollyn"
 msgstr "布洛林"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:635
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:631
 msgid "Ceoran"
 msgstr "希欧兰"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:637
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:633
 msgid "Vindry"
 msgstr "温德里"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:638
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:634
 msgid "Aethacyn"
 msgstr "艾萨辛"
 
 #. [event]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:639
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:635
 msgid "Elomyr"
 msgstr "埃洛米尔"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:669
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:665
 msgid "You can no longer recruit skeletons and skeleton archers."
 msgstr "你不能再征募骷髅战士和骷髅弓箭手了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:731
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:727
 msgid ""
 "Wait, that guard said there were twelve of them, so where are the other five?"
 msgstr "等一下，那卫兵说他们有十二个人，所以剩下那五个在哪儿？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:733
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:729
 msgid ""
 "Wait, that guard said there were seven of them, so where are the other two?"
 msgstr "等一下，那卫兵说他们有七个人，所以剩下那两个在哪儿？"
 
 #. [message]: speaker=Syrillin
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:752
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:748
 msgid "Why are we stuck guarding a cemetery all night?"
 msgstr "为什么我们要整晚守在墓地？"
 
 #. [message]: speaker=Veomyr
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:758
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:754
 msgid ""
 "And why <i>twelve</i> of us? Who wants to break into a cemetery that badly?"
 msgstr "还有，为什么要<b>十二</b>个人？谁会这么想闯进墓地里啊？"
 
 #. [message]: speaker=Veomyr
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:760
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:756
 msgid ""
 "And why <i>seven</i> of us? Who wants to break into a cemetery that badly?"
 msgstr "还有，为什么要<b>七</b>个人？谁会这么想闯进墓地里啊？"
 
 #. [message]: speaker=Glant
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:765
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:761
 msgid ""
 "I don’t know, but this evening a mage from the Academy was here talking to "
 "the mayor, my brother says."
@@ -577,12 +577,12 @@ msgstr ""
 "的。"
 
 #. [message]: speaker=Caradoc
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:769
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:765
 msgid "Well <i>I</i> say you shouldn’t question orders, so pipe down."
 msgstr "好啦，要<b>我</b>说你们不该怀疑命令，就别抱怨了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:808
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:804
 msgid ""
 "They must be guarding the cemetery from <i>me</i>! Maybe Aimucasur really "
 "was suspicious. It’s a good thing I’m here already, but how am I going to "
@@ -596,59 +596,59 @@ msgstr ""
 "好吧，我不如就先做试验，以后再担心离开的问题。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:841
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:837
 msgid "Hello?"
 msgstr "有人吗？"
 
 #. [message]: speaker=first_zombie
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:846
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:842
 msgid "Uhngh."
 msgstr "僵尸发出低吼声..."
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:850
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:846
 msgid "Do you remember anything?"
 msgstr "你还能回想起你经历了什么吗？"
 
 #. [message]: speaker=first_zombie
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:855
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:851
 msgid "Uhrrr."
 msgstr "又发出几声低吼..."
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:859
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:855
 msgid ""
 "It seems that my first guess was correct. The poor creature is mindless."
 msgstr "看起来我的第一个猜想是正确的。这可怜的东西没有意识。"
 
 #. [message]: speaker=Veomyr
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:873
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:869
 msgid "I heard something over there!"
 msgstr "我听到那边有动静！"
 
 #. [message]: speaker=Glant
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:883
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:879
 msgid "Who’s there?"
 msgstr "是谁？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:904
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:900
 msgid "It’s only me. Is the cemetery closed then? I was about to leave."
 msgstr "是我。墓地是不是已经关门了？我正打算离开。"
 
 #. [message]: speaker=Syrillin
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:908
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:904
 msgid "You and that... other person. Who is that?"
 msgstr "你和你旁边那个……另外一个。他是谁？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:912
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:908
 msgid ""
 "Oh, him. See here, I don’t want any trouble, but he is a little... ah..."
 msgstr "呃，他啊。你自己看吧，我可不想惹麻烦，不过他有点儿……嗯哈……"
 
 #. [message]: speaker=Caradoc
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:916
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:912
 msgid ""
 "He’s <i>dead</i>! This is dark sorcery like in my granddad’s time in the old "
 "country! The penalty is death. Attack and destroy them both!"
@@ -657,12 +657,12 @@ msgstr ""
 "是是死刑。动手，把他们都除掉！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:920
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:916
 msgid "Hey! Don’t do that, or I will need more of them."
 msgstr "嘿！别这样，不然我还得找更多的僵尸。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:924
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:920
 msgid ""
 "I would do better if I had weapons, and I bet I can find some in the "
 "guardhouse. Go take it, my companions."
@@ -671,12 +671,12 @@ msgstr ""
 "的伙伴们。"
 
 #. [message]: speaker=Caradoc
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:928
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:924
 msgid "Gwyllin, don’t move from that guardhouse."
 msgstr "格威林，不要离开卫兵室。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:937
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg:933
 msgid ""
 "The morning has come, and we have not escaped the city. We will be caught "
 "for sure!"
@@ -712,7 +712,7 @@ msgstr ""
 #. [side]: type=Bandit, id=Garcyn
 #. [unit]: type=Ghoul
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/03_Bandits.cfg:41
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:238
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:236
 msgid "Garcyn"
 msgstr "伽辛"
 
@@ -723,9 +723,9 @@ msgstr "莫萨"
 
 #. [objective]: condition=win
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/03_Bandits.cfg:67
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:248
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:246
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg:68
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:75
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:73
 msgid "Defeat the enemy leader"
 msgstr "击败敌方领袖"
 
@@ -929,52 +929,52 @@ msgid "Underground"
 msgstr "下层"
 
 #. [side]: type=Sea Captain, id=Rudic
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:153
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:151
 msgid "Ship’s Crew"
 msgstr "船员"
 
 #. [side]: type=Sea Captain, id=Rudic
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:155
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:153
 #: data/campaigns/Secrets_of_the_Ancients/utils/characters.cfg:55
 msgid "Rudic"
 msgstr "鲁迪克"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:260
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:127
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:258
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:125
 msgid "You can recruit from anywhere on the two highest decks."
 msgstr "你可以在最上两层甲板的任意位置进行征募。"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:263
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:261
 msgid ""
 "Player and Enemy units can move between the surface and the interior of the "
 "ship via stairs."
 msgstr "玩家和敌人的单位可以通过楼梯在船的表面和内部之间移动。"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:266
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:264
 msgid "Barrels act as villages."
 msgstr "酒桶的效果和村庄一样。"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:269
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:130
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:267
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:128
 msgid "Right-click to simplify the ship graphics."
 msgstr "鼠标右键单击以简化船只图形。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:508
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:506
 msgid "You can now recruit ghouls!"
 msgstr "你现在可以征募食尸鬼了！"
 
 #. [unit]: type=Sailor, id=Joc
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:542
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:540
 msgid "Joc"
 msgstr "玖克"
 
 #. [message]: speaker=Joc
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:550
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:548
 msgid ""
 "I found Janryn in the hold. Or, ah... some of him. He’s dead. I didn’t stay "
 "to find out what killed him, but there was someone shuffling around in the "
@@ -984,7 +984,7 @@ msgstr ""
 "谁杀了他，但我发现有人在阴影里潜行，他散发出了难闻的恶臭。"
 
 #. [message]: speaker=Rudic
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:554
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:552
 msgid ""
 "Murderous stowaways on my ship? I won’t have it! Go round up the rest of the "
 "crew and get them up here. We’re going hunting. All passengers are confined "
@@ -994,22 +994,22 @@ msgstr ""
 "我们要展开搜捕。现在所有的旅客禁止离开自己的房间。"
 
 #. [message]: speaker=Rudic
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:615
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:613
 msgid "You! Dark girl. Why are you not in your cabin?"
 msgstr "你！深色衣服的姑娘。你为什么不呆在船舱里？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:619
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:617
 msgid "What if I said something in defense of the stowaways?"
 msgstr "要是我为偷渡者说句话会怎么样？"
 
 #. [message]: speaker=Rudic
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:623
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:621
 msgid "I would pitch you over the side with them. What do you know?"
 msgstr "我会把你和他们一起扔下海。你都知道些什么？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:627
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:625
 msgid ""
 "They are my companions, and the poor things are just terribly hungry. I’m "
 "sorry we didn’t pay the full amount, but maybe we can reach some arrangement."
@@ -1018,7 +1018,7 @@ msgstr ""
 "但也许我们可以协商个方案。"
 
 #. [message]: speaker=Rudic
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:631
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:629
 msgid ""
 "They killed my crew member and played me for a fool! The only arrangement "
 "that suits me is the lot of you off my ship, preferably at the bottom of the "
@@ -1028,7 +1028,7 @@ msgstr ""
 "滚下去，最好是滚到海底。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:635
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:633
 msgid ""
 "Oh dear. We must do this again. Come to me my friends! If you are still "
 "hungry, feed on a passenger first."
@@ -1037,29 +1037,29 @@ msgstr ""
 "客吧。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:647
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:645
 msgid ""
 "Good riddance. But, with the captain dead, who will sail the ship and guide "
 "us into port now?"
 msgstr "总算摆脱了。但船长死了， 现在谁来驾驶这艘船，指引我们驶向港口呢？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:651
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:649
 msgid "Rise Captain, and please retain your memories."
 msgstr "站起来吧，船长，上帝保佑你还存有之前的记忆。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:675
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:672
 msgid "Can you still sail this ship?"
 msgstr "你还能驾船吗？"
 
 #. [message]: speaker=Bone Captain
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:680
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:677
 msgid "Sail. Yes. Need wind."
 msgstr "驾船。可以。要风。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:684
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg:681
 msgid ""
 "Oh! It worked! Take us to port, Captain, as soon as you do have the wind."
 msgstr "哦！成功了！一旦有了风，就把我们带去港口，船长。"
@@ -1096,55 +1096,55 @@ msgstr ""
 "须得走了，当船长正准备让船驶入港口时。"
 
 #. [side]: id=Gweddyn, type=Knight
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:63
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:61
 msgid "Guard"
 msgstr "卫兵"
 
 #. [side]: id=Gweddyn, type=Knight
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:66
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:64
 msgid "Gweddyn"
 msgstr "格温丁"
 
 #. [unit]: type=Mage, gender=male, id=Bremen
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:75
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:73
 msgid "Bremen"
 msgstr "布雷门"
 
 #. [objective]: condition=win
 #. [objectives]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:116
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:79
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:87
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:114
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:78
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:85
 msgid "Kill every enemy unit"
 msgstr "击杀每一个敌方单位"
 
 #. [message]: speaker=Gweddyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:313
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:311
 msgid "Ho Rudic! Welcome. You are late, old friend."
 msgstr "嗬鲁迪克！欢迎。你迟到了，老朋友。"
 
 #. [message]: speaker=Bone Captain
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:317
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:315
 msgid "Late."
 msgstr "迟到。"
 
 #. [message]: speaker=Gweddyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:321
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:319
 msgid "Not talking much today? What happened?"
 msgstr "今天不想多说话？发生了什么？"
 
 #. [message]: speaker=Bone Captain
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:325
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:323
 msgid "Happened? Dead."
 msgstr "发生了什么？我死了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:329
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:327
 msgid "Keep quiet about that."
 msgstr "别多嘴。"
 
 #. [message]: speaker=Gweddyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:333
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:331
 msgid ""
 "Ha! Well, actually, you do look terrible. Very... gray, and your face is... "
 "But we’re speaking! You can’t actually be dead!"
@@ -1153,44 +1153,44 @@ msgstr ""
 "你不可能真是死了吧！"
 
 #. [message]: speaker=Bone Captain
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:337
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:335
 msgid "Yes. Dead."
 msgstr "是的。死了。"
 
 #. [message]: speaker=Gweddyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:341
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:339
 msgid "What madness is this?"
 msgstr "这是什么疯话？"
 
 #. [message]: speaker=Bremen
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:345
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:343
 msgid "It’s sorcery my lord. Dark sorcery."
 msgstr "是巫术，阁下。黑暗巫术。"
 
 #. [message]: speaker=Gweddyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:349
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:347
 msgid ""
 "Necromancy! The penalty for that is death. Rudic, who is responsible for "
 "this?"
 msgstr "亡灵巫术！使用亡灵巫术的惩罚是死刑。鲁迪克，这是谁干的？"
 
 #. [message]: speaker=Bone Captain
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:353
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:351
 msgid "She."
 msgstr "她。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:357
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:355
 msgid "Ah, well. I should have known this wouldn’t be easy."
 msgstr "啊，好吧。我早该知道不会这么简单的。"
 
 #. [message]: speaker=Gweddyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:361
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:359
 msgid "Kill her!"
 msgstr "杀了她！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:365
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:363
 msgid ""
 "We must leave no one alive to report us, or the entire country will become "
 "unsafe. We have no choice. We must kill them all."
@@ -1199,32 +1199,32 @@ msgstr ""
 "了，必须把他们全杀掉。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:373
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:371
 msgid "We are finished."
 msgstr "终于结束了。"
 
 #. [message]: speaker=Shadow
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:390
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:388
 msgid "Girl. You will follow."
 msgstr "姑娘。你会跟我走的。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:394
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:392
 msgid "What in the world are <i>you</i>?"
 msgstr "<b>你</b>究竟是什么人？"
 
 #. [message]: speaker=Shadow
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:398
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:396
 msgid "Spirit and shadow. You will follow."
 msgstr "灵魂与暗影。你会跟我走的。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:402
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:400
 msgid "You’re a ghost... a real ghost! I will indeed follow you. Lead on."
 msgstr "你是个幽灵……一个真正的幽灵！我确实会跟你走。带路吧。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:428
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg:426
 msgid ""
 "Blackwater Port is defeated, but we must let none escape. Finish them all."
 msgstr "我们击败了黑水港卫队，但不能让任何人逃走。把他们都解决掉。"
@@ -1288,32 +1288,32 @@ msgstr ""
 "不担心会遇到什么问题。"
 
 #. [side]: type=Direwolf Rider, id=Bogdush
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:74
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:72
 msgid "Goblin Raiders"
 msgstr "地精掠袭者"
 
 #. [side]: type=Direwolf Rider, id=Bogdush
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:77
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:75
 msgid "Bogdush"
 msgstr "博格达什"
 
 #. [unit]: type=Goblin Pillager, id=Blaust
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:86
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:84
 msgid "Blaust"
 msgstr "布劳斯特"
 
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:96
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:94
 msgid "Bats"
 msgstr "蝙蝠"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:156
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:154
 msgid "Find out where the ghost went and follow it"
 msgstr "找出幽灵前往的方向并跟随它"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:226
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:224
 msgid ""
 "Look, there is a cavern below the cave floor. What might we rouse if we go "
 "tromping about in the cave? I hope it is nothing worse than bats."
@@ -1322,17 +1322,17 @@ msgstr ""
 "不会出现比蝙蝠更糟糕的东西。"
 
 #. [message]: speaker=Bone Captain
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:230
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:228
 msgid "Ghost?"
 msgstr "幽灵？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:234
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:232
 msgid "Surely the ghost would not have gone that way, where I cannot follow."
 msgstr "幽灵是绝对不会走那条路的，我也不往那边走。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:254
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:252
 msgid ""
 "If there is one bat, there are certainly more. We should be careful. It "
 "would be foolish to explore this cave alone."
@@ -1341,46 +1341,46 @@ msgstr ""
 "是明智之举。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:276
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:274
 msgid ""
 "There is a tunnel at the back of the cave! The ghost must have gone through "
 "there."
 msgstr "洞穴后面有条隧道！那幽灵肯定是走的那里。"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:285
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:283
 msgid "Move Ardonna to the tunnel"
 msgstr "移动阿冬娜至隧道处"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:514
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:512
 msgid "So it’s only bats, but rather a lot of them."
 msgstr "看起来洞里只有蝙蝠，不过确实不少。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:533
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:531
 msgid "Now let’s see where that ghost went."
 msgstr "现在我们来看看那幽灵去了哪里。"
 
 #. [message]: speaker=Shadow
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:554
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:552
 msgid "Come."
 msgstr "来吧。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:567
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:565
 msgid "Let’s follow it into the cave."
 msgstr "让我们跟着它进入洞穴吧。"
 
 #. [message]: speaker=Blaust
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:571
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:569
 msgid ""
 "I don’t know, Bogdush. The Chief said he wanted stuff that was helpful for "
 "the war."
 msgstr "我不知道怎么说，博格达什。酋长说过，他想要的是对赢得战争有帮助的东西。"
 
 #. [message]: speaker=Bogdush
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:575
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:573
 msgid ""
 "It’s a <i>mage</i>! That <i>would</i> be helpful for the war, you idiot! "
 "It’s only a pup, and unless I miss my guess, it’s a female too. It will be "
@@ -1390,28 +1390,28 @@ msgstr ""
 "而且我要是没猜错的话，那是个女的。很容易就能抓到她。"
 
 #. [message]: speaker=Blaust
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:579
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:577
 msgid ""
 "What about the others? They look like the dead ones back on the Green Isle."
 msgstr "那其他人呢？它们看上去像是以前在绿岛上见过的那些死人。"
 
 #. [message]: speaker=Bogdush
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:583
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:581
 msgid "They are. It makes our job of killing them that much easier!"
 msgstr "它们就是死人。这样看来杀掉他们易如反掌！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:593
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:591
 msgid "You must be goblins. You will stand out of my way if you wish to live."
 msgstr "你们是地精吧。如果想活命的话，就不要挡我的路。"
 
 #. [message]: speaker=Bogdush
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:597
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:595
 msgid "Oh, it’s a mage that makes jokes too! Let’s go."
 msgstr "嘿，这个法师还挺会搞笑的啊！上吧。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:607
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg:605
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg:547
 msgid "You have no more time."
 msgstr "你没有时间了。"
@@ -1437,36 +1437,36 @@ msgstr ""
 
 #. [side]
 #. [unit]: type=Sacrifice, id=necromancer_on_altar
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:38
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:37
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:281
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:37
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:36
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:279
 #: data/campaigns/Secrets_of_the_Ancients/utils/characters.cfg:44
 #: data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg:32
 msgid "Ras-Tabahn"
 msgstr "拉斯-塔班"
 
 #. [unit]: type=Shadow
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:47
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:45
 msgid "Vash-Gorn"
 msgstr "瓦希-戈恩"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:181
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:178
 msgid "Oh, wow."
 msgstr "嘿，哇哦。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:185
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:182
 msgid "I am Ras-Tabahn. Welcome to my laboratory, Ardonna of Tarrynth!"
 msgstr "我是拉斯-塔班。欢迎来到我的研究室，塔林斯的阿冬娜！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:189
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:186
 msgid "How do you know my name?"
 msgstr "你怎么会知道我的名字？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:193
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:190
 msgid ""
 "I know much about you. My ghosts have been watching you for some time now, "
 "and you and I share the goal of resisting death. I have been hoping several "
@@ -1481,7 +1481,7 @@ msgstr ""
 "一些有研究价值的创造物——你管他们叫食尸鬼对吗？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:197
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:194
 msgid ""
 "Yes, I can show you how to make your own, but have you not solved the "
 "problem already with your ghosts?"
@@ -1490,7 +1490,7 @@ msgstr ""
 "吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:201
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:198
 msgid ""
 "Alas, no. Ghosts can retain some memories if they are raised quickly enough, "
 "and they make good scouts and soldiers after they have some experience, but "
@@ -1507,7 +1507,7 @@ msgstr ""
 "意。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:205
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:202
 msgid ""
 "I believe I know how to get the information we seek, but it would have been "
 "too difficult to obtain myself. Therefore, we shall go on a mission, you and "
@@ -1517,12 +1517,12 @@ msgstr ""
 "我们应该一起去干这事儿，你和我。首先，我们要扩大我们的军队，然后……"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:209
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:206
 msgid "Wait. I have heard nothing yet that makes me think I should trust you."
 msgstr "等等。你说了这么多，没有一句能让我信任你的。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:213
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:210
 msgid ""
 "Ah... yes, I suppose not. Let me teach you some of what I know today, and "
 "see if that informs your opinion. However, the question of trust is not the "
@@ -1540,7 +1540,7 @@ msgstr ""
 "们强强联手，我们就有机会在死亡到来之前完成研究。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:217
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:214
 msgid ""
 "For you, you mean. I am only nineteen. Still, you make a good case. We can "
 "work together for now."
@@ -1549,7 +1549,7 @@ msgstr ""
 "手。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:221
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:218
 msgid ""
 "Splendid. Here is what I propose. First, we part ways for a time, and you "
 "raise a force of ghosts following my instructions. Meanwhile, I am going to "
@@ -1566,22 +1566,22 @@ msgstr ""
 "们的味道闻起来太糟糕了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:225
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:222
 msgid "Well I can’t smell, so I didn’t know about that."
 msgstr "好吧，但我闻不到味道，所以我还真不知道这一点。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:229
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:226
 msgid "Curious, but convenient for one such as us."
 msgstr "有趣，不过这点对我们来说倒是很方便。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:233
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:230
 msgid "Why can’t I just raise some of the goblins outside?"
 msgstr "为什么我就不能去复苏外面的几只地精呢？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:237
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:234
 msgid ""
 "Those goblins were too weak, and it would take their spirits a long time to "
 "become strong enough to be useful. You are going to raise elvish warriors "
@@ -1598,7 +1598,7 @@ msgstr ""
 "我们下一步该去哪儿。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:241
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg:238
 msgid "Very well. We will do as you suggest."
 msgstr "好吧。就按你说的办吧。"
 
@@ -1607,7 +1607,7 @@ msgstr "好吧。就按你说的办吧。"
 #. The name of the city
 #. male name
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:13
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:139
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:138
 #: data/campaigns/Secrets_of_the_Ancients/utils/characters.cfg:65
 msgid "Carcyn"
 msgstr "卡辛"
@@ -1629,69 +1629,69 @@ msgstr ""
 "前行数天之后，他接近了边疆小镇卡辛。"
 
 #. [side]: type=Swordsman, id=Carcyn Fisher
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:56
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:55
 msgid "Town Defense"
 msgstr "小镇守卫"
 
 #. [side]: type=Swordsman, id=Carcyn Fisher
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:58
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:57
 msgid "Carcyn Fisher"
 msgstr "卡辛·费希尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:76
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:75
 msgid "Capture every village"
 msgstr "占领每一座村庄"
 
 #. [unit]: type=Mage, id=Wynran
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:93
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:92
 msgid "Wynran"
 msgstr "温兰"
 
 #. [unit]: type=Mage, id=Raydah, gender=female
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:105
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:104
 msgid "Raydah"
 msgstr "瑞达"
 
 #. [label]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:116
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:115
 msgid "Inn"
 msgstr "旅馆"
 
 # Tackle有渔网的意思，且该位置在地图中靠近海边
 #. [label]
 #. or Fishing Supplies
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:122
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:121
 msgid "Tackle Shop"
 msgstr "渔具店"
 
 #. [label]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:127
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:126
 msgid "Cemetery"
 msgstr "墓地"
 
 #. [label]
 #. the old word for "general store"
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:133
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:132
 msgid "Mercantile"
 msgstr "商店"
 
 #. [label]
 #. the old word for "pub". "Bar" is about the same.
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:145
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:144
 msgid "Public House"
 msgstr "酒吧"
 
 #. [label]
 #. or prison, or just "Jail"
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:151
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:150
 msgid "Jailhouse"
 msgstr "监狱"
 
 # Boatyard:an area where boats are built and repaired 造船厂；修船厂；船坞
 #. [label]
 #. or Boatyard
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:157
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:156
 msgid "Boatworks"
 msgstr "造船厂"
 
@@ -1699,49 +1699,49 @@ msgstr "造船厂"
 # 2.hall:a building or large room for public events such as meetings or dances 大厅，会堂，礼堂
 #. [label]
 #. "Grange" in the American usage: farmers' association
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:163
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:162
 msgid "Grange Hall"
 msgstr "议事大厅"
 
 #. [message]: speaker=Carcyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:252
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:249
 msgid "Carcyn Fisher at your service, and this is my friend Shynal."
 msgstr "卡辛·费希尔乐意为您效劳，这位是我的朋友赛娜尔。"
 
 # Giggle:to laugh quickly, quietly, and in a high voice, because something is funny or because you are nervous or embarrassed 咯咯笑，傻笑
 #. [message]: speaker=Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:256
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:253
 msgid "“Friend?” (<i>Giggle</i>) Oh, yes, we’re very good friends."
 msgstr "“朋友？”（<b>傻笑</b>）哦，是的，我们是非常要好的朋友。"
 
 #. [message]: speaker=Carcyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:260
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:257
 msgid ""
 "Or... you know. Thanks so much for getting us out, sir. We would be glad to "
 "follow you!"
 msgstr "或者说……您懂的。十分感谢您解救我们出来，先生。我们很乐意追随您！"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:264
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:261
 msgid "You are Carcyn the Third I presume?"
 msgstr "我猜你是卡辛三世？"
 
 # threw me in this hole
 # 推进火坑
 #. [message]: speaker=Carcyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:273
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:270
 msgid "Don’t remind me. My father is the one who threw me in this hole."
 msgstr "请别提我的姓氏。就是我爸亲手把我关在这里的。"
 
 # stay out of vt. 置身于……之外
 #. [message]: speaker=Carcyn Fisher
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:277
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:274
 msgid "You stay out of this, son."
 msgstr "别插手这事，儿子。"
 
 # put someone in his/her place:Someone who puts you in your place shows you that you are not better than other people and should not be acting in such a confident and proud way.挫某人的锐气；杀某人的气焰
 #. [message]: speaker=Carcyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:281
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:278
 msgid ""
 "Not a chance! I’ve waited all my life to see someone put you in your place. "
 "Here is someone you can’t push around!"
@@ -1751,13 +1751,13 @@ msgstr ""
 
 # stinking: spoken used to say that something is bad, unfair, dishonest etc 让人感觉糟糕，令人厌恶
 #. [message]: speaker=Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:285
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:282
 msgid "And we’re leaving this stinking town!"
 msgstr "而且我们就要离开这个令人厌恶的小镇了！"
 
 # put someone in his/her place:Someone who puts you in your place shows you that you are not better than other people and should not be acting in such a confident and proud way.挫某人的锐气；杀某人的气焰
 #. [message]: speaker=Carcyn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:291
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:288
 msgid ""
 "The only Carcyn now. I’ve waited all my life to see someone to put my father "
 "in his place. I guess you did that."
@@ -1766,18 +1766,18 @@ msgstr ""
 "气。我想你做到了。"
 
 #. [message]: speaker=Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:295
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:292
 msgid "You’re the only Carcyn for me."
 msgstr "对我来说你永远是卡辛家族唯一的真男人。"
 
 #. [message]: speaker=Raydah
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:308
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:305
 msgid "Look at that! He’s not from the Academy."
 msgstr "看那个！他不是从学院来的。"
 
 # tolerate:可接纳的; 被接受的
 #. [message]: speaker=Carcyn Fisher
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:312
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:309
 msgid ""
 "Hold your tongue! I can see that! I tolerate advisors but not when they only "
 "speak the obvious."
@@ -1787,26 +1787,26 @@ msgstr ""
 
 # defy: to refuse to obey a law or rule, or refuse to do what someone in authority tells you to do 违抗〔法律或规则〕；拒不服从〔有权威者〕
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:323
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:320
 msgid "I warned you not to defy me."
 msgstr "我警告过你不要违抗我。"
 
 # greetings: old use used to say hello to someone 你好！
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:333
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:330
 msgid "Greetings! I am Ras-Tabahn the mage."
 msgstr "你好！我是法师拉斯-塔班。"
 
 # greetings: old use used to say hello to someone 你好！
 #. [message]: speaker=Carcyn Fisher
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:337
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:334
 msgid ""
 "Greetings, traveler. I am Carcyn Fisher the Second. How can I be of service?"
 msgstr "你好，旅行者。我是卡辛·费希尔二世。我能为您做什么呢？"
 
 # offer: a statement saying that you are willing to do something for someone or give them something 〔愿为某人做某事或愿给某人某物的〕提议；提供
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:341
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:338
 msgid ""
 "I come with an offer. An offer of training in the magical arts. An offer of "
 "learning, adventure, and escape from this town."
@@ -1817,7 +1817,7 @@ msgstr ""
 # 1.peddle: to try to persuade people to accept an opinion or idea which is wrong or false 散布，兜售〔错误的观点、主张〕
 # 2.corruption:dishonest, illegal, or immoral behaviour, especially from someone with power 〔尤指有权势者的〕贪污，受贿，腐败；贿赂
 #. [message]: speaker=Carcyn Fisher
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:345
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:342
 msgid ""
 "No one in <i>my</i> town wishes to “escape”! We don’t care to hear your "
 "offer. Peddle your corruption elsewhere."
@@ -1826,7 +1826,7 @@ msgstr ""
 "狗屁提议吧。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:349
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:346
 msgid ""
 "The offer is not intended for <i>you</i>, it is for your youth. I will send "
 "my agents to every house and public space in this town and repeat my offer. "
@@ -1838,32 +1838,32 @@ msgstr ""
 # ensorcell
 # vt. 迷惑，盅惑；使着迷时
 #. [message]: speaker=Carcyn Fisher
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:353
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:350
 msgid ""
 "I will do no such thing! I will be dead before I allow you to ensorcell our "
 "children!"
 msgstr "我不会这么做的！我死也不会让你蛊惑我们的孩子！"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:357
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:354
 msgid "That may well be true."
 msgstr "你说的也对。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:365
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:362
 msgid ""
 "Hmm. The youngsters most willing to leave may be the ones in the jailhouse. "
 "I should investigate."
 msgstr "嗯。最希望离开的年轻人可能是监狱里的那些。我得去调查一下。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:407
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:404
 msgid "You can now recruit dark adepts!"
 msgstr "你现在可以征募黑暗狂徒了！"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:433
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:415
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg:430
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:413
 msgid ""
 "This has taken too long. We will surely miss our meeting with Ardonna now."
 msgstr "这花掉了太多时间。现在我们肯定会错过和阿冬娜的会面了。"
@@ -1893,30 +1893,30 @@ msgstr ""
 "一小部分力量。他们继续前进之后不久，便在河岸上看见了三座明显被袭击过的农场。"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:140
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:138
 msgid "(there will be three waves)"
 msgstr "（将有三波敌军）"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:140
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:138
 msgid "Destroy all the undead units"
 msgstr "摧毁所有的亡灵单位"
 
 #. [objective]: condition=lose
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:144
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:142
 msgid "Death of all five dark adepts"
 msgstr "所有五名黑暗狂徒死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:148
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:534
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:146
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:527
 #: data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg:104
 #: data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg:116
 msgid "Death of Ras-Tabahn"
 msgstr "拉斯-塔班死亡"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:158
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:156
 msgid ""
 "You will not earn gold this scenario, but your gold from the previous "
 "scenario will be available in the next."
@@ -1929,7 +1929,7 @@ msgstr ""
 # ‘就’ 可以表现塔班的性格，
 # ‘却’符合场景
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:353
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:351
 msgid ""
 "What happened here, I wonder. Well, no matter. What was bad for these "
 "families is good for us. I will animate them, and you will attack. Practice "
@@ -1943,42 +1943,42 @@ msgstr ""
 "我希望你们中的绝大部分人在这场战斗中活下来，所以试着别死掉。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:361
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:359
 msgid "plural^You may watch."
 msgstr "你们就看着吧。"
 
 #. [message]: speaker=Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:365
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:363
 msgid "Can we help?"
 msgstr "我们能帮什么忙吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:369
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:367
 msgid "plural^As you wish. (<i>Cough, cough</i>)"
 msgstr "想去就去吧。（<b>咳，咳</b>）"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:379
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:377
 msgid "You may watch."
 msgstr "你就看着吧。"
 
 #. [message]: id=Carcyn,Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:383
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:381
 msgid "Can I help?"
 msgstr "我能帮什么忙吗？"
 
 #. [message]: id=Carcyn,Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:384
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:382
 msgid "self_female^Can I help?"
 msgstr "我能帮什么忙吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:388
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:386
 msgid "As you wish. (<i>Cough, cough</i>)"
 msgstr "想去就去吧。（<b>咳，咳</b>）"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:396
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg:394
 msgid ""
 "You can recruit from in front of each dark adept during the first turn only."
 msgstr "只有在第一回合，你才可以在每一名黑暗狂徒前方进行征募。"
@@ -2001,7 +2001,7 @@ msgstr ""
 #. [side]: type=Merman Triton, id=Okean
 #. [side]
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg:46
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:132
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:126
 msgid "Merfolk"
 msgstr "人鱼"
 
@@ -2013,14 +2013,14 @@ msgstr "欧基恩"
 #. [message]: speaker=$unit.id
 #. Bones examined by a ghost, skeleton, ghoul, or corpse.
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg:134
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:160
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:158
 msgid "Bones. Claws and wings."
 msgstr "骨头、爪子和翅膀。"
 
 #. [message]: speaker=$unit.id
 #. Bones examined by a human.
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg:141
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:167
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:165
 msgid "There are some large bones here. I can see claws and wings."
 msgstr "这儿有很多大骨架。还有爪子和翅膀。"
 
@@ -2053,7 +2053,7 @@ msgstr "我想知道这些是什么物种的骨架。也许是一只不会飞的
 #. [message]: speaker=$other_human
 #. [message]: speaker=Ardonna
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg:246
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:243
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:241
 msgid "Oh, you were right!"
 msgstr "哦，你说对了！"
 
@@ -2069,7 +2069,7 @@ msgstr "太棒了！有了这些鸟我们就如虎添翼了。"
 
 #. [message]: speaker=narrator
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg:318
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:340
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:338
 msgid "You can now recruit chocobones!"
 msgstr "你现在可以征募骷髅鸟骑手了！"
 
@@ -2273,56 +2273,56 @@ msgstr ""
 
 #. [side]: type=Saurian Soothsayer, id=Krissaz
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:65
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:72
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:63
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:70
 msgid "Saurians"
 msgstr "蜥蜴人"
 
 #. [side]: type=Saurian Soothsayer, id=Krissaz
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:68
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:66
 msgid "Krissaz"
 msgstr "克里萨兹"
 
 #. [side]: type=Naga Myrmidon, id=Blianxkep
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:78
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:157
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:76
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:150
 msgid "Nagas"
 msgstr "娜迦"
 
 #. [side]: type=Naga Myrmidon, id=Blianxkep
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:81
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:79
 msgid "Blianxkep"
 msgstr "连克斯克普"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:102
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:115
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:100
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:526
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:100
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:111
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:98
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:519
 msgid "Defeat all enemy leaders"
 msgstr "击败所有敌方首领"
 
 # load: a large quantity of something that is carried by a vehicle, person etc 〔车辆、人等的〕负载物
 #. [message]: speaker=Blianxkep
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:130
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:127
 msgid ""
 "The fish people gave good value for the last load. More metal of that type "
 "is desired."
 msgstr "鱼人们对最后一批货给予了很好的评价。我还想要更多这种类型的金属。"
 
 #. [message]: speaker=Krissaz
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:134
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:131
 msgid "Firssst, pay us our ssshare."
 msgstr "嘶嘶，首先，把分成付给我们。"
 
 #. [message]: speaker=Blianxkep
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:138
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:135
 msgid "Wait, who approaches?"
 msgstr "等等，是谁来了？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:142
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:139
 msgid ""
 "I am a mage and not a threat to you gentle... reptiles. I wish only to "
 "animate some spirits, so I won’t disturb your salvage operation."
@@ -2331,7 +2331,7 @@ msgstr ""
 "们的分成谈判。"
 
 #. [message]: speaker=Krissaz
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:146
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:143
 msgid ""
 "No! You can’t make thisss place more haunted than it isss! The femalesss "
 "already won’t come here, and we are forced to rely on these ssserpents for "
@@ -2341,7 +2341,7 @@ msgstr ""
 "了，我们不得不靠这些蛇来保护自己。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:150
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:147
 msgid ""
 "I was only informing you out of courtesy. In truth, I don’t require your "
 "permission."
@@ -2350,7 +2350,7 @@ msgstr "我只是出于礼貌来通知你们，并不是来和你们商量的。
 # 1. drive off: drive somebody ↔ off to force a person or animal to go away from you 赶走某人[动物]
 # 2. in full: including the whole of something
 #. [message]: speaker=Blianxkep
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:154
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:151
 msgid ""
 "We will help you drive off this foe if you will consider your share paid in "
 "full."
@@ -2359,7 +2359,7 @@ msgstr ""
 "这个敌人。"
 
 #. [message]: speaker=Krissaz
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:158
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:155
 msgid ""
 "When the mage isss dead and her dead horde put to ressst, we agree. We will "
 "have been compensssated adequately."
@@ -2368,32 +2368,32 @@ msgstr ""
 "当作分成的补偿了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:162
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:159
 msgid "Every time..."
 msgstr "每次都是这样……"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:171
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:168
 msgid "Good. Now I can practice recruiting ghosts."
 msgstr "很好。现在我可以练习征募幽灵了。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:177
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:174
 msgid "You can now recruit ghosts!"
 msgstr "你现在可以征募幽灵了！"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:210
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:206
 msgid "Human, take me with you!"
 msgstr "人类，带我一起走吧！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:214
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:210
 msgid "Why should I allow that? Your people attacked me!"
 msgstr "我为什么要答应你？你们的人攻击我！"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:218
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:214
 msgid ""
 "I tried to ssstop them! For myself, I wissshed not to attack. I wissshed to "
 "learn. My race livesss but a short time compared to yoursss. I would learn "
@@ -2404,14 +2404,14 @@ msgstr ""
 "这一秘密。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:222
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:218
 msgid ""
 "Actually, I am searching for that secret now. But could you follow the "
 "orders of a woman?"
 msgstr "实际上，我正在探寻这一秘密。但你能听从一个女人的命令吗？"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:226
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:222
 msgid ""
 "I have ssstared into the darknesss between the starsss and not been "
 "intimidated by the void, but your mind holds a darknesss of another kind, "
@@ -2423,25 +2423,25 @@ msgstr ""
 "道你是女性，我觉的这更易于我们相处，因为这是我们一族待人处世的方式。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:230
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:226
 msgid "Very well, come along. I am Ardonna."
 msgstr "好，那就一起吧。我叫阿冬娜。"
 
 # untrue:  not based on facts that are correct 不真实的，假的
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:234
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:230
 msgid ""
 "Yesss, but the planetsss tell me your name isss now untrue. I do not "
 "underssstand thisss."
 msgstr "嘶嘶，太好了，但星相告诉我你的名字现在不再真实了。我不明白。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:238
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:234
 msgid "Nor do I. Your planets are quite cryptic."
 msgstr "我也不明白。你的星相很神秘。"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:242
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg:238
 msgid "They reveal what they will."
 msgstr "它们只揭示事物的本质。"
 
@@ -2479,17 +2479,17 @@ msgstr "森林"
 
 #. [unit]: type=Elvish Enchantress, id=Isthiniel
 #: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:56
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:761
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:754
 msgid "Isthiniel"
 msgstr "伊丝忒馨妮尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:105
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:106
 msgid "Move Ardonna to the northeast corner of the map"
 msgstr "移动阿冬娜至地图东北角"
 
 #. [message]: speaker=Isthiniel
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:319
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:320
 msgid ""
 "I felt our dead stirring and corruption descending on the forest. When I "
 "left to investigate, I expected to find grim, veiled forces at work. Instead "
@@ -2503,7 +2503,7 @@ msgstr ""
 "奴役的亡魂们。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:323
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:324
 msgid ""
 "Well, that I won’t do. However, if you do not attack, you will be rid of me "
 "soon, as I only wish to leave these woods."
@@ -2513,7 +2513,7 @@ msgstr ""
 
 # cast somebody/something ↔ out: to force someone or something to leave a place 把…赶走，驱逐
 #. [message]: speaker=Isthiniel
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:327
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:328
 msgid ""
 "Attack? No, I cannot. Most of my people won’t come here; it is only duty "
 "that drives me. However, the woods themselves are disturbed, and they will "
@@ -2524,22 +2524,22 @@ msgstr ""
 "们的觉醒。"
 
 #. [unit]: type=Ancient Wose, id=Dolmathengalin
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:344
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:345
 msgid "Dolmathengalin"
 msgstr "多尔玛森伽林"
 
 #. [message]: speaker=Dolmathengalin
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:351
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:352
 msgid "You are greeted daughter of elves. Why does the forest moan in despair?"
 msgstr "你好，精灵之女。为什么森林会发出绝望的呻吟？"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:355
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:356
 msgid "That tree can talk!"
 msgstr "那棵树会说话！"
 
 #. [message]: speaker=Isthiniel
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:359
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:360
 msgid ""
 "That dark mage has woken our dead and stifles the air with her very "
 "presence. Please wake your people, Elder, and destroy her."
@@ -2548,12 +2548,12 @@ msgstr ""
 "唤醒你的族人，长老，消灭她。"
 
 #. [message]: speaker=Dolmathengalin
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:363
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:364
 msgid "This shall be done."
 msgstr "理应如此。"
 
 #. [message]: speaker=Isthiniel
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:367
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg:368
 msgid "I shall leave you. I have no wish to witness this violence."
 msgstr "我现在要离开了。我并不想目击这样的暴力。"
 
@@ -2580,14 +2580,14 @@ msgstr ""
 "在那儿等着。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:121
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:119
 msgid ""
 "Greetings Ardonna! (<i>Cough</i>) I was successful, and I see that you were "
 "as well."
 msgstr "你好阿冬娜！（<b>咳</b>）我很顺利，我看你干的也很不错。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:125
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:123
 msgid ""
 "Well met, Ras-Tabahn. Yes I was. Now, can you explain the mission you spoke "
 "of?"
@@ -2596,7 +2596,7 @@ msgstr ""
 "所说的任务是什么了吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:129
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:127
 msgid ""
 "Gladly. I assume you studied the great mage Crelanu in history class. He "
 "fought with King Haldric the First. Since he faced the immortal lords of the "
@@ -2608,14 +2608,14 @@ msgstr ""
 "更了解他们的方法。最近，我已经知道在哪里可以找到他。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:133
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:131
 msgid ""
 "Of course I know about Crelanu. But can we force him to reveal his knowledge "
 "to us?"
 msgstr "我当然知道克雷拉努。但我们能迫使他把知道的东西都告诉我们吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:137
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:135
 msgid ""
 "That shouldn’t be necessary. I have also learned that he wrote a book "
 "containing all his secrets, which must include all he knows of immortality. "
@@ -2628,21 +2628,21 @@ msgstr ""
 "但现在，有我们这么大的一支队伍，要拿到书很容易。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:141
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:139
 msgid ""
 "Yes, that seems like a plan with a good chance of success. I will join you "
 "in your effort."
 msgstr "是的，这看起来是个成功几率很高的计划。我会协助你的。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:145
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:143
 msgid ""
 "I thought as much. We must cross the Great River, and head north into the "
 "Heart Mountains."
 msgstr "我也是这么想的。我们必须横渡泰河，往北进入心之山脉。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:154
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:152
 msgid ""
 "Before we leave, I have an unrelated question. Vendraxis here has said that "
 "my name is untrue. Do you have an idea what that could mean?"
@@ -2651,7 +2651,7 @@ msgstr ""
 "代表着什么吗？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:160
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:158
 msgid ""
 "Before we leave, I have an unrelated question. I met a mystic who said that "
 "my name was untrue. Do you have an idea what that could mean?"
@@ -2660,7 +2660,7 @@ msgstr ""
 "了。你知道这代表着什么吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:166
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:164
 msgid ""
 "Possibly. When an Academy mage completes his studies, he is granted "
 "syllables of power, which become his new name. You are well beyond that "
@@ -2674,7 +2674,7 @@ msgstr ""
 "合适了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:170
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:168
 msgid ""
 "I suppose you are right. I am no longer the ordinary girl Ardonna, and "
 "Vendraxis was correct. From now on I shall be... Ardryn-Na."
@@ -2683,14 +2683,14 @@ msgstr ""
 "始，我是……阿德琳-娜。"
 
 #. [modify_unit]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:177
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:175
 #: data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg:49
 #: data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg:56
 msgid "Ardryn-Na"
 msgstr "阿德琳-娜"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:181
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg:179
 msgid "Well then Ardryn-Na, let us head north."
 msgstr "那么阿德琳-娜，我们出发去北方吧。"
 
@@ -2731,28 +2731,28 @@ msgstr ""
 
 #. [side]: type=Orcish Warlord, id=Rod-Ishnak
 #. [side]: type=Orcish Warlord, id=Vok-Hroog
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:53
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:67
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:49
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:63
 msgid "Orcs"
 msgstr "兽人"
 
 #. [side]: type=Orcish Warlord, id=Rod-Ishnak
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:54
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:50
 msgid "Rod-Ishnak"
 msgstr "罗德-伊什纳克"
 
 #. [side]: type=Orcish Warlord, id=Vok-Hroog
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:68
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:64
 msgid "Vok-Hroog"
 msgstr "沃克-鲁格"
 
 #. [unit]: type=Orcish Shaman, id=Krongk
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:75
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:71
 msgid "Krongk"
 msgstr "隆克"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:173
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:169
 msgid ""
 "I have a sssense of dark foreboding regarding the sssnowy peaksss ahead. We "
 "may meet our doom if we don’t have enough coinsss."
@@ -2761,7 +2761,7 @@ msgstr ""
 "于此。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:179
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:175
 msgid ""
 "The passes to the north are the end of many travelers. We would be wise to "
 "reach them with a reserve of gold. (<i>Cough, cough</i>)"
@@ -2770,25 +2770,25 @@ msgstr ""
 "咳，咳</b>）"
 
 #. [message]: speaker=Krongk
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:192
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:188
 msgid "They’re attacking me!"
 msgstr "他们在攻击我！"
 
 #. [message]: speaker=Vok-Hroog
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:196
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:246
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:192
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:242
 msgid "Yeah, yeah."
 msgstr "来吧，开始吧。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:206
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:202
 msgid ""
 "We have crossed into the north. The dwarven kingdom of Knalga lies straight "
 "ahead."
 msgstr "我们已经到了北方地区。矮人王国纳尔迦就在正前方。"
 
 #. [message]: speaker=Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:210
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:206
 msgid ""
 "Now I’m really far from home. I’ve never been north of the river before. I "
 "hope I get to see some dwarves!"
@@ -2797,7 +2797,7 @@ msgstr ""
 
 # true: if a type of animal breeds true, the young animals are exactly like their parents 〔动物〕纯种地〔繁殖〕
 #. [message]: speaker=Vok-Hroog
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:214
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:210
 msgid ""
 "I claim this territory in the name of Krag-Ubor, the ruler of all true orcs! "
 "Leave now, Ishnak, or face the combined wrath of the five tribes."
@@ -2806,17 +2806,17 @@ msgstr ""
 "好面对五个部落燃起的熊熊怒火吧。"
 
 #. [message]: speaker=Rod-Ishnak
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:218
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:214
 msgid "I arrived first, Hroog. It’s mine!"
 msgstr "我先来的，拉格。这地方是我的！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:222
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:218
 msgid "This could be trouble."
 msgstr "看来会有麻烦的。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:226
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:222
 msgid ""
 "Many orcs are decent sorts (<i>cough, cough</i>). I fought alongside Krag-"
 "Ubor once, who the farther orc just mentioned."
@@ -2825,12 +2825,12 @@ msgstr ""
 "远处的兽人刚提到的那位。"
 
 #. [message]: speaker=Vok-Hroog
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:230
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:226
 msgid "Wait who’s that?"
 msgstr "等等，那边是谁？"
 
 #. [message]: speaker=Rod-Ishnak
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:234
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:230
 msgid ""
 "Wizards and deaders just like from back home! I <i>hate</i> those! I suggest "
 "a contest. Whoever kills the most wizards and skeletons and stuff takes this "
@@ -2840,23 +2840,23 @@ msgstr ""
 "多的巫师和骷髅之类的东西，谁就能得到这块领地和所有的人类奴隶。"
 
 #. [message]: speaker=Vok-Hroog
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:238
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:234
 msgid "Huh. Fine. That sounds like good sport."
 msgstr "哈。好啊。这听起来是个不错的运动项目。"
 
 #. [message]: speaker=Krongk
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:242
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:238
 msgid ""
 "I declare this competition official. I will support the claim of the winner."
 msgstr "我宣布这场比赛有效。我将会支持胜利者的要求。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:250
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:246
 msgid "I did say this was trouble."
 msgstr "我说过会有麻烦的。"
 
 #. [message]: speaker=Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:254
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg:250
 msgid "But we’ll win, won’t we?"
 msgstr "但我们肯定会赢的，不是吗？"
 
@@ -2889,73 +2889,73 @@ msgstr ""
 "他不想谈论这事，而宁愿否认自己的问题很严重。"
 
 #. [side]: type=Gryphon
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:46
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:57
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:44
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:55
 msgid "Gryphons"
 msgstr "狮鹫"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:73
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:71
 msgid "Move Ardryn-Na and Ras-Tabahn to level ground in the northeast corner"
 msgstr "移动阿德琳-娜和拉斯-塔班至东北角平地处"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:147
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:145
 msgid "There are some... large bones there. Claws and wings... I think."
 msgstr "这儿有些……很大的骨头。爪子和翅膀……我觉得。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:176
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:174
 msgid "I wonder what they are from. A gryphon perhaps?"
 msgstr "我想知道这些骨头是什么动物的。也许是一只狮鹫？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:180
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:178
 msgid "A large (<i>cough, cough</i>) flightless bird... would be my guess."
 msgstr "一种大型的（<b>咳，咳</b>）不能飞的鸟……我猜是这样。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:184
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:182
 msgid "Well, there is an easy way to discover the truth."
 msgstr "好吧，有个简单的方法可以找到答案。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:253
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:251
 msgid "I wonder... if it could carry... someone light. Vendraxis perhaps."
 msgstr "我想知道……它是不是能载上……体重轻的人。或许文德拉克西斯可以。"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:257
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:255
 msgid "I will not climb on that ridiculous thing!"
 msgstr "我不会坐上那种可笑的东西的！"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:263
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:261
 msgid "I wonder... if it could carry... someone light."
 msgstr "我想知道……它是不是能载上……体重轻的人。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:270
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:268
 msgid "A skeleton could ride it I think."
 msgstr "我觉得它可以承托一个骷髅。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:331
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:329
 msgid "That’s fantastic! These birds could be quite useful."
 msgstr "太棒了！这些鸟会很有用的。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:350
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:348
 msgid "What dangers may lurk in this fog?"
 msgstr "这片迷雾中可能潜藏着什么危险？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:354
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:352
 msgid "Gryphons... live at this height. We should be cautious."
 msgstr "狮鹫……就生活在这里的高处。我们得小心点。"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:363
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg:361
 msgid "Yesss. The danger I sssensed is here."
 msgstr "没错，嘶嘶。我感觉到的危险就在这里，嘶嘶。"
 
@@ -2982,18 +2982,18 @@ msgstr ""
 "病很重，呼吸也很混乱。我不知道他还能活多久。"
 
 #. [side]: type=Elder Mage, id=Crelanu
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:47
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:50
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:45
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:48
 msgid "Crelanu"
 msgstr "克雷拉努"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:73
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:71
 msgid "Defeat Crelanu"
 msgstr "击败克雷拉努"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:85
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:83
 msgid ""
 "Ras-Tabahn is slowed and will lose four hitpoints every turn. He will die if "
 "he reaches zero."
@@ -3001,41 +3001,41 @@ msgstr ""
 "拉斯-塔班行动缓慢，每回合还会失去四点生命值，如果生命值降到零，他就会死亡。"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:88
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:86
 msgid ""
 "Moving any unit onto a bottle of holy water will remove the bottle. An "
 "undead unit will be destroyed."
 msgstr "将任何单位移动到圣水瓶处，将会移除此瓶。同时一个亡灵单位将被摧毁。"
 
 #. [unit]: type=White Mage, id=Ginmera
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:224
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:222
 msgid "Ginmera"
 msgstr "金梅拉"
 
 #. [message]: speaker=Ginmera
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:257
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:255
 msgid ""
 "It seems that the invaders can raise undead soldiers, so I placed some holy "
 "water around the castle for protection."
 msgstr "看起来入侵者可以复苏亡灵士兵，所以我在城堡周围布置了一些圣水来防护。"
 
 #. [unit]: type=White Mage, id=Rinconan
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:262
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:260
 msgid "Rinconan"
 msgstr "林柯南"
 
 #. [message]: speaker=Ginmera
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:274
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:272
 msgid "Rinconan and I will stay here to guard you."
 msgstr "林柯南和我会待在这儿保护您。"
 
 #. [message]: speaker=Crelanu
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:278
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:276
 msgid "Yes. Thank you Ginmera."
 msgstr "好的。谢谢你金梅拉。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:284
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:282
 msgid ""
 "Moving a unit onto a bottle of holy water will remove the bottle. A living "
 "unit can do this safely, but any undead unit will be destroyed."
@@ -3044,17 +3044,17 @@ msgstr ""
 "何亡灵单位都将被摧毁。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:336
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:334
 msgid "Crelanu! (<i>Cough, cough</i>) We have come... for your book."
 msgstr "克雷拉努！（<b>咳，咳</b>）我们想……看看你的书。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:340
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:338
 msgid "We need to borrow it."
 msgstr "我们需要借你的书看看。"
 
 #. [message]: speaker=Crelanu
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:344
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:342
 msgid ""
 "Yes, I knew people like you would be coming, but the book is out of reach "
 "now — for all of us. I have given it to the elves. Only they know where it "
@@ -3064,12 +3064,12 @@ msgstr ""
 "如此。我已经把它给了精灵。只有他们才知道它在哪儿。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:348
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:346
 msgid "Why would you do such a thing?"
 msgstr "你为什么要这样做？"
 
 #. [message]: speaker=Crelanu
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:352
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:350
 msgid ""
 "So that one like you would not be tempted to do what you intend. Oh, yes. I "
 "know well what you seek."
@@ -3078,22 +3078,22 @@ msgstr ""
 "什么。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:356
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:354
 msgid "Then you can tell us what we want to know."
 msgstr "那么你可以把我们想知道的东西告诉我们。"
 
 #. [message]: speaker=Crelanu
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:360
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:358
 msgid "I shall not."
 msgstr "我不会的。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:364
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:362
 msgid "We shall see."
 msgstr "走着瞧。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:369
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:367
 msgid ""
 "Ras-Tabahn is sick. He is slowed, and will lose four hitpoints every turn. "
 "He will die if he reaches zero."
@@ -3102,12 +3102,12 @@ msgstr ""
 "么他就会死亡。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:397
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:395
 msgid "Now, you will tell us the secret of immortality or die!"
 msgstr "现在，你得告诉我们长生不老的秘密，不然就去死！"
 
 #. [message]: speaker=Crelanu
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:401
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:399
 msgid ""
 "There <i>is no secret</i>, you fools! Magic cannot stop aging. You cannot "
 "live forever. It is the way of nature, and the greatest thing we have in "
@@ -3119,7 +3119,7 @@ msgstr ""
 "的身体。我不会因为任何理由尝试这些的。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:405
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:403
 msgid ""
 "You are the fool, for you have, indeed, told us all we required. For that, I "
 "will spare you to live a few more lonely years with your cowardice."
@@ -3128,12 +3128,12 @@ msgstr ""
 "你，让你继续怯懦孤独地苟活几年。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:418
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:416
 msgid "I don’t understand. What did Crelanu tell us?"
 msgstr "我不明白。克雷拉努告诉了我们什么？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:422
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg:420
 msgid ""
 "I will explain. Let us get you somewhere safe first. We’ll go into the cave. "
 "Come with me."
@@ -3159,23 +3159,23 @@ msgstr ""
 "人。”城堡里到处都是老鼠，很明显，很长时间以来，都没有矮人住在这里了。"
 
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:37
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:35
 msgid "Rats"
 msgstr "老鼠"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:129
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:127
 msgid "Just a little farther."
 msgstr "再往里走一点就好。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:138
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:136
 msgid ""
 "Ardryn-Na, I’m dying. (<i>Cough, cough</i>) I don’t think... I can stop it."
 msgstr "阿德琳-娜，我要死了。（<b>咳，咳</b>）我不认为……我能阻止死亡的来临。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:142
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:140
 msgid ""
 "Nor should you! You must embrace it. Crelanu said as much. He also said your "
 "life force must depart, but he didn’t say it could not come back to you!"
@@ -3184,12 +3184,12 @@ msgstr ""
 "须离开你的身体，但他并没有说这力量不能回到你的身上！"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:146
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:144
 msgid "What are you... proposing?"
 msgstr "你的……意思是？"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:150
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:148
 msgid ""
 "That you project your will into another object so that it is part of you — "
 "your staff for example. If you do this just as your body dies, your whole "
@@ -3201,7 +3201,7 @@ msgstr ""
 "去，因为它没有别的地方可去。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:154
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:152
 msgid ""
 "Well, it could go to the... lands of the dead. But... if I had an altar... "
 "the stone would serve to anchor me (<i>cough, cough, cough</i>) to this "
@@ -3211,7 +3211,7 @@ msgstr ""
 "咳，咳</b>）锚定在这个层面上……这样就可以阻止我的灵魂流逝……但只是一小会儿。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:158
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:156
 msgid ""
 "And a moment is all you need! You only need project your will <i>back</i> "
 "into your body, animating it as you would anything else!"
@@ -3220,13 +3220,13 @@ msgstr ""
 "苏，就像你复苏其他东西一样！"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:162
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:160
 msgid ""
 "You seem... more sure than I, but  (<i>cough, cough</i>) I have no choice."
 msgstr "你看起来……比我确信多了，我（咳，咳）也没有别的选择了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:166
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:164
 msgid ""
 "Crelanu said he wouldn’t do it. That implies that he <i>could</i>, so he "
 "also believed that it would work. And like you said, he should know. For "
@@ -3236,7 +3236,7 @@ msgstr ""
 "且正如你所说，他应该知道这些。现在你可以休息一下。我们很快就会建好祭坛。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:302
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:300
 msgid ""
 "No need for you to wait to die. We can have done with it immediately. And "
 "although neither of us needs speak the incantations aloud anymore, you "
@@ -3246,7 +3246,7 @@ msgstr ""
 "语，你自己来，因为任何失误都会是灾难性的。"
 
 #. [message]: speaker=necromancer_on_altar
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:306
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg:304
 msgid "Yes. I’m ready. Do it."
 msgstr "是的。我准备好了。开始吧。"
 
@@ -3321,33 +3321,33 @@ msgstr ""
 "界分享我的知识，这样一来，<b>没人</b>会死了。"
 
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:70
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:68
 msgid "Spiders"
 msgstr "蜘蛛"
 
 #. [objective]: condition=win
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:84
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:82
 msgid "Move Ardryn-Na and Ras-Tabahn to the west end of the cave"
 msgstr "移动阿德琳-娜和拉斯-塔班至洞穴西端"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:97
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:95
 msgid ""
 "To turn a necromancer into a lich, right-click on it while it is in a castle."
 msgstr "若要将一名死灵法师转变为巫妖，那么当它在城堡之中时鼠标右键单击它。"
 
 #. [set_menu_item]: id=lichify
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:104
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:102
 msgid "Make Into a Lich"
 msgstr "转变为巫妖"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:134
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:132
 msgid "You can only do this in a castle."
 msgstr "只有在城堡里才能这样做。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:423
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:421
 msgid ""
 "You can now advance dark sorcerers to liches! For the rest of the campaign, "
 "you can also right-click on an existing necromancer to turn it into a lich "
@@ -3359,7 +3359,7 @@ msgstr ""
 "获得了足够多的经验，那么它会直接升级成为上古巫妖！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:428
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:426
 msgid ""
 "We have conquered death! Let us bring the news back to Wesnoth! Let all in "
 "this world know that nobody ever need die again."
@@ -3368,7 +3368,7 @@ msgstr ""
 "有人死了。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:432
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:430
 msgid ""
 "I was planning to go that direction myself, so I have no objection. But, let "
 "us not go over those wretched mountain passes again. These tunnels should "
@@ -3378,32 +3378,32 @@ msgstr ""
 "该是通往纳尔迦区域的，我们能直接到那儿。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:436
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:434
 msgid "Why would the dwarvish empire abandon an outpost like this?"
 msgstr "矮人帝国为什么会放弃这样一个前哨站呢？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:440
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:438
 msgid "We may find out. We should proceed cautiously."
 msgstr "我们也许能找到答案。我们得小心前进。"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:456
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:454
 msgid "Giant spidersss! That explainsss the cobwebsss everywhere."
 msgstr "巨型蜘蛛！嘶嘶！怪不得到处都是蜘蛛网。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:462
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:460
 msgid "Giant spiders! That explains the cobwebs everywhere."
 msgstr "巨型蜘蛛！怪不得到处都是蜘蛛网。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:468
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:466
 msgid "They are not moving much. Hopefully they continue to stay sleepy."
 msgstr "它们没怎么动。但愿它们一直这样睡着。"
 
 #. [message]: speaker=Shynal
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:474
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg:472
 msgid "They’re waking up now. Watch out."
 msgstr "它们正在苏醒。小心。"
 
@@ -3465,29 +3465,29 @@ msgstr "我们的旅程继续着，最终，我们面前出现了橙色的光芒
 #. [side]: type=Troll Shaman, id=Shurd
 #. [side]: type=Great Troll, id=Brek
 #. [side]: type=Troll Shaman, id=Uurgh
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:52
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:66
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:81
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:50
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:64
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:79
 msgid "Trolls"
 msgstr "巨魔"
 
 #. [side]: type=Troll Shaman, id=Shurd
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:57
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:55
 msgid "Shurd"
 msgstr "术德"
 
 #. [side]: type=Great Troll, id=Brek
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:72
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:70
 msgid "Brek"
 msgstr "雷克"
 
 #. [side]: type=Troll Shaman, id=Uurgh
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:87
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:85
 msgid "Üurgh"
 msgstr "物戈"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:123
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:121
 msgid ""
 "I had heard that mountains sometimes breathed fire like dragons, but that "
 "seemed a fanciful tale. From the look of this, that may actually be true."
@@ -3496,7 +3496,7 @@ msgstr ""
 "来，那传说或许是真的。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:127
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:125
 msgid ""
 "Yes, it’s quite true. This mountain fire has some uses too. For example, "
 "trolls use it for welding together crude armor."
@@ -3505,27 +3505,27 @@ msgstr ""
 "甲。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:131
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:129
 msgid "Trolls! Do you think we shall encounter any?"
 msgstr "巨魔！你觉得我们会遇到它们吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:135
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:133
 msgid "I see no reason to expect..."
 msgstr "我觉得别遇到比较好……"
 
 #. [message]: speaker=Shurd
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:139
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:137
 msgid "Invaders!"
 msgstr "入侵者！"
 
 #. [message]: speaker=Brek
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:143
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:141
 msgid "Crush them!"
 msgstr "打碎他们！"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:147
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg:145
 msgid "... Yes. Yes, I do."
 msgstr "……是的，没错，我觉得会遇到巨魔。"
 
@@ -3550,88 +3550,88 @@ msgstr ""
 
 #. [side]: type=Dwarvish Lord, id=Golbanduth
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:39
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:90
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:37
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:87
 msgid "Dwarves"
 msgstr "矮人"
 
 #. [side]: type=Dwarvish Lord, id=Golbanduth
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:42
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:40
 msgid "Golbanduth"
 msgstr "戈尔班达斯"
 
 #. [note]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:87
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:85
 msgid "You can recruit from anywhere in the Hall of Heroes."
 msgstr "你可以在英灵殿的任何一处进行征募。"
 
 #. [message]: speaker=Golbanduth
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:514
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:512
 msgid ""
 "The invaders approach! Fetch the last chest o’ gold. We’re equippin’ more "
 "soldiers."
 msgstr "入侵者来了！把最后的一箱金子拿出来。我们得武装更多的士兵。"
 
 #. [message]: speaker=porter
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:519
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:517
 msgid "Yes, sire."
 msgstr "是，陛下。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:630
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:628
 msgid ""
 "Actually, I don’t think this is the end. There is air coming through here. "
 "Help me shift these stones."
 msgstr "实际上，我不认为这是尽头。这儿有空气流通。来帮我把石头移开。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:708
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:706
 msgid "Now, where are we?"
 msgstr "现在，我们在哪儿？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:712
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:710
 msgid ""
 "We are in a dwarvish burial chamber it seems. That is good. We could always "
 "use some more soldiers."
 msgstr "我们似乎是在一座矮人的墓穴里。非常好。我们可以征募更多的士兵。"
 
 #. [unit]: type=Dwarvish Sentinel, id=Aigondur
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:724
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:722
 msgid "Aigondur"
 msgstr "艾贡达"
 
 #. [message]: speaker=Aigondur
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:729
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:727
 msgid ""
 "Human invaders be comin’ through the Hall o’ Heroes! I’m closin’ th’ Troll "
 "Gate!"
 msgstr "人类入侵者正通过英灵殿攻来！我必须立刻关闭巨魔之门！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:769
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:767
 msgid "Well, we are not going that way."
 msgstr "好吧，我们不能走那边了。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:773
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:771
 msgid ""
 "But look. There is a large crack in the wall to our right! I’m certain we "
 "could squeeze through."
 msgstr "但你看，我们左方的墙上有个大裂缝！我确信我们可以从那儿挤过去。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:777
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:775
 msgid "We’ll just remove the statue..."
 msgstr "我们只要移开雕像……"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:812
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:810
 msgid "... and push the coffin out of the way."
 msgstr "……再把棺木推走就行。"
 
 #. [message]: speaker=spotter
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:840
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg:838
 msgid "Ach! Th’ invaders have made it inna the Crystal Caves!"
 msgstr "啊！入侵者进入水晶洞穴了！"
 
@@ -3681,34 +3681,34 @@ msgid ""
 msgstr "但计划被打乱了。正当我们准备分道扬镳之时，平原突然变得拥挤起来。"
 
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:59
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:58
 msgid "Cavalry"
 msgstr "骑兵"
 
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:104
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:100
 msgid "Magi"
 msgstr "法师"
 
 #. [side]
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:118
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:113
 msgid "Elves"
 msgstr "精灵"
 
 #. [message]: speaker=Thrigalurd
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:330
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:323
 msgid ""
 "The enemy already attempts to breach our castle walls! Up arms lads, look "
 "lively!"
 msgstr "敌人试图突破我们的城墙！拿起武器，小伙子们，打起精神来！"
 
 #. [message]: speaker=Thrigalurd
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:336
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:329
 msgid "Now we avenge the fallen of Knalga!"
 msgstr "现在我们要为纳尔迦的牺牲者们报仇！"
 
 #. [message]: speaker=Carmyna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:359
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:352
 msgid ""
 "The enemy is already poised to attack! They must have anticipated our "
 "arrival. No rest my friends; we go to work immediately."
@@ -3717,7 +3717,7 @@ msgstr ""
 "马上开始战斗。"
 
 #. [message]: speaker=Carmyna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:365
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:358
 msgid ""
 "The battle is already underway. So many of our comrades have fallen! We must "
 "incinerate these undead and rid the world of this evil."
@@ -3726,7 +3726,7 @@ msgstr ""
 "邪恶从世上驱除出去。"
 
 #. [message]: speaker=Isthiniel
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:388
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:381
 msgid ""
 "What is this? The enemy lurking in wait in our forests? To arms! Let us "
 "immediately rid our land of this foulness!"
@@ -3735,25 +3735,25 @@ msgstr ""
 "的领地上驱除出去吧！"
 
 #. [message]: speaker=Isthiniel
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:394
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:387
 msgid ""
 "Never again will these monsters use the spirits of our ancestors against us. "
 "We will burn them down!"
 msgstr "这些怪物将会再也不能用我们祖先的灵魂来对付我们。我们将把他们烧尽！"
 
 #. [objective]: condition=lose
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:530
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:523
 #: data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg:112
 msgid "Death of Ardryn-Na"
 msgstr "阿德琳-娜死亡"
 
 #. [unit]: type=Saurian Flanker, id=Fizztsars
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:568
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:561
 msgid "Fizztsars"
 msgstr "菲兹萨斯"
 
 #. [message]: speaker=Fizztsars
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:575
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:568
 msgid ""
 "We have arrived, Taxsstrimon. We will fight bessside you. They will pay for "
 "killing our malesss!"
@@ -3762,120 +3762,120 @@ msgstr ""
 "而付出代价！"
 
 #. [message]: speaker=Taxtrimon
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:579
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:572
 msgid "Well met Fizztsars. Now these creatures will certainly fall."
 msgstr "幸会，菲兹萨斯。现在这些生物必将被毁灭。"
 
 #. [message]: speaker=Fizztsars
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:588
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:581
 msgid "Except for the male of oursss with them. He will come with usss."
 msgstr "他们队伍里有我们的同胞，别杀他。他会回到我们这边的。"
 
 #. [message]: speaker=Vendraxis
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:592
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:585
 msgid "No! I will not return yet, I still have sssecrets to learn!"
 msgstr "不！我不会回去的，我还有秘密要去探索！"
 
 #. [unit]: type=Dwarvish Dragonguard, id=Thrigalurd
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:619
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:612
 msgid "Thrigalurd"
 msgstr "崔伽拉德"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:634
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:627
 msgid "Look! The dwarves circled around in front of us."
 msgstr "看！矮人又回来添乱了。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:638
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:631
 msgid "That’s why getting through Knalga was so easy."
 msgstr "这就是通过纳尔迦时那么容易的原因吧。"
 
 #. [unit]: type=Great Mage, gender=female, id=Carmyna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:696
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:689
 msgid "Carmyna"
 msgstr "卡麦那"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:715
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:708
 msgid "They just keep coming! Has nobody even considered what we offer?"
 msgstr "他们源源不断地来增援！难道就没人考虑过我们永生不死的提议吗？"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:725
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:718
 msgid "Well. That was intense."
 msgstr "嗯。战斗还挺激烈的。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:729
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:722
 msgid "At last we are victorious!"
 msgstr "我们终于胜利了！"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:780
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:773
 msgid "The whole world is against us."
 msgstr "全世界都和我们为敌。"
 
 #. [unit]: type=Paladin, id=Gwendir
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:818
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:811
 msgid "Gwendir"
 msgstr "格温迪尔"
 
 #. [message]: speaker=adviser
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:842
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:835
 msgid ""
 "This is the place Crelanu’s gryphon told us to come, and yon party has an "
 "ill-favored look."
 msgstr "这是克雷拉努的狮鹫告诉我们该来的地方，你们这群人看上去真让人不快啊。"
 
 #. [message]: speaker=Gwendir
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:846
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:839
 msgid "Yes, I believe that is our quarry."
 msgstr "是了，我相信那些就是我们的目标。"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:850
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:843
 msgid "Crelanu! Still he haunts us. Remind me again why we didn’t kill him."
 msgstr "克雷拉努！他还是缠着我们不放。再提醒我一下，我们当初为什么没有杀掉他。"
 
 #. [message]: speaker=Gwendir
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:854
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:847
 msgid ""
 "Ardonna of Tarrynth and Rassin Tabin, you stand convicted of necromancy, and "
 "are sentenced to death!"
 msgstr "塔林斯的阿冬娜以及拉辛·塔宾，你们的亡灵巫术罪名成立，并被判处死刑!"
 
 #. [message]: speaker=Ras-Tabahn
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:858
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:851
 msgid ""
 "Is that all? Death holds no terror for us as we have died already. You will "
 "follow shortly."
 msgstr "就这？死亡可吓不到我们，因为我们已经死了。你很快也会死的。"
 
 #. [message]: speaker=Gwendir
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:862
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:855
 msgid "The blessed swords of our order will soon give you cause to fear again."
 msgstr "我们神圣的剑很快就会让你再次感到恐惧。"
 
 #. [message]: speaker=adviser
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:866
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:859
 msgid "Sir, the magi have not yet arrived."
 msgstr "长官，法师们还没有到。"
 
 #. [message]: speaker=Gwendir
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:870
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:863
 msgid ""
 "No matter. We need not fear this darkness, and we need not wait on the "
 "schoolteachers."
 msgstr "没关系。我们不需要害怕这黑暗，我们也不需要等那些学校老师。"
 
 #. [unit]: type=Naga Myrmidon, id=Taxtrimon
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:883
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:876
 msgid "Taxtrimon"
 msgstr "塔克斯崔蒙"
 
 #. [message]: speaker=Taxtrimon
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:900
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:893
 msgid ""
 "We have found them! These magi destroyed a profitable business venture. We "
 "will take vengeance. You horse humans can assist us."
@@ -3884,17 +3884,17 @@ msgstr ""
 "可以协助我们。"
 
 #. [unit]: type=Merman Hoplite, id=Mauapan
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:913
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:906
 msgid "Mauapan"
 msgstr "矛阿潘"
 
 #. [message]: speaker=Mauapan
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:919
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:912
 msgid "I will also assist. Too many innocents have died. This ends today."
 msgstr "我也会帮忙的。已经有太多无辜者死去了。今天必须做个了结。"
 
 #. [message]: speaker=Ardonna
-#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:923
+#: data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg:916
 msgid "We are surrounded. We must defeat this horde."
 msgstr "我们被包围了。我们必须击败这一大群敌人。"
 
@@ -4415,7 +4415,7 @@ msgstr "半虚空"
 #. shown instead of the unit_type name in the recruitment dialog
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:24
 msgid "recruit^Flying Corpse (Bat)"
-msgstr "征募^飞行僵尸（蝙蝠）"
+msgstr "飞行僵尸（蝙蝠）"
 
 #. [value]: type=SotA Flying Corpse_Bat
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:25
@@ -4425,7 +4425,7 @@ msgstr "你现在可以征募僵尸蝙蝠了！"
 #. [value]: type=SotA Walking Corpse_Rat
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:30
 msgid "recruit^Walking Corpse (Rat)"
-msgstr "征募^陆行僵尸（老鼠）"
+msgstr "陆行僵尸（老鼠）"
 
 #. [value]: type=SotA Walking Corpse_Rat
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:31
@@ -4435,7 +4435,7 @@ msgstr "你现在可以征募僵尸老鼠了！"
 #. [value]: type=SotA Walking Corpse_Wolf
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:36
 msgid "recruit^Walking Corpse (Wolf)"
-msgstr "征募^陆行僵尸（狼）"
+msgstr "陆行僵尸（狼）"
 
 #. [value]: type=SotA Walking Corpse_Wolf
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:37
@@ -4445,7 +4445,7 @@ msgstr "你现在可以征募僵尸狼了！"
 #. [value]: type=SotA Walking Corpse_Human
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:42
 msgid "recruit^Walking Corpse (Human)"
-msgstr "征募^陆行僵尸（人类）"
+msgstr "陆行僵尸（人类）"
 
 #. [value]: type=SotA Walking Corpse_Human
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:43
@@ -4456,7 +4456,7 @@ msgstr "你现在可以征募僵尸人类了！"
 #. the mount is an undead horse (not a wolf), this is shown instead of the unit_type name in the recruitment dialog
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:49
 msgid "recruit^Walking Corpse (Mounted)"
-msgstr "征募^陆行僵尸（骑兵）"
+msgstr "陆行僵尸（骑兵）"
 
 #. [value]: type=SotA Walking Corpse_Mounted
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:50
@@ -4466,7 +4466,7 @@ msgstr "你现在可以征募僵尸骑兵了！"
 #. [value]: type=SotA Walking Corpse_Wolf Rider
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:55
 msgid "recruit^Walking Corpse (Wolf Rider)"
-msgstr "征募^陆行僵尸（狼骑兵）"
+msgstr "陆行僵尸（狼骑兵）"
 
 #. [value]: type=SotA Walking Corpse_Wolf Rider
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:56
@@ -4477,7 +4477,7 @@ msgstr "你现在可以征募僵尸狼骑兵了！"
 #. this is used for both naga and merfolk zombies
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:62
 msgid "recruit^Swimming Corpse"
-msgstr "征募^水行僵尸"
+msgstr "水行僵尸"
 
 #. [value]: type=SotA Swimming Corpse
 #. this is used for both naga and merfolk zombies
@@ -4488,7 +4488,7 @@ msgstr "你现在可以征募水行僵尸了！"
 #. [value]: type=SotA Walking Corpse_Saurian
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:69
 msgid "recruit^Walking Corpse (Saurian)"
-msgstr "征募^陆行僵尸（蜥蜴人）"
+msgstr "陆行僵尸（蜥蜴人）"
 
 #. [value]: type=SotA Walking Corpse_Saurian
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:70
@@ -4498,7 +4498,7 @@ msgstr "你现在可以征募僵尸蜥蜴人了！"
 #. [value]: type=SotA Walking Corpse_Wose
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:75
 msgid "recruit^Walking Corpse (Wose)"
-msgstr "征募^陆行僵尸（树人）"
+msgstr "陆行僵尸（树人）"
 
 #. [value]: type=SotA Walking Corpse_Wose
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:76
@@ -4508,7 +4508,7 @@ msgstr "你现在可以征募僵尸树人了！"
 #. [value]: type=SotA Walking Corpse_Goblin
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:81
 msgid "recruit^Walking Corpse (Goblin)"
-msgstr "征募^陆行僵尸（地精）"
+msgstr "陆行僵尸（地精）"
 
 #. [value]: type=SotA Walking Corpse_Goblin
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:82
@@ -4518,7 +4518,7 @@ msgstr "你现在可以征募僵尸地精了！"
 #. [value]: type=SotA Flying Corpse_Gryphon
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:87
 msgid "recruit^Flying Corpse (Gryphon)"
-msgstr "征募^陆行僵尸（狮鹫）"
+msgstr "陆行僵尸（狮鹫）"
 
 #. [value]: type=SotA Flying Corpse_Gryphon
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:88
@@ -4528,7 +4528,7 @@ msgstr "你现在可以征募僵尸狮鹫了！"
 #. [value]: type=SotA Walking Corpse_Spider
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:93
 msgid "recruit^Walking Corpse (Spider)"
-msgstr "征募^陆行僵尸（蜘蛛）"
+msgstr "陆行僵尸（蜘蛛）"
 
 #. [value]: type=SotA Walking Corpse_Spider
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:94
@@ -4538,7 +4538,7 @@ msgstr "你现在可以征募僵尸蜘蛛了！"
 #. [value]: type=SotA Walking Corpse_Troll
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:99
 msgid "recruit^Walking Corpse (Troll)"
-msgstr "征募^陆行僵尸（巨魔）"
+msgstr "陆行僵尸（巨魔）"
 
 #. [value]: type=SotA Walking Corpse_Troll
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:100
@@ -4548,7 +4548,7 @@ msgstr "你现在可以征募僵尸巨魔了！"
 #. [value]: type=SotA Walking Corpse_Dwarf
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:105
 msgid "recruit^Walking Corpse (Dwarf)"
-msgstr "征募^陆行僵尸（矮人）"
+msgstr "陆行僵尸（矮人）"
 
 #. [value]: type=SotA Walking Corpse_Dwarf
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg:106
@@ -4578,24 +4578,9 @@ msgstr "经验："
 #. [lua]: postshow
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie_recruit_dialog.lua:88
 msgid "There are no corpses available."
-msgstr "没有可用的僵尸。"
+msgstr "没有可用的尸体。"
 
 #. [lua]: postshow
 #: data/campaigns/Secrets_of_the_Ancients/utils/zombie_recruit_dialog.lua:96
 msgid "You do not have enough gold to recruit that unit"
 msgstr "你没有足够的金币用来征募此单位"
-
-#~ msgid "Dwarvish Miner"
-#~ msgstr "矮人矿工"
-
-#~ msgid ""
-#~ "Dwarvish miners are the grunt workers of dwarvish society. They take the "
-#~ "precious ores out of the ground, but do not ever take part in the "
-#~ "crafting of weapons or artifacts. They have no military training, but "
-#~ "they can still do some damage with their picks."
-#~ msgstr ""
-#~ "矮人矿工是矮人社会的底层工人。他们从地里挖出宝贵的矿物，但从来都不参与武器"
-#~ "或其他铸造品的铸造。他们没有受过军事训练，但还是能用镐子造成一些伤害。"
-
-#~ msgid "pick"
-#~ msgstr "镐"

--- a/translations/wesnoth/po/wesnoth-sotbe/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-sotbe/zh_CN.po
@@ -1,26 +1,27 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
 # IkathrioLionheart <axalaraflameheart@163.com>, 2012.
 # CloudiDust <cloudidust@gmail.com>, 2017.
 # termanary, 2019.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.16\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2025-09-22 04:01 UTC\n"
-"PO-Revision-Date: 2024-06-10 15:51+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-06-23 03:16 UTC\n"
+"PO-Revision-Date: 2026-08-27 20:54+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=Son_of_the_Black-Eye
 #: data/campaigns/Son_Of_The_Black_Eye/_main.cfg:9
@@ -91,17 +92,13 @@ msgstr "战役设计"
 
 #. [about]
 #: data/campaigns/Son_Of_The_Black_Eye/_main.cfg:41
-#, fuzzy
-#| msgid "Campaign Maintenance"
 msgid "Current Campaign Maintainer"
-msgstr "战役维护"
+msgstr "当前战役维护者"
 
 #. [about]
 #: data/campaigns/Son_Of_The_Black_Eye/_main.cfg:47
-#, fuzzy
-#| msgid "Campaign Maintenance"
 msgid "Campaign Maintainers (former)"
-msgstr "战役维护"
+msgstr "战役维护者（原先）"
 
 #. [about]
 #: data/campaigns/Son_Of_The_Black_Eye/_main.cfg:56
@@ -139,7 +136,7 @@ msgstr "打败阿尔伯"
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:25
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg:24
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:26
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:58
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:54
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:27
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:31
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:30
@@ -155,8 +152,8 @@ msgstr "卡破尔死亡"
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:56
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:64
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/02_The_Human_Army.cfg:76
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:96
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:138
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:95
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:137
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:57
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:87
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/05_To_the_Harbor_of_Tirigaz.cfg:75
@@ -171,11 +168,11 @@ msgstr "卡破尔死亡"
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg:57
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:59
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:85
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:82
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:78
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:52
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:60
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:53
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:159
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:158
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/19_Epilogue.cfg:19
 #: data/campaigns/Son_Of_The_Black_Eye/utils/utils.cfg:92
 #: data/campaigns/Son_Of_The_Black_Eye/utils/utils.cfg:106
@@ -249,7 +246,7 @@ msgstr ""
 "而言如此。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:114
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:113
 msgid ""
 "In the thirteenth year of the Lord Protectorship of Howgarth III — the "
 "successor of Rahul I — tension began to rise between orcish tribes and human "
@@ -264,7 +261,7 @@ msgstr ""
 "毁了。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:119
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:118
 msgid ""
 "Retaliating, the orcs systematically slaughtered human colonies and villages "
 "on their lands. Then, Earl Lanbec’h — the most powerful human warlord of the "
@@ -276,14 +273,14 @@ msgstr ""
 "率。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:124
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:123
 msgid ""
 "Baron Alber personally led a small vanguard with the mission to establish a "
 "base inside orcish lands."
 msgstr "阿尔伯男爵受命亲自带领了一支小先锋队，在兽人的领地上建立据点。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:129
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:128
 msgid ""
 "By nightfall his troops reached a mountainous region under the authority of "
 "orcish leader Kapou’e, the son of the Black-Eye."
@@ -292,7 +289,7 @@ msgstr ""
 "子的领土。"
 
 #. [message]: speaker=Alber
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:140
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:139
 msgid ""
 "Look, friends! Those orcs don’t imagine they are living their last day. "
 "Let’s slay them and claim this land back to our people!"
@@ -301,61 +298,61 @@ msgstr ""
 "还给我们的人民！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:144
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:143
 msgid "Who is this unlicked whelp? Grunts — kill him and bring me his head!"
 msgstr "那无理的小崽子是谁？ 大兵们，杀了他，提头回来！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:155
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:154
 msgid "Argh! I die! But other humans will come to avenge me, filthy orcs!"
 msgstr "啊！我死了！但其它人类会为我复仇的，污秽的兽人！"
 
 #. [message]: role=second
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:164
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:163
 msgid "Victory!"
 msgstr "赢啦！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:169
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:168
 msgid "Oh, just die, human-worm."
 msgstr "人类臭虫，死的干脆点儿吧，黄泉路上别找不自在了。"
 
 #. [unit]: type=Wolf Rider, id=Vrag
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:188
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:187
 msgid "Vrag"
 msgstr "瓦格"
 
 #. [message]: speaker=Vrag
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:198
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:197
 msgid "(<i>Pant</i>) Chief! Chief!"
 msgstr "*喘息* 头儿! 头儿!"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:203
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:202
 msgid "Speak, rider."
 msgstr "说吧，骑兵。"
 
 #. [message]: speaker=Vrag
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:208
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:207
 msgid ""
 "There is a huge human army marching on us! They can’t be more than one or "
 "two days march from here."
 msgstr "一支庞大的人类军团正向我们前进！他们一两天内就会到了。"
 
 #. [message]: role=second
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:213
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:212
 msgid "Uh oh! What should we do, Chief?"
 msgstr "哦不！我们应该怎么办，老大？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:218
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:217
 msgid ""
 "Don’t be afraid. If any more of these pathetic humans come, we’ll deal with "
 "them the way we did with this trash!"
 msgstr "不要害怕。如果那些可悲的人类胆敢再来，我们会像这次一样解决这些废物！"
 
 #. [message]: speaker=Vrag
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:223
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:222
 msgid ""
 "Uh, Chief, with all respect that army is huge! Not only that, but most of "
 "them look like tough old soldiers. It would be foolish to confront them with "
@@ -365,19 +362,19 @@ msgstr ""
 "兵。靠咱们现在的军力去对抗他们似乎没什么指望啊。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:228
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:227
 msgid "Hmmm..."
 msgstr "唔……"
 
 #. [option]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:231
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:230
 msgid ""
 "If what you say is true, then there is no way our tribe can face such an "
 "army alone."
 msgstr "如果你说得是真的，我们的部落将无法独自对抗他们。"
 
 #. [message]: speaker=Vrag
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:236
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:235
 msgid ""
 "Wise decision, Kapou’e. By the size of that army, this is no mere raid — it "
 "seems to me that the humans have decided to declare war on us."
@@ -386,12 +383,12 @@ msgstr ""
 "宣战了。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:241
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:240
 msgid "If they want war, then they shall get war!"
 msgstr "他们要战争，那就给他们战争！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:246
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:245
 msgid ""
 "We’ll head for Barag Gór in the lands of the free tribes and demand "
 "assistance from the Great Council. With their help, we can raise troops from "
@@ -401,14 +398,14 @@ msgstr ""
 "下，我们可以从自由部落征兵，而后再碾碎人类。"
 
 #. [message]: role=second
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:251
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:250
 msgid ""
 "But the free tribes are beyond the Mountains of Haag. These mountains are "
 "infested with dwarves and wild trolls."
 msgstr "但是自由部落在海格山区后面。这些山区被侏儒和巨魔控制着。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:256
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:255
 msgid ""
 "Don’t be so cowardly. The trolls have been our allies in the past — maybe "
 "they will help us. And what true orc has ever feared dwarvish dirt-grubbers? "
@@ -418,12 +415,12 @@ msgstr ""
 "侏儒？快，我们得赶紧离开这儿。如果你们还不起身，就只能等死了。"
 
 #. [option]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:268
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:267
 msgid "Bah, humans? No better than goblins. We’ll break them!"
 msgstr "呸，人类。能比地精强到哪儿去？碾碎他们！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:273
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg:272
 msgid ""
 "Prepare for battle, my grunts! We’ll show these humans what happens when you "
 "try to steal from Kapou’e, Son of the Black-Eye!"
@@ -630,7 +627,7 @@ msgstr "击败敌方首领"
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:29
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg:28
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:30
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:62
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:58
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:31
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:43
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:33
@@ -638,41 +635,41 @@ msgid "Death of Grüü"
 msgstr "咕噜死亡"
 
 #. [side]: type=Dwarvish Steelclad, id=Kwili
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:106
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:105
 msgid "Kwili"
 msgstr "魁里"
 
 #. [side]: type=Dwarvish Steelclad, id=Kwili
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:113
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:112
 msgid "Dwarves"
 msgstr "矮人"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:185
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:184
 msgid ""
 "We have almost crossed the mountains. We’re close to the lands of the free "
 "tribes. So far so good."
 msgstr "我们已经要翻过山区了。自由部落就在前方。一切尚好。"
 
 #. [message]: speaker=Kwili
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:189
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:188
 msgid "Halt! Who goes there?"
 msgstr "停下！是谁在那里？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:194
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:193
 msgid "It is I, Kapou’e, son of the Black-Eye Karun. What do you want, dwarf?"
 msgstr "是我，卡破尔，黑眼卡伦之子。你想干什么，矮人？"
 
 #. [message]: speaker=Kwili
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:200
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:198
 msgid ""
 "Oh, so it’s another group o’ stinkin’ orcs, eh. Begone, or we shall wash our "
 "axes in yer blood."
 msgstr "噢，所以又是一伙臭兽人。滚，否则拿你们的血洗斧头。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:205
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:203
 msgid ""
 "Look, you pint-sized idiot, we aren’t out to kill you so why don’t you just "
 "scamper away and hide in a cave or something. We’ll be through here in a few "
@@ -682,12 +679,12 @@ msgstr ""
 "地儿躲起来？我们只要几个小时就会离开了。"
 
 #. [message]: role=Helper
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:210
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:208
 msgid "(<i>Snicker</i>)"
 msgstr "（<b>窃笑</b>）"
 
 #. [message]: speaker=Kwili
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:215
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:213
 msgid ""
 "Your scorn and rudeness shall be your undoing. Dwarves, let no orc pass this "
 "way alive!"
@@ -695,24 +692,24 @@ msgstr ""
 "你们会为自己的傲慢与野蛮付出代价。矮人们，不要让任何一个兽人或者走过这条路！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:220
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:218
 msgid "It looks like we might have to fight them after all."
 msgstr "看来我们似乎必须要和他们一战。"
 
 #. [message]: role=Helper
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:225
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:223
 msgid ""
 "Hey, Chief, I was thinking — dwarves are pretty slow; why don’t we just "
 "bypass them?"
 msgstr "头儿，俺在想——矮人既然都那么慢，俺们为什么不绕过他们？"
 
 #. [message]: role=Helper
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:230
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:228
 msgid "I mean, we could defeat them easily but it would just slow us down."
 msgstr "俺的意思是，俺们对付它们是简单，但是会拖慢俺们啊。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:235
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:233
 msgid ""
 "We could, but then again, if we crush them, then we can loot their treasury "
 "and their dwellings. The gold will be useful."
@@ -721,7 +718,7 @@ msgstr ""
 "的。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:240
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:238
 msgid ""
 "Whatever else happens, we have to pass through these mountains and I dislike "
 "leaving enemies to our rear. Stab, smite, and slay!"
@@ -730,52 +727,52 @@ msgstr ""
 "穿，砍翻，杀光！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:256
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:254
 msgid ""
 "I’ve never pushed so far. We are crossing the border of the Black-Eye lands."
 msgstr "我从来没有推进过这么远。我们就要越过自家边界了。"
 
 #. [unit]: id=Blemaker, type=Troll Warrior
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:275
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:273
 msgid "Blemaker"
 msgstr "布列马克"
 
 #. [unit]: id=Grüü, type=Troll Hero
 #. [side]: id=Grüü, type=Great Troll
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:284
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:282
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:81
 msgid "Grüü"
 msgstr "咕噜"
 
 #. [unit]: id=Toughkon, type=Troll Whelp
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:306
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:304
 msgid "Toughkon"
 msgstr "塔夫孔"
 
 #. [unit]: id=Pe, type=Troll Whelp
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:315
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:313
 msgid "Pe"
 msgstr "丕"
 
 #. [message]: speaker=Blemaker
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:325
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:323
 msgid "Look! Dwarves are fighting orcs!"
 msgstr "看！矮人和兽人打起来了！"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:329
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:327
 msgid "Father, we should help them. Orcs are our allies."
 msgstr "爹，俺们应该去帮他们。兽人是我们的盟友。"
 
 #. [message]: speaker=Blemaker
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:333
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:331
 msgid ""
 "I don’t know. Orcs have been our allies in the past, but they treat us as "
 "fools."
 msgstr "我不知道。兽人过去一直是我们的盟友，但他们老把我们当成傻子看。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:337
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:335
 msgid ""
 "But, Father, we don’t know what they are seeking there. Between us, we could "
 "squash these dwarves."
@@ -783,7 +780,7 @@ msgstr ""
 "但是爹，俺虽然不知道他们在那儿干啥。但至少跟他们一道，俺们能扁那群矮人。"
 
 #. [message]: speaker=Blemaker
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:341
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:339
 msgid ""
 "Right, my son. We help our orcish friends. But you take care... I would be "
 "desperate if something happened to you."
@@ -792,29 +789,29 @@ msgstr ""
 "就伤心死啦。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:355
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:353
 msgid "Father! Oh no!"
 msgstr "爹！不！"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:359
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:357
 msgid "Filthy dwarves! Now I’ll kill you to the last!"
 msgstr "肮脏的矮人！俺要把你们杀得一个不剩！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:370
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:368
 msgid "Oh no, I’m defeated."
 msgstr "噢不。败了。"
 
 #. [message]: speaker=Blemaker
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:379
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:377
 msgid ""
 "My son! I should have never brought him to this fight. Now we return to our "
 "caverns, and we never return."
 msgstr "儿子！真不应该卷入这场战斗。现在我们就回洞穴去，再也不要回来了。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:385
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:383
 msgid ""
 "The trolls are done. We will desperately need their help in the coming "
 "battles. Without them there is no hope."
@@ -822,12 +819,12 @@ msgstr ""
 "巨魔们走了。在将来的作战中我们会迫切需要他们的帮助。没有他们，就没有指望了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:402
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:400
 msgid "Argh! I die!"
 msgstr "啊！我要死了！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:407
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:405
 msgid ""
 "You were warned, dwarf. Riders, spread out over the area and collect what "
 "you can from each of these houses. If anyone refuses to pay, tie them up and "
@@ -839,12 +836,12 @@ msgstr ""
 "了。我领队去霸拉戈·高，你们抢完以后跟上。"
 
 #. [message]: role=doggie
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:417
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:415
 msgid "Sounds like fun. All right boys, let’s go!"
 msgstr "听起来不错。弟兄们，我们上！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:442
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:440
 msgid ""
 "We’ve succeeded! We’ve passed through the Mountains of Haag! Look at these "
 "green hills! The land of the free tribes is near now. I can see the walls of "
@@ -854,7 +851,7 @@ msgstr ""
 "可以看见远处的霸拉戈·高的城墙。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:462
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:460
 msgid ""
 "Blemaker, many thanks for your help in this fight. Would you and your son "
 "like to join us in our journey? You are a powerful warrior, and you would be "
@@ -864,12 +861,12 @@ msgstr ""
 "一位强力的武士，能帮上大忙。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:467
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:465
 msgid "Father, I’d like to join them. Would you mind it?"
 msgstr "爹，俺想加入他们。您介意吗？"
 
 #. [message]: speaker=Blemaker
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:471
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:469
 msgid ""
 "My son, you’re old enough to discover the world. Me, I have to stay here. "
 "But take care, there are plenty of creatures that seek our end, like elves "
@@ -879,12 +876,12 @@ msgstr ""
 "多人想要杀了我们，比如精灵或人类。他们又精明又残忍。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:475
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:473
 msgid "Thanks, father. Don’t worry, I’ll take care of myself."
 msgstr "多谢啦爹。您多余操那份心，俺会保护好自己的。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:481
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:479
 msgid ""
 "Grüü, many thanks for your help in this fight. I’m sorry for the loss of "
 "your father. Would you like to join us in our journey? Your help would be "
@@ -894,7 +891,7 @@ msgstr ""
 "用场的。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:485
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg:483
 msgid ""
 "My father would have come to help you. I would insult his memory not to help "
 "you. I come!"
@@ -973,32 +970,32 @@ msgid "Sammual"
 msgstr "撒马耳"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:190
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1148
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:189
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1162
 msgid "Pirk"
 msgstr "皮尔克"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:192
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1149
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:190
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1163
 msgid "Gork"
 msgstr "古尔克"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:194
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1150
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:191
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1164
 msgid "Vraurk"
 msgstr "瓦鲁克"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:239
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:236
 msgid ""
 "When the party finally reached Barag Gór, they were met with a most "
 "startling sight."
 msgstr "当军队终于抵达霸拉戈·高以后，他们看到了令人吃惊的一幕。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:249
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:246
 msgid ""
 "What the—! Barag Gór is besieged by elves! The wose-born weaklings have "
 "always been jealous of our power, but what reason do they have to attack the "
@@ -1008,28 +1005,28 @@ msgstr ""
 "为什么要来攻击我们呢？"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:255
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:252
 msgid "What can you expect, Chief? They’re elves after all."
 msgstr "你指望什么呢，老大？他们毕竟是精灵。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:260
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:257
 msgid "Hmmm. $scout.name, go find out what they are up to."
 msgstr "呣。$scout.name|，去看看他们在搞什么飞机。"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:265
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:262
 msgid "Sure."
 msgstr "是。"
 
 #. [message]: speaker=Ammon
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:295
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:292
 msgid ""
 "One more step and you are dead, flea-bag. Better run if you value your life."
 msgstr "再往前一步你就死定了，小跳蚤。要活命还不赶紧跑。"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:300
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:297
 msgid ""
 "Quit your boasting, mule-ears. The Chief wants to know why you’re here, "
 "instead of cowering in your dung-spattered forests."
@@ -1038,7 +1035,7 @@ msgstr ""
 "什么。"
 
 #. [message]: speaker=Ammon
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:305
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:302
 msgid ""
 "Watch your mouth around your betters, goblin! And you can tell your chief to "
 "hand the shamans over to us if he wants to be alive by sundown."
@@ -1047,17 +1044,17 @@ msgstr ""
 "把萨满交给我们。"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:310
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:307
 msgid "What business do you high-and-mighty elves have with our shamans?"
 msgstr "你们这些“高等而强大”的精灵要我们的萨满干什么？"
 
 #. [message]: speaker=Ammon
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:315
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:312
 msgid "Our business with them is none of your concern."
 msgstr "我们跟他们的事轮不上你操心。"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:320
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:317
 msgid ""
 "Oh, yes, it is. The shamans keep our ancient knowledge and our sacred "
 "things; they are not for the likes of you. Why do you want them anyway?"
@@ -1066,55 +1063,55 @@ msgstr ""
 "到底要他们干什么？"
 
 #. [message]: speaker=Ammon
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:325
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:322
 msgid "Well... the humans want to... meet with them."
 msgstr "这个嘛……人类想……会会他们。"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:330
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:327
 msgid "Oh, so they paid you to come and get them, have they?"
 msgstr "噢，所以他们付钱让你们来抓人，是这样吧？"
 
 #. [message]: speaker=Ammon
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:335
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:332
 msgid "Well..."
 msgstr "这个嘛……"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:340
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:337
 msgid ""
 "So the ‘great and mighty’ elves are now nothing but a bunch of mercenaries."
 msgstr "所以“伟岸而强大”的精灵现在不过是一堆佣兵喽。"
 
 #. [message]: speaker=Ammon
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:345
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:342
 msgid "KILL HIM!!"
 msgstr "杀！了！他！"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:384
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:381
 msgid "Hahaha! If you can!"
 msgstr "哈哈哈！来试试啊！"
 
 #. [message]: speaker=Ammon
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:414
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:411
 msgid "Blast it, he got away."
 msgstr "可恶，他跑了。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:419
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:416
 msgid "So, what news do you bring, $scout.name?"
 msgstr "那么，你有什么新消息吗，$scout.name？"
 
 #. [message]: role=Scout
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:424
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:421
 msgid ""
 "The elves have been bribed by the humans to capture and deliver the shamans "
 "to them."
 msgstr "人类贿赂了精灵来抓萨满给他们。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:429
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:426
 msgid ""
 "Over my dead body! The shamans of the Great Council are the only people who "
 "can call up the Great Horde. If they are captured, then all the orcs on this "
@@ -1124,36 +1121,36 @@ msgstr ""
 "个大陆的兽人肯定得玩完。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:434
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:431
 msgid "I have a subtle plan, Chief."
 msgstr "俺有个绝妙的计划，头儿。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:439
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:436
 msgid "Go on, Grüü."
 msgstr "说吧，咕噜。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:444
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:441
 msgid "We go and we kill all of them. What do you think?"
 msgstr "俺们把他们杀光，咋样？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:449
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:446
 msgid "..."
 msgstr "……"
 
-#. [unit]: id=Jetto, type=Orcish Assassin
+#. [unit]: id=Jetto, type=Orcish Slayer
 #. [message]: speaker=narrator
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:469
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:582
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:598
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:618
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:466
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:579
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:595
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:615
 msgid "Jetto"
 msgstr "杰图"
 
 #. [message]: speaker=Jetto
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:488
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:485
 msgid ""
 "Freedom! Many thanks, Son of the Black-Eye. I’m Jetto, master of assassins, "
 "now you can count on the assassins’ guild to help you in your quest!"
@@ -1162,12 +1159,12 @@ msgstr ""
 "的帮助！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:493
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:490
 msgid "Jetto, how did you get captured by the likes of these?"
 msgstr "杰图，你怎么会被这些贱货俘虏呢?"
 
 #. [message]: speaker=Jetto
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:498
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:495
 msgid ""
 "The Barag Gór Council sent me to assassinate the elvish leaders. "
 "Unfortunately, I was captured. But now I am free and the elves shall feel my "
@@ -1177,40 +1174,40 @@ msgstr ""
 "我的怒火！"
 
 #. [message]: speaker=Pirk
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:509
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:506
 msgid "At last! The siege has been broken."
 msgstr "终于！打破包围了。"
 
 #. [message]: speaker=Gork
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:514
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:511
 msgid ""
 "Thank you, Son of the Black-Eye. If you hadn’t arrived when you did, I don’t "
 "know what would have happened to us."
 msgstr "谢谢你，黑眼之子。如果你没能及时到来，我都不知道该怎样。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:519
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:516
 msgid "No problem! It was fun, wasn’t it, Grüü?"
 msgstr "小菜一碟！咕噜，有意思吧？"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:524
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:521
 msgid "Hahaha! Yeah!"
 msgstr "哈哈哈！耶！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:529
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:526
 msgid ""
 "But, actually, we have come all the way from our lands to get your help."
 msgstr "可是实际上，我们好不容易来这里本是为了请求你们帮助的。"
 
 #. [message]: speaker=Vraurk
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:534
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:531
 msgid "Why? What’s wrong?"
 msgstr "为什么？又怎么了？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:539
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:536
 msgid ""
 "Those insolent humans have massed a huge army and attacked us. We defeated "
 "their vanguard but in the end we were forced to retreat."
@@ -1219,49 +1216,49 @@ msgstr ""
 "不撤退。"
 
 #. [message]: speaker=Pirk
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:544
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:541
 msgid ""
 "Hmmmm, this situation is very serious. As you know by now, they have also "
 "hired these elves to attack us here."
 msgstr "唔……局势很危急啊。你也看到了，他们还雇了精灵来打我们。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:549
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:546
 msgid "Yes. It seems to me that the humans are declaring all-out war on us."
 msgstr "是的。似乎人类向我们全面宣战了。"
 
 #. [message]: speaker=Gork
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:554
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:551
 msgid ""
 "We must give this matter careful consideration. Come inside the city, and "
 "we’ll discuss it."
 msgstr "我们必须仔细斟酌下。进来吧，我们讨论下。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:584
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:581
 msgid ""
 "Son of the Black-Eye! Could I ask for my release from this blighted cage?"
 msgstr "黑眼之子！请您把我从这笼中放出来，好吗？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:589
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:586
 msgid "How did you get captured by the likes of these?"
 msgstr "你是怎么被抓住的？"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:600
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:597
 msgid ""
 "The Barag Gór Council sent me to assassinate the elvish leaders. "
 "Unfortunately, I was captured."
 msgstr "霸拉戈·高评议会派我暗杀精灵首领。但我不幸被抓了。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:605
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:602
 msgid "Fine, someone go release him."
 msgstr "好，快来个人去放了他。"
 
 #. [message]: speaker=Jetto
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:637
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg:634
 msgid ""
 "Freedom! Many thanks, Son of the Black-Eye. I’m Jetto, master of assassins, "
 "now you can count on my assassins to help you in your quest!"
@@ -1526,11 +1523,6 @@ msgstr "萨满们安全吗?"
 
 #. [message]: speaker=Affman
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg:238
-#, fuzzy
-#| msgid ""
-#| "When we realized that there was no way we could hold the humans off, we "
-#| "sent them east to a place near the Mourned Hills along with most of our "
-#| "women and children. The rest of us remained here to buy them some time."
 msgid ""
 "When we realized that there was no way we could hold the humans off, we sent "
 "them east to a place near the Mourned Hills along with most of our women and "
@@ -1538,18 +1530,12 @@ msgid ""
 "their safety. The rest of us remained here to buy them some time. It has "
 "been three days since their evacuation."
 msgstr ""
-"我们意识到没法挡住住人类时，就让他们和妇女孩子们一起去了东方，靠近哀悼山峦的"
-"某处。其余的人留在这里为他们争取时间。"
+"当我们意识到根本无法抵挡人类时，我们便将妇孺连同他们一起送往了东边，靠近哀悼"
+"山峦的地方。我们的大部分步兵和弓箭手随行护送，以确保他们的安全。剩下的人留在"
+"这里，为他们争取时间。他们撤离至今已经三天了。"
 
 #. [message]: speaker=Kapou'e
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg:243
-#, fuzzy
-#| msgid ""
-#| "Wise decision. We have actually come to speak to the shamans, but while "
-#| "we are here we must help you out of this scrape. Grüü, hold them while I "
-#| "run to the keep and organize our forces to counterattack. We can’t defeat "
-#| "them by sea without ships, but we can destroy the foothold they have "
-#| "gained on the land."
 msgid ""
 "Wise decision. We have actually come to speak to the shamans, but while we "
 "are here we must help you out of this scrape. Grüü, fight the humans if you "
@@ -1558,9 +1544,10 @@ msgid ""
 "to stay alive. We can’t defeat them by sea without ships, but we can destroy "
 "the foothold they have gained on the land."
 msgstr ""
-"英明的决断。我们其实是来找萨满们的，但是我们既然都在这儿了就要援助自家弟兄。"
-"咕噜，在我去城堡集结军队反击的路上挡住他们！虽然我们在没有海军的情况下无法击"
-"败他们，但是我们可以让他们在路上无处立足。"
+"明智的决定。我们此行其实是来与萨满们商谈，但既然我们在这里，就必须帮你们摆脱"
+"这个困境。格鲁，如果必须的话就与人类战斗，但不要鲁莽行事。把我送到提里嘎兹要"
+"塞，好让我集结部队发动反击，这必须是我们的首要任务。而且，我需要你活着。没有"
+"船只我们无法在海上击败他们，但我们可以摧毁他们在陆地上取得的据点。"
 
 #. [message]: speaker=Grüü
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg:248
@@ -1613,6 +1600,8 @@ msgid ""
 "consuming but much safer compared to the direct route through the Desert of "
 "Death."
 msgstr ""
+"他们很可能选择了穿越山麓的路线。这段旅程耗时较长，但比起直接穿越死亡沙漠的路"
+"线要安全得多。"
 
 #. [message]: speaker=Pirk
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg:399
@@ -1665,12 +1654,12 @@ msgstr "亚单"
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/07_The_Desert_of_Death.cfg:98
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:119
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:147
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:75
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:133
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:157
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:173
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:86
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:106
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:80
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:143
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:170
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:186
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:84
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:104
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg:82
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg:96
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:122
@@ -1678,8 +1667,8 @@ msgstr "亚单"
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:159
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:177
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:92
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:86
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:131
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:85
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:130
 msgid "Villains"
 msgstr "恶霸"
 
@@ -2166,7 +2155,7 @@ msgstr "打败闪·陶姆"
 #. [unit]: type=Orcish Warlord, id=Shan Taum
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:60
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:145
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:124
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:123
 msgid "Shan Taum"
 msgstr "闪·陶姆"
 
@@ -2194,7 +2183,7 @@ msgstr "终于！这里就是哀悼山峦。我希望能够一切顺利。"
 #. [message]: speaker=Grüü
 #. [message]: role=cannonfodder
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:112
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:290
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:303
 msgid "Why?"
 msgstr "为什么？"
 
@@ -2224,7 +2213,7 @@ msgid "Hold on, Shan Taum. We seek the Great Council, not a quarrel with you."
 msgstr "收敛点，闪·陶姆，我们在找元老们，懒得和你吵嘴。"
 
 #. [message]: speaker=Shan Taum
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:136
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:135
 msgid ""
 "Bwahaha! You are nothing! Where is your land? You became a beggar. You are "
 "as pathetic as your father!"
@@ -2232,40 +2221,40 @@ msgstr ""
 "哈哈哈！你算个蛋！你哪儿还有领地？你已经是个乞丐了，和你的父亲一样可悲！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:141
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:140
 msgid ""
 "How can you talk that way about my father, you miserable coward?! I’ll make "
 "a mug from your skull!"
 msgstr "你吃了豹子胆的说我父亲，可怜的软蛋？！我要拿你的头颅喝酒！"
 
 #. [message]: speaker=Shan Taum
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:145
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:144
 msgid "Really? What would you drink with it? Mint cordial?"
 msgstr "当真？打算喝什么？薄荷甜酒？"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:150
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:149
 msgid ""
 "Exasperated, Kapou’e launched an attack on his fellow orc Shan Taum the Smug."
 msgstr "气急败坏之下，卡破尔对他的同族人，自以为是的闪·陶姆，发动了攻击。"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:157
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:156
 msgid "Fabstep"
 msgstr "法布斯坦普"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:158
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:157
 msgid "Klebar"
 msgstr "柯乐巴"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:159
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:158
 msgid "Echarp"
 msgstr "以查普"
 
 #. [message]: speaker=Echarp
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:162
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:161
 msgid ""
 "What is this? Are you mad?! Humans are to besiege our fortress at Prestim "
 "and you are fighting each other?!"
@@ -2274,12 +2263,12 @@ msgstr ""
 "杀？！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:167
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:165
 msgid "Well, ermmm..."
 msgstr "好吧，那……"
 
 #. [message]: speaker=Echarp
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:171
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:169
 msgid ""
 "Kapou’e, rumors tell of you making a long trip to seek assistance from us, "
 "and escorting Pirk, Gork and Vraurk. The Council is grateful for that."
@@ -2288,17 +2277,17 @@ msgstr ""
 "此非常感激。"
 
 #. [message]: speaker=Fabstep
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:175
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:173
 msgid "I know what you want from us but I’m afraid we can’t help you."
 msgstr "我知道你想要我们做什么，但很抱歉我们帮不了你。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:179
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:177
 msgid "But my people..."
 msgstr "但是我的人民……"
 
 #. [message]: speaker=Echarp
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:183
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:181
 msgid ""
 "You don’t understand. Orcs have been divided for ages. The only one who gave "
 "us some unity was your father, Black-Eye Karun. When we heard rumors of your "
@@ -2308,7 +2297,7 @@ msgstr ""
 "结的人。我们从传言中听闻了你的功绩，相信你一定是位不辱父名的儿子。"
 
 #. [message]: speaker=Vraurk
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:187
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:185
 msgid ""
 "This is true. Now we are pressed from all sides by humans and elves; we need "
 "a leader that can unite all banners. This one is <i>you</i>!"
@@ -2317,17 +2306,17 @@ msgstr ""
 "帜。这个人就是——你！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:191
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:189
 msgid "Thank you."
 msgstr "谢谢。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:195
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:193
 msgid "Did you hear? There is a battle waiting for us at Prestim!"
 msgstr "你听说了吗？在普雷斯提姆有一场战争在等着我们！"
 
 #. [message]: speaker=Echarp
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:199
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:197
 msgid ""
 "Kapou’e, if Prestim falls, humans will have a strong bridgehead on this side "
 "of the river and your people won’t be safe. You are the only one that can "
@@ -2337,7 +2326,7 @@ msgstr ""
 "再也不会安全了。你是唯一能够帮助我们坚守普雷斯提姆的人！"
 
 #. [message]: speaker=Pirk
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:203
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:201
 msgid ""
 "Go defend Prestim, Kapou’e. In the meantime, now that the Council is "
 "complete again, we will decide. We may have to form the Great Horde again "
@@ -2347,7 +2336,7 @@ msgstr ""
 "的。我们可能得再次组成大部落，并授予你最高领导权。"
 
 #. [message]: speaker=Shan Taum
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:248
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg:246
 msgid "Nooo! Don’t kill me, I surrender to you, little earthworm."
 msgstr "不不不！别杀我，我向你这小蚯蚓投降。"
 
@@ -2368,12 +2357,8 @@ msgstr "等待伊诺斯在第四回合从南方赶来"
 
 #. [objective]: condition=win
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:48
-#, fuzzy
-#| msgid ""
-#| "In order to recruit saurians later on, bring Inarix and at least four "
-#| "saurians to safety"
 msgid "Escort Inarix and at least four saurians to Prestim."
-msgstr "为了日后招募蜥蜴人，你至少要保证依那利克斯和至少四个蜥蜴人的安全"
+msgstr "护送依那利克斯和至少四名蜥蜴人抵达普雷斯蒂姆。"
 
 #. [note]
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:75
@@ -2382,14 +2367,11 @@ msgstr "引爆桥梁的人会死。"
 
 #. [note]
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:78
-#, fuzzy
-#| msgid ""
-#| "In order to recruit saurians later on, bring Inarix and at least four "
-#| "saurians to safety"
 msgid ""
 "In order to recruit saurians later on, bring Inarix and at least four "
 "saurians to safety."
-msgstr "为了日后招募蜥蜴人，你至少要保证依那利克斯和至少四个蜥蜴人的安全"
+msgstr ""
+"为了在日后能够招募蜥蜴人，请把依那利克斯和至少四名蜥蜴人送到安全的地方。"
 
 #. [side]: type=Elvish Champion, id=Thelarion
 #. [unit]: type=Elvish Champion, id=Thelarion
@@ -2402,7 +2384,7 @@ msgstr "塞拉利昂"
 
 #. [side]: type=Dwarvish Steelclad, id=Darstang
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:130
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:85
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:90
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg:77
 msgid "Darstang"
 msgstr "靼斯湯"
@@ -2594,47 +2576,47 @@ msgid "<i>Phew!</i>"
 msgstr "<b>咻！</b>"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:609
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:612
 msgid ""
 "Blast it! The saurians have had too many casualties in order for them to be "
 "of any real help to us. We won’t be able to recruit them in the future."
 msgstr "可恶！蜥蜴人死伤太多，已经帮不了我们什么了。我们日后无法征募它们。"
 
 #. [message]: speaker=Thelarion
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:655
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:658
 msgid ""
 "This isn’t working. Mobilize all our troops and send these creatures back to "
 "hell."
 msgstr "这没有效果。所有部队出击，送这些混蛋回地狱去。"
 
 #. [message]: speaker=Darstang
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:659
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:662
 msgid "It won’t be said that Elves were braver than us, everyone attack!"
 msgstr "我们岂能不如精灵勇猛，全体出击！"
 
 #. [unit]: type=General, id=Earl Lanbec'h
 #. [side]: type=General, id=Earl Lanbec'h
 #. [side]: type=Grand Marshal, id=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:678
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:708
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:144
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:681
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:711
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:154
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:86
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:80
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:79
 msgid "Earl Lanbec’h"
 msgstr "兰贝契伯爵"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:694
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:697
 msgid "At them! Rip them to the last!"
 msgstr "找到他们了！把它们统统砍成肉酱！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:698
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:701
 msgid "It is too late, we are defeated."
 msgstr "太迟了，我们被打败了。"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:718
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:721
 msgid ""
 "So, the elves and dwarves failed to take the fortress and the beasts were "
 "able to muster a defense. No matter. Once the vanguard of my army arrives, I "
@@ -2644,12 +2626,12 @@ msgstr ""
 "锋到达，我将亲自攻克他们可怜的堡垒。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:758
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:761
 msgid "The green earth will curse you for this..."
 msgstr "大地母亲诅咒你们……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:770
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg:773
 msgid "Curse you, foul orc!"
 msgstr "可恶，混蛋兽人！"
 
@@ -2671,27 +2653,27 @@ msgid ""
 msgstr "在回合耗尽时，你没能控制住河北岸的所有村庄"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:233
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:246
 msgid "Telamir"
 msgstr "特拉米尔"
 
 #. [event]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:234
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:247
 msgid "Angthur"
 msgstr "安哥萨"
 
 #. [message]: role=cannonfodder
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:255
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:268
 msgid "So here we are, and they are preparing to assault."
 msgstr "所以我们现在在这头，而他们在准备攻城。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:260
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:273
 msgid "Prestim’s walls are rock-hard, they’ll waste themselves on them."
 msgstr "普雷斯提姆的城墙像坚不可摧，他们只会在这上面浪费生命。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:265
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:278
 msgid ""
 "I’m not that sure. Every fortress has its own weakness. Prestim’s walls are "
 "strong but long, and it is difficult to defend them from many directions at "
@@ -2704,24 +2686,24 @@ msgstr ""
 "滩来攻破这座城，所以他肯定还有什么更好的计划。"
 
 #. [message]: role=cannonfodder
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:270
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:283
 msgid ""
 "We’ve received messengers from the Council, saying that they are gathering "
 "tribes into the Great Horde."
 msgstr "我从评议会那儿得到消息说，他们正在召集各族人民重聚大部落。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:275
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:288
 msgid "Great! When do they arrive?"
 msgstr "太棒了！他们什么时候到？"
 
 #. [message]: role=cannonfodder
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:280
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:293
 msgid "In four days. I fear it will be too late."
 msgstr "四天左右。我怕会太迟了。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:285
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:298
 msgid ""
 "Fool! We can hold that long. But we have to have Prestim firmly in control "
 "when the shamans arrive with the Great Horde. We can’t let the humans "
@@ -2731,7 +2713,7 @@ msgstr ""
 "姆。我们绝不能让人类在河这边建立落脚处……"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:295
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:308
 msgid ""
 "... because if we cannot decisively beat these humans, the other tribes "
 "won’t think us strong enough to lead them. Each chieftain will try to claim "
@@ -2742,53 +2724,53 @@ msgstr ""
 "酋长都会想当大部落的首领，而人类就可以击破我们的防线。"
 
 #. [message]: role=cannonfodder
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:300
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:313
 msgid "Great."
 msgstr "好。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:379
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:392
 msgid "Look, the humans are boarding a ship!"
 msgstr "看，人类正在登船！"
 
 #. [message]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:900
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:913
 msgid "Charge!"
 msgstr "冲啊！"
 
 #. [message]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:909
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:922
 msgid "Get them!"
 msgstr "杀了他们！"
 
 #. [unit]: type=Merman Warrior, id=Plouf
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1042
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1055
 msgid "Plouf"
 msgstr "普劳夫"
 
 #. [message]: speaker=Plouf
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1053
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1066
 msgid "We arrive to honor our alliance, Earl Lanbec’h."
 msgstr "我们来兑现我们的盟约了，兰贝契伯爵。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1058
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1071
 msgid "Curses! They have fish-men on their side."
 msgstr "见鬼！他们那边有鱼尾巴人。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1141
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1154
 msgid ""
 "The Great Horde is almost here! Drive them out of our villages <b>now</b>!"
 msgstr "大部落就要到达了！把他们从我们的村子里轰出去！快！！"
 
 #. [message]: speaker=Gork
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1178
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1191
 msgid "Here we are!"
 msgstr "我们来了！"
 
 #. [message]: role=greathordewarlord1
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1183
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1196
 msgid ""
 "What’s this? This weakling has let humans enter Prestim? I will lead the "
 "horde and push them to the river!"
@@ -2797,37 +2779,37 @@ msgstr ""
 "吧！"
 
 #. [message]: role=greathordewarlord2
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1189
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1202
 msgid ""
 "Bah! I’m the only one strong enough to drive out the humans! The Great Horde "
 "follows me!"
 msgstr "呸！只有我才够资格领导大部落打败人类！大部落，跟随我走向胜利吧！"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1195
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1208
 msgid ""
 "Look at that, the stupid orcs are starting to fight amongst themselves! "
 "Now’s our chance, everyone attack!"
 msgstr "看啊，那帮傻×兽人开始起内讧了！现在我们的机会来了，全体出动！"
 
 #. [message]: speaker=Gork
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1206
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1219
 msgid "Here we are! Hold on Prestim, we will help you push them to the river!"
 msgstr "我们来了！普雷斯提姆挺住，我们会帮你们把他们推到河里去！"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1211
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1224
 msgid "They are too numerous now, RETREAT!"
 msgstr "他们太多了。撤退！！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1233
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1246
 msgid ""
 "The Great Horde at last! I was beginning to think they would never come."
 msgstr "大部落终于来了！我还以为他们永远不会来呢。"
 
 #. [message]: speaker=Gork
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1238
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1251
 msgid ""
 "Your defense of Prestim was heroic, facing such opposition surely undermined "
 "the morale of the humans. Now they are retreating to their fortresses and "
@@ -2837,7 +2819,7 @@ msgstr ""
 "他们撤回了自己的要塞，短期内应该不会冒险出来了。"
 
 #. [message]: speaker=Pirk
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1243
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg:1256
 msgid ""
 "It is now time to show them who we are and to lead the Great Horde in "
 "pursuit. We will not rest until we destroy Earl Lanbec’h. Smite, stab, slay!"
@@ -2867,17 +2849,17 @@ msgid "Death of Flar’Tar"
 msgstr "弗拉塔死亡"
 
 #. [side]: type=General, id=Arthain
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:80
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:78
 msgid "Arthain"
 msgstr "亚瑟因"
 
 #. [side]: type=Lieutenant, id=Hanak
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:101
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:99
 msgid "Hanak"
 msgstr "哈纳克"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:120
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:118
 msgid ""
 "With the arrival of the Great Horde, and the humans having retreated, the "
 "united orcish forces held a council of war."
@@ -2885,7 +2867,7 @@ msgstr ""
 "伴随着大部落的到来，人类的撤退同时进行着，联合的兽人军团建立了战争议会。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:126
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:124
 msgid ""
 "After a fair amount of squabbling — for some of the older warlords were "
 "reluctant to let this young upstart lead them — and a few consequent "
@@ -2895,14 +2877,14 @@ msgstr ""
 "头之后，大部落的领导权终于被正式授予卡破尔。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:132
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:130
 msgid ""
 "Riders were dispatched in all directions to gather intelligence and to "
 "pinpoint the exact locations of hostile forces."
 msgstr "狼骑手被派往四面八方收集情报，查明敌方军队的准确位置。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:138
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:136
 msgid ""
 "The horde was then split into two forces. On the advice of the shamans, "
 "Kapou’e placed one force under the leadership of Shan Taum the Smug, who — "
@@ -2917,7 +2899,7 @@ msgstr ""
 "领地。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:145
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:142
 msgid ""
 "Kapou’e sent the shamans, Pirk, Gork and Vraurk back to Borstep — a city "
 "just north of the Mourned Hills — to organize any remaining orcish forces as "
@@ -2927,7 +2909,7 @@ msgstr ""
 "织所有残余的兽人军队，同时建立军备补给点。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:151
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:148
 msgid ""
 "Kapou’e himself — desiring to settle this business once and for all — led "
 "his remaining forces to Dorest, the human city due southeast of Prestim, to "
@@ -2937,20 +2919,20 @@ msgstr ""
 "城市多雷斯特，也是兰贝契伯爵撤退的地方。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:226
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:223
 msgid ""
 "Earl Lanbec’h, you slimy coward, come out and face me if you have the guts!"
 msgstr "兰贝契，你这烂泥巴懦夫，有种的就出来跟我对♂肛！"
 
 #. [message]: speaker=Arthain
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:232
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:229
 msgid ""
 "Sorry there, old chap. You’re deemed too insignificant for the likes of the "
 "Earl to deal with. He’s left that pleasure to me instead."
 msgstr "抱歉，老小伙子。你还不够格让伯爵亲自处理。他把这美差留给我了。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:237
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:234
 msgid ""
 "Foolish human. Attack, men! I want that city to be orcish territory within "
 "the week. Smite, stab, and slay!"
@@ -2958,14 +2940,14 @@ msgstr ""
 "愚蠢的人类。进攻，战士们！我要这城市一周之内成为兽人领土！砍翻、刺穿、杀光！"
 
 #. [message]: speaker=Al'Brock
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:244
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:241
 msgid ""
 "Easier said than done, Chief. There are many humans in that city. And they "
 "are well armed, too."
 msgstr "说起来比做起来容易，老大。那城里人类很多。而且他们的武装也很精良。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:249
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg:246
 msgid "No matter. Horde smash!"
 msgstr "没关系。大部落，冲锋！"
 
@@ -3469,10 +3451,8 @@ msgstr "把他丢到湖里。冻死他，那就再好不过了。"
 
 #. [message]
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg:768
-#, fuzzy
-#| msgid "You retrieve $amount_gold of Grüü's leftover gold."
 msgid "You retrieve $amount_gold of Grüü’s leftover gold."
-msgstr "你获得了咕噜剩下的金币中的$amount_gold|枚。"
+msgstr "你取回了咕噜剩下的金币中的$amount_gold|枚。"
 
 #. [scenario]: id=15_Civil_War
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:4
@@ -3485,17 +3465,17 @@ msgid "Defeat all rebel leaders and..."
 msgstr "击败所有反抗首领并且……"
 
 #. [objective]: condition=win
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:38
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:34
 msgid "Then move Kapou’e to the signpost in the southwest"
 msgstr "移动卡破尔至西南方路标处"
 
 #. [objective]: condition=win
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:47
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:43
 msgid "Move Kapou’e to the signpost in the southwest"
 msgstr "移动卡破尔至西南方路标处"
 
 #. [side]: type=Orcish Warlord, id=Braga
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:93
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:89
 msgid "Braga"
 msgstr "布拉戛"
 
@@ -3506,10 +3486,10 @@ msgstr "布拉戛"
 #. [side]: type=Orcish Warlord, id=Orga
 #. [side]: type=Orcish Warrior, id=Knorgh
 #. [side]: type=Orcish Warrior, id=Nofhug
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:101
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:122
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:143
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:164
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:97
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:118
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:139
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:160
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:67
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:88
 #: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:102
@@ -3517,22 +3497,22 @@ msgid "Rebels"
 msgstr "叛军"
 
 #. [side]: type=Orcish Warlord, id=Meato
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:114
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:110
 msgid "Meato"
 msgstr "米亚图"
 
 #. [side]: type=Orcish Warlord, id=Ragvan
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:135
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:131
 msgid "Ragvan"
 msgstr "拉格文"
 
 #. [side]: type=Orcish Warlord, id=Kergai
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:156
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:152
 msgid "Kergai"
 msgstr "科尔咖"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:176
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:172
 msgid ""
 "Infuriated by the murder of the shamans, the orcish horde massacred the "
 "humans and their allies. In their rage, they scoured the snow for hours "
@@ -3544,7 +3524,7 @@ msgstr ""
 "实在他们心中渐渐沉湎。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:182
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:178
 msgid ""
 "With the Council broken, there was now nothing left to hold the orcish "
 "forces together. And if the orcish forces began to fight amongst themselves, "
@@ -3554,7 +3534,7 @@ msgstr ""
 "人类就可以轻易灭绝他们。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:188
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:184
 msgid ""
 "Kapou’e vowed that this would not happen. Events had the smell of a "
 "treacherous plot aimed at destroying the unity of the orcs. Furthermore, if "
@@ -3572,7 +3552,7 @@ msgstr ""
 "——这可是老路子了。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:194
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:190
 msgid ""
 "Furthermore, the troops who had been led by Kapou’e this far had grown to "
 "respect him as a wise and capable leader, and they proclaimed their loyalty "
@@ -3591,14 +3571,14 @@ msgstr ""
 "到多雷斯特会师，一同击退必定要卷土重来的人类。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:200
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:196
 msgid ""
 "Having thus made his plans, Kapou’e set out for Bitok to get to the root of "
 "this treachery."
 msgstr "这样定了计划，卡破尔出发前往毕脱克，寻找这叛乱的根源。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:225
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:221
 msgid ""
 "If we are going to make it to Bitok, and then back to Dorest before spring, "
 "we have to get a move on. Break camp as soon as possible. Destroy all "
@@ -3609,12 +3589,12 @@ msgstr ""
 "地。杀光一切挡路的敌人，穿过此地时，我要这里完全在我的控制之下。"
 
 #. [message]: speaker=Braga
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:231
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:227
 msgid "Black-Eye! We won’t submit to an upstart like you!"
 msgstr "黑眼！我们不会向你这种新人服从的！"
 
 #. [message]: speaker=Meato
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:237
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:233
 msgid ""
 "Turn around and go back to where you came from or you’ll find your head on a "
 "pike! Right?"
@@ -3622,68 +3602,68 @@ msgstr "掉头回去否则就把你的脑袋挂在长矛上！明白吗？"
 
 #. [message]: speaker=Ragvan
 #. [message]: speaker=Kergai
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:242
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:247
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:238
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:243
 msgid "Right!"
 msgstr "没错！"
 
 #. [message]: speaker=Kapou'e
 #. "whupping" is not a typo for "whipping"; it is a Southern
 #. American dialect word meaning "a severe beating".
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:255
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:250
 msgid ""
 "It’s been a chilly winter. How about we warm ourselves up a bit by giving "
 "these traitors a good whupping, boys?"
 msgstr "这冬天真冷。我们热热身给叛徒们送出个惊喜怎样，伙计们？"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:260
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:255
 msgid "Yeah!"
 msgstr "耶！"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:337
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:332
 msgid "Little orcs fun to squash too! Chief doesn’t let me too often."
 msgstr "扁小兽人也好玩！头儿老是不让我干这事儿。"
 
 # 更贴切
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:342
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:337
 msgid "You can have as many as you want now, Grüü."
 msgstr "现在你想砸多少都行，咕噜。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:362
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:357
 msgid "This rabble won’t be a problem anymore."
 msgstr "这群乌合之众马上就不是问题了。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:371
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:366
 msgid "Got this tribe under control."
 msgstr "这个部落被摆平了。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:380
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:375
 msgid "This is what you get for deserting the Son of the Black-Eye."
 msgstr "这是你们背弃黑眼之子的下场。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:389
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:384
 msgid "This trash’s gone."
 msgstr "这垃圾挂啦。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:411
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:405
 msgid "Heehee, we wiped them out good."
 msgstr "嘿嘿嘿，我们团灭了他们。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:416
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:410
 msgid "Now let’s get going, we have an appointment with Shan Taum."
 msgstr "现在赶紧上路吧，我们还与闪·陶姆有个约会。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:566
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg:560
 msgid ""
 "I can’t leave these renegades unguarded at our rear. I must take care of "
 "them before continuing."
@@ -3820,22 +3800,22 @@ msgid "Right... So what will it be, beheading or torture?"
 msgstr "好吧……那你选什么呢，砍头还是拷打致死？"
 
 #. [message]: speaker=Shan Taum
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:251
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:250
 msgid "Orga, kill this kid for me. I’ll be in my keep."
 msgstr "奥加，杀了这崽子。我会呆在城堡里。"
 
 #. [message]: speaker=Orga
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:257
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:256
 msgid "Yes, sir!"
 msgstr "是，老大！"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:273
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:272
 msgid "What! Fight like an orc, you gutless coward!"
 msgstr "什么？！像个兽人一样战斗嘛，没骨气的小废物！"
 
 #. [message]: role=Helper
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:297
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:296
 msgid ""
 "Hey Chief, it’s pretty odd. Shan Taum doesn’t seem to have too many of his "
 "men around. He was given control of half the Great Horde. Do you think they "
@@ -3845,7 +3825,7 @@ msgstr ""
 "的。您认为他们离开他了吗？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:302
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:301
 msgid ""
 "I doubt it. Shan Taum knows how to dissemble. I’ll bet he sent them out like "
 "we did to clobber the other tribes into his rule. In any case, it will be "
@@ -3855,7 +3835,7 @@ msgstr ""
 "论如何，这倒是方便了我们。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:311
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg:310
 msgid ""
 "Good, we crushed this pocket of resistance too. Now where in the world did "
 "that coward Shan Taum run off to?"
@@ -3941,71 +3921,73 @@ msgid "Forward, men! Our wolves will feed well tonight!"
 msgstr "出征，伙计们！让我们的狼今晚大肆饕餮！"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:247
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:246
 msgid "Come here, human softlings. Grüü has a little present for you..."
 msgstr "来吧，人类软蛋。咕噜有小礼物送给你们……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:346
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:345
 msgid "As a fresh day dawned, more human forces arrived."
 msgstr "新的破晓，人类又来了。"
 
 #. [message]: speaker=Bruce
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:359
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:357
 msgid "We have arrived, my lord."
 msgstr "我们到了，伯爵阁下。"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:370
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:368
 msgid "Ahhh, perfect. More reinforcements."
 msgstr "啊，好极了，更多援军。"
 
 #. [unit]: type=General, id=Howgarth III
 #. [side]: type=General, id=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:388
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:152
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:386
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:151
 msgid "Howgarth III"
 msgstr "豪伽施三世"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:429
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:427
 msgid "Hold it! What in the wide green world is going on here!"
 msgstr "住手！宽广翠绿的世界啊，究竟发生了什么！"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:435
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:433
 msgid ""
 "Howgarth? You and your interfering alliance always show up at the worst "
 "possible time."
 msgstr "豪伽施？你和你总喜欢搅局的联盟总是在最坏的时刻出现。"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:441
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:439
 msgid ""
 "Curses! He is here already?! I had the messengers of the Alliance bribed to "
 "ensure no messages reached Dwarven Doors. I suppose it was only a matter of "
 "time..."
 msgstr ""
+"可恶！他竟然已经来了？！我明明贿赂了联盟的信使，确保不会有任何消息传到矮人之"
+"门。我想这是迟早的……"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:446
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:444
 msgid "Just who do you think you are, slug?"
 msgstr "你以为你谁啊，鼻涕虫？"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:452
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:450
 msgid "I am Howgarth of the Northern Alliance, successor to the late Rahul I."
 msgstr "我是北方联盟的豪伽施，拉乎尔一世的继任者。"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:458
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:456
 msgid ""
 "This is a strictly territorial matter, Howgarth. The Northern Alliance has "
 "no right to intervene in this affair."
 msgstr "这完全是本地的内部问题，豪伽施。北方联盟无权干涉。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:463
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:461
 msgid ""
 "The hell I don’t, Earl Lanbec’h, the Northern Alliance was witness to a "
 "treaty some seventeen years ago between your people and the orcs, which both "
@@ -4017,7 +3999,7 @@ msgstr ""
 "守。"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:469
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:467
 msgid ""
 "Well, good for you. As a matter of fact, this land is clearly defined under "
 "your precious treaty as human territory. So if you are so keen on being all "
@@ -4027,7 +4009,7 @@ msgstr ""
 "还算个高尚的人，赶紧召集你的人马帮我们轰走这些兽人。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:474
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:472
 msgid ""
 "Cease your lies, Lanbec’h. We all know that you were the one who started "
 "this war. But enough. It is time for all this to end. I call for both sides "
@@ -4037,7 +4019,7 @@ msgstr ""
 "呼吁双方谈判，大家一起讨论这件事。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:479
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:477
 msgid ""
 "Ha ha, very funny, old fool. You think we are stupid enough to fall for "
 "that? I’ve not forgotten what you people did to my father."
@@ -4046,12 +4028,12 @@ msgstr ""
 "做了什么。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:485
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:483
 msgid "What in the world are you talking about?"
 msgstr "你这是在说什么啊？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:490
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:488
 msgid ""
 "I am Kapou’e, son of the Black-Eye Karun. Seventeen years ago, you people "
 "assassinated my father after inviting him to join the Northern Alliance."
@@ -4060,7 +4042,7 @@ msgstr ""
 "暗杀了他。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:496
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:494
 msgid ""
 "What? We received word that he declined our invitation and that was the end "
 "of the matter. I know nothing of his assassination. As a matter of fact, I "
@@ -4070,17 +4052,17 @@ msgstr ""
 "他被刺之事。事实上，兽人信使把卡伦的回复带给拉乎尔时，我就在现场。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:501
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:499
 msgid "Messenger, what messenger?"
 msgstr "信使？什么信使？"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:507
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:505
 msgid "If I remember correctly, it was some orc named Shan Taum."
 msgstr "如果我记得没错，那个兽人名叫闪·陶姆。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:512
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg:510
 msgid "Funny, that name sounds oddly familiar..."
 msgstr "有意思，这名字听着怪耳熟的……"
 
@@ -4100,7 +4082,7 @@ msgid "Death of Howgarth III"
 msgstr "豪伽施三世死亡"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:180
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:179
 msgid ""
 "Kapou’e agreed to meet Howgarth III. Not trusting the human however, Kapou’e "
 "brought along Grüü, as well as one of his most trusted soldiers. Earl "
@@ -4110,7 +4092,7 @@ msgstr ""
 "兵。兰贝契伯爵断然拒绝参加和谈。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:186
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:185
 msgid ""
 "The human attack having stopped for the time being, both parties met in the "
 "middle of the battlefield. Howgarth III demanded that Kapou’e give Dorest "
@@ -4126,7 +4108,7 @@ msgstr ""
 "大部落。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:192
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:191
 msgid ""
 "Howgarth III agreed and further added that, if Earl Lanbec’h continued in "
 "aggression, then under the dictates of the Northern Alliance, he himself "
@@ -4136,7 +4118,7 @@ msgstr ""
 "令与伯爵对抗。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:198
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:197
 msgid ""
 "That having been settled, Kapou’e began to inquire about the death of his "
 "father. Howgarth III repeated his story, that the last thing they heard from "
@@ -4147,43 +4129,43 @@ msgstr ""
 "事：黑眼卡伦的最后消息是拒绝了北方联盟的邀请，而消息完全由闪·陶姆传达。"
 
 #. [part]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:204
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:203
 msgid ""
 "As they were discussing the matter, a group of orcs charged from the "
 "surrounding trees and hills and surrounded the parley."
 msgstr "他们正在谈判时，一队兽人从四周的树丛和山丘里包围了谈判者。"
 
 #. [message]: speaker=Shan Taum
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:475
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:474
 msgid ""
 "Now now now, what do we have here? Collaborating with the enemy again just "
 "like your disgusting father, are you?"
 msgstr "啊呀呀，看看这都是谁呀。又通敌了，像你那恶心老爹一样，嗯哼？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:481
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:479
 msgid ""
 "Collaborating with the humans, pfff. You’re one to talk. What are you doing "
 "here, Shan Taum?"
 msgstr "私通人类，呵。你倒是有脸说。你在这儿干什么，闪·陶姆？"
 
 #. [message]: speaker=Shan Taum
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:486
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:484
 msgid "I am here to do to you what I did to your father."
 msgstr "我来这儿是为了对你干和我对你老爹干的一样的事儿。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:491
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:489
 msgid "So you did kill my father then."
 msgstr "那么确实是你杀了我父亲。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:496
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:494
 msgid "What did I tell you, Kapou’e?"
 msgstr "你看看我怎么跟你说的，卡破尔？"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:502
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:500
 msgid ""
 "Ha ha! Good work Shan Taum. That will teach them. Attack, boys! I want "
 "Dorest recaptured by sunset."
@@ -4192,7 +4174,7 @@ msgstr ""
 "回多雷斯特。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:507
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:505
 msgid ""
 "Hold, Earl Lanbec’h. I have reached an agreement with these orcs. Since your "
 "army has been the aggressor, you must immediately disperse it and withdraw "
@@ -4207,19 +4189,19 @@ msgstr ""
 "里保护你，防止他违约。"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:513
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:511
 msgid ""
 "You and your damned compromises can go to hell! Your beloved Kapou’e will be "
 "joining you shortly."
 msgstr "你和你那见鬼的妥协一起下地狱吧！你心爱的卡破尔不久就会下去陪你的。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:518
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:516
 msgid "You leave us no choice but to take military action against you."
 msgstr "你让我们别无选择，只能动用军力来对付你了。"
 
 #. [message]: speaker=Earl Lanbec'h
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:524
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:522
 msgid ""
 "Ha ha! Very funny, Howgarth. Look around you. You are going to be dead as "
 "soon as my orc friend here gives the order. And then your men will "
@@ -4229,12 +4211,12 @@ msgstr ""
 "然会认为是卡破尔设计杀了你。"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:529
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:527
 msgid "Not today, my friend. (<i>Whistles</i>)"
 msgstr "今天可不行，我的朋友。（<b>口哨</b>）"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:637
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:635
 msgid ""
 "Kapou’e, it is essential that I make it back to my camp to bring news of our "
 "agreement and this treachery. One of my gryphon riders will take me. My "
@@ -4248,62 +4230,62 @@ msgstr ""
 "叛徒。等他们都被赶尽杀绝，我相信你会坚守承诺。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:642
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:640
 msgid "Agreed. Let’s get to it. BLOOD AND STEEL!"
 msgstr "同意。我们来吧。血流漂杵！！"
 
 #. [message]: speaker=Shan Taum
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:666
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:664
 msgid ""
 "Blast! The human has escaped. Orcs, bring me Kapou’e’s head. I must get to "
 "my camp and assault the city."
 msgstr "可恶！那个人类逃跑了。兽人们，把卡破尔的头提给我。我要返回营地攻城。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:695
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:693
 msgid "Shan Taum big coward. Never want to fight."
 msgstr "闪·陶姆懦夫。从来不参战。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:750
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:748
 msgid "Yeah, we finally got the coward."
 msgstr "耶！俺们终于逮住这厮啦。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:756
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:754
 msgid ""
 "Yeah, we finally got the coward. What do you want us to do with him, Chief?"
 msgstr "耶！俺们终于逮住这厮啦。老大，怎么处理他？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:765
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:763
 msgid "Blood and steel! The traitor was mine!"
 msgstr "让他死！这叛徒是我的！"
 
 #. [message]: speaker=Howgarth III
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:771
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:769
 msgid "I’m sorry, Kapou’e. I’ll have my men leave what remains of him to you."
 msgstr "对不起，卡破尔。我会让我的人把他的尸首留给你的。"
 
 #. [message]
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:777
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:775
 msgid "What do you want us to do with him, Chief?"
 msgstr "头儿，您想要我们怎么处理他？"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:784
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:782
 msgid ""
 "Stick his head at the end of a pike and let the buzzards pick it clean. I "
 "wasn’t joking about making a mug from his skull."
 msgstr "用长矛刺穿他的脑袋，喂给秃鹫吃干净。拿他的头颅做酒杯，我TM没开玩笑。"
 
 #. [message]: speaker=Kapou'e
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:797
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:795
 msgid "No! Without him the Northern Alliance will continue to fall apart."
 msgstr "不！失去了他，北方联盟将继续分崩离析。"
 
 #. [message]: speaker=Grüü
-#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:810
+#: data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg:808
 msgid "YEAH!"
 msgstr "耶！！"
 
@@ -4453,124 +4435,124 @@ msgstr ""
 #. [advancement]: id=wol_amla_hitpoints
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:25
 msgid "Endurance: +8 HP (Hitpoints)"
-msgstr ""
+msgstr "耐力：+8 HP（生命值）"
 
 #. [modify_unit_type]: type=Orcish Warlord
 #. [modify_unit_type]: type=Orcish Sovereign
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:71
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:207
 msgid "Melee: greatsword +1 damage"
-msgstr ""
+msgstr "近战：大剑 +1 伤害"
 
 #. [modify_unit_type]: type=Orcish Warlord
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:76
 msgid "Ranged: bow +1 damage"
-msgstr ""
+msgstr "远程：弓 +1 伤害"
 
 #. [modify_unit_type]: type=Orcish Slurbow, type=blade, type=pierce, type=fire
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:91
 msgid "Melee: short sword +1 damage"
-msgstr ""
+msgstr "近战：短剑 +1 伤害"
 
 #. [modify_unit_type]: type=Orcish Slurbow, type=blade, type=pierce, type=fire
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:97
 msgid "Ranged: crossbow (pierce) +1 damage"
-msgstr ""
+msgstr "远程：十字弓（穿刺） +1 伤害"
 
 #. [modify_unit_type]: type=Orcish Slurbow, type=blade, type=pierce, type=fire
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:103
 msgid "Ranged: crossbow (fire) +2 damage"
-msgstr ""
+msgstr "远程：十字弓（火焰） +2 伤害"
 
 #. [modify_unit_type]: type=Direwolf Rider
 #. [modify_unit_type]: type=Goblin Pillager
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:117
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:136
 msgid "Melee: fangs +1 damage"
-msgstr ""
+msgstr "近战：利齿 +1 伤害"
 
 #. [modify_unit_type]: type=Direwolf Rider
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:122
 msgid "Melee: claws +1 damage"
-msgstr ""
+msgstr "近战：利爪 +1 伤害"
 
 #. [modify_unit_type]: type=Goblin Pillager
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:141
 msgid "Melee: torch +1 damage"
-msgstr ""
+msgstr "近战：火炬 +1 伤害"
 
 #. [modify_unit_type]: type=Goblin Pillager
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:146
 msgid "Ranged: net +1 damage"
-msgstr ""
+msgstr "远程：网 +1 伤害"
 
 #. [modify_unit_type]: type=Troll Warrior
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:160
 msgid "Melee: hammer +2 damage"
-msgstr ""
+msgstr "近战：锤 +2 伤害"
 
 #. [modify_unit_type]: type=Troll Rocklobber
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:174
 msgid "Melee: fist +2 damage"
-msgstr ""
+msgstr "近战：拳 +2 伤害"
 
 #. [modify_unit_type]: type=Troll Rocklobber
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:179
 msgid "Melee: sling +4 damage"
-msgstr ""
+msgstr "近战：投石索 +4 伤害"
 
 #. [modify_unit_type]: type=Great Troll
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:193
 msgid "Melee: hammer +1 damage"
-msgstr ""
+msgstr "近战：锤 +1 伤害"
 
 #. [modify_unit_type]: type=Orcish Sovereign
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:212
 msgid "Ranged: crossbow +1 damage"
-msgstr ""
+msgstr "远程：十字弓 +1 伤害"
 
 #. [modify_unit_type]: type=Orcish Nightblade, type=blade, type=impact
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:227
 msgid "Melee: blade +2 damage"
-msgstr ""
+msgstr "近战：利刃 +2 伤害"
 
 #. [modify_unit_type]: type=Orcish Nightblade, type=blade, type=impact
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:233
 msgid "Melee: kick +2 damage"
-msgstr ""
+msgstr "近战：踢击 +2 伤害"
 
 #. [modify_unit_type]: type=Orcish Nightblade, type=blade, type=impact
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:238
 msgid "Ranged: throwing knives +1 damage"
-msgstr ""
+msgstr "远程：飞刀 +1 伤害"
 
 #. [modify_unit_type]: type=Saurian Flanker
 #. [modify_unit_type]: type=Saurian Javelineer
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:252
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:271
 msgid "Melee: +1 spear damage"
-msgstr ""
+msgstr "近战：+1 长矛伤害"
 
 #. [modify_unit_type]: type=Saurian Flanker
 #. [modify_unit_type]: type=Saurian Javelineer
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:257
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:276
 msgid "Ranged: +1 spear damage"
-msgstr ""
+msgstr "远程：+1 长矛伤害"
 
 #. [modify_unit_type]: type=Saurian Prophet
 #. [modify_unit_type]: type=Saurian Seer
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:290
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:309
 msgid "Melee: staff +1 damage"
-msgstr ""
+msgstr "近战：杖 +1 伤害"
 
 #. [modify_unit_type]: type=Saurian Prophet
 #. [modify_unit_type]: type=Saurian Seer
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:295
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:314
 msgid "Ranged: curse +1 damage"
-msgstr ""
+msgstr "远程：诅咒 +1 伤害"
 
 #. [message]: speaker=narrator
 #. newlines at the end are deliberate, and function as spacers before the [option]s
@@ -4591,16 +4573,27 @@ msgid ""
 "experience bars</b></span>, they’ll only get +3 max hp when they level up.\n"
 "\n"
 msgstr ""
+"恭喜，你的 $unit.language_name 升级了……但他/她已经达到最高等级了！\n"
+"\n"
+"发生这种情况时，<span color='#0D87B6'><b>某些战役</b></span>——例如本战役——允"
+"许你选择生命值或伤害的小幅加成。这些加成被称为“满级奖励\"（AMLA）。如果你的满"
+"级单位拥有正常的<span color='#0D87B6'><b>蓝色经验条</b></span>，就意味着可以"
+"得到这些AMLA。\n"
+"\n"
+"<span color='#9608CF'><b>其他战役</b></span>没有这些AMLA选项，而是会在满级单"
+"位升级时始终给予+3最大生命值。如果你的满级单位拥有<span color='#9608CF'><b>紫"
+"色经验条</b></span>，他们升级时只会获得+3最大生命值。\n"
+"\n"
 
 #. [option]
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:358
 msgid "Ok, continue with the game"
-msgstr ""
+msgstr "好的，继续游戏"
 
 #. [option]
 #: data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg:361
 msgid "Don’t show this message again"
-msgstr ""
+msgstr "别再显示这条信息了"
 
 #. [message]: speaker=unit
 #: data/campaigns/Son_Of_The_Black_Eye/utils/deaths.cfg:17
@@ -4646,9 +4639,3 @@ msgstr "弗拉塔"
 #: data/campaigns/Son_Of_The_Black_Eye/utils/utils.cfg:112
 msgid "The Great Horde: upkeep cost of every unit decreased by one."
 msgstr "大部落：每个单位的维护费用均减一。"
-
-#~ msgid "Novice Orcish Shaman"
-#~ msgstr "兽人萨满新手"
-
-#~ msgid "Old Orcish Shaman"
-#~ msgstr "兽人萨满长者"

--- a/translations/wesnoth/po/wesnoth-tb/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-tb/zh_CN.po
@@ -1,28 +1,31 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
 # wind <everywherewind@gmail.com>, 2011.
 # CloudiDust <cloudidust@gmail.com>, 2017.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.16\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2025-10-21 01:10 UTC\n"
-"PO-Revision-Date: 2025-05-26 18:17+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-06-23 03:16 UTC\n"
+"PO-Revision-Date: 2026-08-27 21:11+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.4.4\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=Two_Brothers
+#. [achievement_group]
 #: data/campaigns/Two_Brothers/_main.cfg:13
+#: data/campaigns/Two_Brothers/achievements.cfg:4
 msgid "A Tale of Two Brothers"
 msgstr "兄弟传说"
 
@@ -53,20 +56,13 @@ msgstr "高阶骑士"
 
 #. [campaign]: id=Two_Brothers
 #: data/campaigns/Two_Brothers/_main.cfg:21
-#, fuzzy
-#| msgid ""
-#| "An evil mage is threatening the small village of Maghre and its "
-#| "inhabitants. The village’s mage sends to his warrior brother for help, "
-#| "but not all goes as planned. Can you help?\n"
-#| "\n"
 msgid ""
 "An evil mage is threatening the small village of Maghre and its inhabitants. "
 "The village’s mage sends to his warrior brother for help, but not all goes "
 "as planned. Can you help?"
 msgstr ""
-"一个邪恶的法师威胁着玛格雷小村和它的居民们。村里的法师向他的骑士哥哥求助，但"
-"事态的发展并不如所料。你能帮忙吗？\n"
-"\n"
+"一个邪恶的法师威胁着玛格雷小村和它的居民们。村里的法师派人向他的武士哥哥求"
+"助，但事态的发展并不如所料。你能帮忙吗？"
 
 #. [campaign]: id=Two_Brothers
 #: data/campaigns/Two_Brothers/_main.cfg:23
@@ -75,6 +71,8 @@ msgid ""
 "The Grand Knight difficulty is intended for players who’ve already completed "
 "Liberty and Heir to the Throne."
 msgstr ""
+"此战役设有两个难度，二者差异较大。高阶骑士难度面向已完成<b>自由</b>和<b>王座"
+"继承人</b>的玩家。"
 
 #. [campaign]: id=Two_Brothers
 #: data/campaigns/Two_Brothers/_main.cfg:25
@@ -111,6 +109,49 @@ msgstr "其他"
 msgid "And special thanks to everyone else who I forgot to mention."
 msgstr "也特别感谢我没有提到的其他人。"
 
+#. [achievement]: id=heroes_of_maghre
+#: data/campaigns/Two_Brothers/achievements.cfg:8
+msgid "Heroes of Maghre"
+msgstr "玛格雷的英雄们"
+
+#. [achievement]: id=heroes_of_maghre
+#: data/campaigns/Two_Brothers/achievements.cfg:9
+msgid "Complete <i>Rooting Out a Mage</i> without recruiting."
+msgstr "在不进行征募的情况下，完成<b>铲除法师</b>。"
+
+#. [achievement]: id=treasure
+#: data/campaigns/Two_Brothers/achievements.cfg:15
+msgid "Treasure"
+msgstr "财宝"
+
+#. [achievement]: id=treasure
+#: data/campaigns/Two_Brothers/achievements.cfg:16
+msgid "Find the chest of gold in <i>Guarded Castle</i>."
+msgstr "找到<b>戒备森严的城堡</b>中的金币箱"
+
+#. [achievement]: id=baran_returns
+#: data/campaigns/Two_Brothers/achievements.cfg:22
+msgid "Baran Returns"
+msgstr "巴兰回归"
+
+#. [achievement]: id=baran_returns
+#: data/campaigns/Two_Brothers/achievements.cfg:23
+msgid ""
+"Complete <i>Return to the Village</i> by defeating the enemy leader with "
+"Baran."
+msgstr "和巴兰一起击败敌方首领，完成<b>回到村庄</b>。"
+
+#. [achievement]: id=arvith_the_great_knight
+#: data/campaigns/Two_Brothers/achievements.cfg:29
+msgid "Arvith the Great Knight"
+msgstr "伟大骑士阿维斯"
+
+#. [achievement]: id=arvith_the_great_knight
+#: data/campaigns/Two_Brothers/achievements.cfg:30
+msgid ""
+"Advance Arvith into a Grand Knight or a Paladin before the campaign ends."
+msgstr "在战役结束前，将阿维斯升级为高阶骑士或圣骑士。"
+
 #. [scenario]: id=01_Rooting_Out_a_Mage
 #: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:5
 msgid "Rooting Out a Mage"
@@ -119,7 +160,7 @@ msgstr "铲除法师"
 #. [part]
 #. This text is shown with the journey map, showing the village in the foothills along the route between Aldril and Dan’Tonk.
 #. I'm assuming the beacons either use smoke signals or basic fire signals, with a few agreed ones to request goods or indicate that surplus is for sale.
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:52
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:51
 msgid ""
 "The remote freehold of Maghre in the western reaches of the Kingdom of "
 "Wesnoth was once a peaceful place, its inhabitants largely unaware of the "
@@ -132,7 +173,7 @@ msgstr ""
 "管艾迪尔和丹·冬克之间的商队可能会在烽火台召唤时派出一辆马车。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:57
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:56
 msgid ""
 "Then came the day that a dark mage settled in the region and began seeking "
 "sacrifices for his summonings.\n"
@@ -152,7 +193,7 @@ msgstr ""
 "去请他帮忙的信使都没有回来。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:63
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:62
 msgid ""
 "There was a man named Baran who had shown talent as a mage when he was "
 "young, gone to the great Academy on the Isle of Alduin, and returned to work "
@@ -168,7 +209,7 @@ msgstr ""
 "理干净并上油。他让玛格雷的铁匠们为没有武器的人制造了矛尖和斧刃。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:68
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:67
 msgid ""
 "Now Baran had a brother named Arvith who had also left Maghre to seek his "
 "fortune, and had become the leader of a small band of horsemen who hired out "
@@ -181,20 +222,7 @@ msgstr ""
 "使用贸易信标作为信号。巴兰呼唤了自己的哥哥。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:72
-#, fuzzy
-#| msgid ""
-#| "12 V, 363 YW\n"
-#| "Excerpt from the journal of Baran of Maghre\n"
-#| "\n"
-#| "If I could but face this ‘Mordak’! I think my magic might prove stronger "
-#| "than his. But he bides in the hills, well-guarded by his servants, and I "
-#| "muster frightened peasants to fight his minions with blades and sticks.\n"
-#| "\n"
-#| "I need my brother; he always had a better head for battle than I. Yet we "
-#| "have not spoken since that evil day at Toen Caric. If he will not come "
-#| "for me, perhaps he will return to aid our village in its hour of "
-#| "desperate need."
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:71
 msgid ""
 "12 Scryer’s Bloom, 363 YW\n"
 "Excerpt from the journal of Baran of Maghre\n"
@@ -207,7 +235,7 @@ msgid ""
 "have not spoken since that evil day at Toen Caric. If he will not come for "
 "me, perhaps he will return to aid our village in its hour of desperate need."
 msgstr ""
-"韦元363年5月12日\n"
+"韦元363年占卜花月12日\n"
 "摘自玛格雷的巴兰的日记\n"
 "\n"
 "要是我能面对这个“魔达克”就好了！我想我的魔法也许比他的强。但是他藏身在丘陵"
@@ -219,7 +247,7 @@ msgstr ""
 "燃眉之急吧。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:81
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:80
 msgid ""
 "Heeding the call, Arvith gathered such men as he could and hurried to Maghre "
 "to help Baran."
@@ -228,11 +256,11 @@ msgstr ""
 
 #. [side]
 #. [side]: type=Longbowman, id=Reeve Hoban
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:99
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:66
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:56
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:58
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:111
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:97
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:64
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:54
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:56
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:107
 msgid "Humans"
 msgstr "人类"
 
@@ -240,79 +268,79 @@ msgstr "人类"
 #. [side]: type=Dark Sorcerer, id=Rotharik
 #. [side]
 #. [side]: type=Orcish Warlord, id=Tairach
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:120
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:81
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:131
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:82
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:116
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:77
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:127
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:78
 msgid "Enemies"
 msgstr "敌人"
 
 #. [side]: type=Dark Sorcerer, id=Mordak
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:125
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:121
 msgid "Mordak"
 msgstr "魔达克"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:152
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:148
 msgid "Alwyn"
 msgstr "奥尔温"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:153
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:149
 msgid "Brent"
 msgstr "布伦特"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:154
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:150
 msgid "Cadell"
 msgstr "卡戴尔"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:155
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:151
 msgid "Dannen"
 msgstr "丹能"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:156
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:152
 msgid "Efran"
 msgstr "埃夫兰"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:157
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:153
 msgid "Faren"
 msgstr "法伦"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:160
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:156
 msgid "Tarek"
 msgstr "塔雷克"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:161
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:157
 msgid "Hann"
 msgstr "韩"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:162
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:158
 msgid "Magrid"
 msgstr "玛格里德"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:167
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:163
 msgid "Slay Mordak, the evil mage"
 msgstr "杀死邪恶法师魔达克"
 
 #. [objective]: condition=lose
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:171
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:270
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:339
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:143
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:288
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:167
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:266
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:334
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:139
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:283
 msgid "Death of Arvith"
 msgstr "阿维斯死亡"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:182
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:178
 msgid ""
 "Use footpads as fodder to protect your loyal units and attack during the day "
 "to minimize the damage your forces take."
@@ -320,27 +348,27 @@ msgstr ""
 "用走卒当炮灰以保卫你的忠诚单位，在昼间进攻以将你的部队所受的伤害降至最低。"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:192
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:188
 msgid "Greetings, brother, and welcome home."
 msgstr "你好，哥哥，欢迎回家。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:197
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:193
 msgid "Hail."
 msgstr "嗨。"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:202
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:198
 msgid "Is that all, Arvith? I understand, but..."
 msgstr "就这样，阿维斯？我懂，但是……"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:207
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:203
 msgid "You called, and I came; be content with that. What ails Maghre?"
 msgstr "你呼唤我，我便来了；知足吧。是什么在侵扰玛格雷？"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:212
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:208
 msgid ""
 "A dark mage has come upon us; his creatures call him Mordak. They have been "
 "terrorizing outlying farms, and we fear they may soon attack the village "
@@ -352,7 +380,7 @@ msgstr ""
 "素的战士；但我们需要你的手下帮助，还需要你来领导他们。"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:217
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:213
 msgid ""
 "I can feel Mordak’s foul touch on the hidden currents of the earth and air. "
 "He is somewhere due north of here, I would say not more than two days’ ride."
@@ -361,14 +389,14 @@ msgstr ""
 "马前去，是不到两天的路程。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:222
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:218
 msgid ""
 "All right. I will do this for the village. Can you keep the mage off our "
 "backs?"
 msgstr "好吧。我会为村子而战。你能防止这法师从背后偷袭我们吗？"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:227
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:223
 msgid ""
 "I will go stealthily with a handful of our best scouts and woodsmen. While "
 "you demonstrate against him and kill his creatures, I will try to defeat "
@@ -379,29 +407,29 @@ msgstr ""
 "物之时，我会趁他没有防备，试图打败他的。你为右手，而我为左手……同意吗，哥哥？"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:232
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:228
 msgid "... Aye. Just make sure you’re there when we need you."
 msgstr "……好的。只要保证我们需要你的时候你会出现就行。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:243
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:248
 msgid ""
 "Baran should be in position by now. Press them, distract the adept so Baran "
 "can spring his trap!"
 msgstr "巴兰现在应该就位了。压制他们，引开那些狂徒，让巴兰可以突袭魔达克！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:254
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:259
 msgid "Baran has not made his attack!"
 msgstr "巴兰没有进攻！"
 
 #. [message]: role=Mercenary
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:259
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:264
 msgid "Could he have abandoned us?"
 msgstr "他难道抛弃我们了吗？"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:264
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:269
 msgid ""
 "No... No. This is something else. I’m worried about him... but right now it "
 "means we have to deal with this Mordak ourselves."
@@ -410,46 +438,46 @@ msgstr ""
 "魔达克了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:276
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:281
 msgid "Argh!"
 msgstr "啊！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:281
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:286
 msgid "Good work, men! But what has become of my brother?"
 msgstr "大伙干得好！但我的弟弟怎么了？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:286
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:291
 msgid "Worried about him, are you? E-he-he... hergh... gaargh..."
 msgstr "你担心他，是不是？呃呵呵……哈咯……嘎啊……"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:296
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:301
 msgid ""
 "There’s nothing more to be had from this one; we will have to search for "
 "Baran ourselves!"
 msgstr "这个家伙吐不出什么了；我们得自己去找巴兰！"
 
 #. [message]: role=Reporter
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:318
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:323
 msgid ""
 "Sir, our scouts report that Baran was seen captured and carried away further "
 "north!"
 msgstr "长官，我们的侦察兵报告说他们看见巴兰被俘虏了，并被送往了更北面！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:323
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:328
 msgid "That they should dare this! We will give chase at once."
 msgstr "他们胆敢做这种事！我们马上追。"
 
 #. [message]: speaker=Mordak
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:349
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:369
 msgid "Your brother’s plan to ambush me has failed. He is our prisoner now."
 msgstr "你弟弟偷袭我的计划失败了。他现在是我们的俘虏。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:354
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:374
 msgid ""
 "My brother, kidnapped? I have failed you, Baran! And even now Mordak’s "
 "forces descend upon the village!"
@@ -457,12 +485,12 @@ msgstr ""
 "我弟弟，被绑架了？我让你失望了，巴兰！而在此刻魔达克的军队已经开到村庄了！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:370
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:390
 msgid "I hear these creatures are nigh-immune to our weapons, let us see!"
 msgstr "我听说这些生物对我们的武器几乎免疫，我们走着瞧！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:386
+#: data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg:406
 msgid "That was not so hard!"
 msgstr "对付他们没那么困难啊！"
 
@@ -477,26 +505,7 @@ msgid "Arvith and his band rode north in search of his missing brother."
 msgstr "阿维斯和他的队伍骑马去北方寻找他失踪的弟弟。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:34
-#, fuzzy
-#| msgid ""
-#| "16 V, 363 YW\n"
-#| "Excerpt from the journal of Arvith of Maghre\n"
-#| "\n"
-#| "We’ve been searching three days for Baran, and turned up nothing. My best "
-#| "hunch was to head north into the borderlands, where the necromancer’s "
-#| "minions could safely hide; everywhere else is more farmland. At first I "
-#| "thought the search might be useless, but late in the first day we found a "
-#| "set of tracks. Some of them had been made by skeletal feet, although "
-#| "after their first campsite the tracks were merely those of men carrying "
-#| "heavy loads.\n"
-#| "\n"
-#| "We’re close enough to be certain now: those tracks are heading into the "
-#| "Grey Woods. No one from Maghre or any of the other villages has gone into "
-#| "that forest in living memory. Stories have been passed down for "
-#| "generations warning against it. Supposedly the place is haunted by lost "
-#| "souls who hunger for the living, and anyone who dies there is doomed to "
-#| "join them."
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:33
 msgid ""
 "16 Scryer’s Bloom, 363 YW\n"
 "Excerpt from the journal of Arvith of Maghre\n"
@@ -515,7 +524,7 @@ msgid ""
 "warning against it. Supposedly the place is haunted by lost souls who hunger "
 "for the living, and anyone who dies there is doomed to join them."
 msgstr ""
-"韦元363年5月16日\n"
+"韦元363年占卜花月16日\n"
 "摘自玛格雷的阿维斯的日记\n"
 "\n"
 "我们已经找了巴兰三天了，但什么都没有找到。我的直觉告诉我应该向北到边陲去，也"
@@ -530,23 +539,7 @@ msgstr ""
 "的一员。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:43
-#, fuzzy
-#| msgid ""
-#| "16 V, 363 YW\n"
-#| "Excerpt from the journal of Arvith of Maghre\n"
-#| "\n"
-#| "But I’m past superstitions now; I’ve seen enough of the world to guess at "
-#| "the truth behind these sorts of tales. The forest is home to elves — "
-#| "unfriendly ones, if the stories have any basis at all. I worry for my "
-#| "men; horses don’t fight well in forests, and the elves will be more "
-#| "dangerous in their own territory. But there are things that need done and "
-#| "questions that need answered. Something bigger is happening. One "
-#| "necromancer terrorizing townsfolk is nothing new, but why didn’t his "
-#| "servants scatter when he was killed? Where are they headed now? And most "
-#| "importantly, why did they take Baran with them?\n"
-#| "\n"
-#| "Besides... I want my brother back."
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:42
 msgid ""
 "16 Scryer’s Bloom, 363 YW\n"
 "Excerpt from the journal of Arvith of Maghre\n"
@@ -563,7 +556,7 @@ msgid ""
 "\n"
 "Besides... I want my brother back."
 msgstr ""
-"韦元363年5月16日\n"
+"韦元363年占卜花月16日\n"
 "摘自玛格雷的阿维斯的日记\n"
 "\n"
 "但我现在不再迷信了；我对这世界有了足够的见识，让我能够猜测这类传说背后的真"
@@ -576,78 +569,78 @@ msgstr ""
 "除此以外……我要夺回我的弟弟。"
 
 #. [side]: type=Elvish Rider, id=Nil-Galion
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:88
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:84
 msgid "Elves"
 msgstr "精灵"
 
 #. [side]: type=Elvish Rider, id=Nil-Galion
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:93
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:89
 msgid "Nil-Galion"
 msgstr "尼尔-伽利温"
 
 #. [side]: type=Dark Adept, id=Muff Toras
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:170
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:166
 msgid "Kidnappers"
 msgstr "绑架者"
 
 #. [side]: type=Dark Adept, id=Muff Toras
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:174
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:170
 msgid "Muff Toras"
 msgstr "玛夫·托拉斯"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:239
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:235
 msgid "Fight your way through the woods before the kidnappers escape"
 msgstr "在绑架者逃跑之前杀出丛林"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:256
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:252
 msgid "Catch the kidnappers"
 msgstr "逮住绑架者"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:266
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:262
 msgid "Kill the Dark Adept before more elves arrive"
 msgstr "在更多精灵到达之前击杀黑暗狂徒"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:282
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:278
 msgid ""
 "The elvish forces are spread out. Seek to fight them one at a time with "
 "several of your units."
 msgstr "精灵部队是四散的。尝试使用多个单位对战单个单位，各个击破。"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:295
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:291
 msgid ""
 "Use horsemen or footpads to quickly explore the shrouded woods to locate the "
 "kidnappers."
 msgstr "使用骑师或走卒快速探索黑幕下的森林以定位绑架者。"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:310
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:306
 msgid ""
 "Separate the Dark Adept from his guards and attack in force for an easy kill."
 msgstr "将黑暗狂徒和他的守卫分开，击中兵力进攻以简单击杀。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:353
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:349
 msgid ""
 "Come on, men. A stroll through such lovely green woods, what could be finer?"
 msgstr "来吧，伙计们。慢慢穿过这可爱的绿色丛林，还有比这更好的事吗？"
 
 #. [message]: speaker=Nil-Galion
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:358
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:354
 msgid "You there! Halt and explain yourself."
 msgstr "那边的人！站住，说明来意。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:363
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:359
 msgid "We’re chasing after some men who kidnapped my brother!"
 msgstr "我们正在追赶一些绑架了我弟弟的人！"
 
 #. [message]: speaker=Nil-Galion
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:368
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:364
 msgid ""
 "Those men caught their prisoner practicing necromancy; for your sake, I hope "
 "he was not your brother. Assume that the man they caught was your brother’s "
@@ -659,21 +652,23 @@ msgstr ""
 "世界的灵魂的。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:379
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:375
 msgid ""
 "We killed the necromancer on the battlefield! I struck the killing blow "
 "myself."
 msgstr "我们在战场上击杀了死灵法师！我亲自了结了他。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:385
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:381
 msgid ""
 "We killed the necromancer on the battlefield! I saw the killing blow with my "
 "own eyes."
 msgstr "我们在战场上击杀了死灵法师！我亲眼看到了最后一击。"
 
 #. [message]: speaker=Nil-Galion
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:392
+#. For 1.21, this will be clarified to "...as the group with the prisoner passed us..."
+#. The semicolon onwards is also likely to be replaced with "Remember your brother as he was, trust that he is not the prisoner, and know that the prisoner’s fate will be revenge as dire as you could wish."
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:390
 msgid ""
 "We heard the sounds of battle three days ago, but the foul reek of death was "
 "unmistakable as the prisoner passed us; if your brother really is the "
@@ -693,7 +688,7 @@ msgstr ""
 "们的土地。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:399
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:397
 msgid ""
 "So much for those ghost stories, but even ghosts might have been more "
 "observant than these elves. Still, they will not stop me from freeing Baran!"
@@ -701,7 +696,7 @@ msgstr ""
 "鬼故事到此为止了，就算是鬼都比这些精灵观察得仔细。他们不能阻止我救出巴兰！"
 
 #. [message]: role=Mercenary
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:404
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:402
 msgid ""
 "I am glad at least that we will not have to face ghosts. But those elves "
 "will have us at a disadvantage; our horses will not maneuver well in the "
@@ -711,7 +706,7 @@ msgstr ""
 "地在树林里机动。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:409
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:407
 msgid ""
 "Bah, just stay on the paths; our spearmen and bowmen can fight in the deeper "
 "woods. We have faced and won through greater perils than those amateurs can "
@@ -721,13 +716,13 @@ msgstr ""
 "业余对手更大的威胁，并取得了胜利。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:450
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:448
 msgid "I see them! There they are!"
 msgstr "我看到他们了！他们在那儿！"
 
 #. [message]: speaker=Muff Toras
 #. There are no undead on the map yet, but Muff Toras summons some immediately after saying this
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:462
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:460
 msgid ""
 "Curses! Had they been a few hours slower, I might have covered our tracks "
 "without arousing the elves’ suspicions. Still, no need for the disguise any "
@@ -738,13 +733,13 @@ msgstr ""
 
 #. [message]: speaker=Arvith
 #. it's likely that all the elves are already dead, and Arvith is just shouting to the forest
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:498
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:496
 msgid "Well, elves? Now do you see who the necromancers are?"
 msgstr "看到了吧，精灵们？现在你们看到谁才是死灵法师了吧？"
 
 #. [message]: speaker=messenger_elf
 #. a elven scout rides in from off-map, takes their first look at the situation, and realises that they have no idea what's going on
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:517
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:515
 msgid ""
 "I heard sounds of battle, but did not expect to see this. I will inform the "
 "Council, they can work out who the necromancers are."
@@ -753,12 +748,12 @@ msgstr ""
 "灵法师的。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:544
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:542
 msgid "Come on, men, let’s catch those kidnappers!"
 msgstr "快，伙计们，我们去逮住那些绑架者！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:556
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:554
 msgid ""
 "Hah! You have captured me, but it will avail you nothing. I sent your "
 "precious brother the mage north with half my men a day since; he will be "
@@ -768,7 +763,7 @@ msgstr ""
 "弟，那个法师往北面去了；到现在他已经被安全地锁在我们主人的地牢里了。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:561
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:559
 msgid ""
 "My blade is at your throat. Give us the way to my brother now, or I will "
 "spill your wretched blood on the ground."
@@ -777,47 +772,47 @@ msgstr ""
 "溅地三尺。"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:564
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:562
 msgid "Sithrak"
 msgstr "西斯拉克"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:565
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:563
 msgid "Eleben"
 msgstr "艾勒本"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:566
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:564
 msgid "Jarlom"
 msgstr "伽罗姆"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:567
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:565
 msgid "Hamik"
 msgstr "哈米克"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:571
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:569
 msgid "Akranbral"
 msgstr "阿克兰布雷尔"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:572
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:570
 msgid "Drakanal"
 msgstr "德拉卡纳尔"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:573
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:571
 msgid "Xaskanat"
 msgstr "卡斯卡纳特"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:574
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:572
 msgid "Katklagad"
 msgstr "卡特克拉加德"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:580
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:578
 msgid ""
 "Three days ride to the northeast, in a deserted castle. The passwords to the "
 "guards are $first_password_$first_password and "
@@ -827,12 +822,12 @@ msgstr ""
 "$first_password_$first_password|和$second_password_$second_password|。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:588
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:586
 msgid "Bind him and take him with us. If he has played us false, he will die."
 msgstr "把他绑上，带他一起走。如果他敢耍花样，就得死。"
 
 #. [message]: role=Mercenary
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:602
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:600
 msgid ""
 "Captain, what are we riding into? I thought you wanted nothing to do with "
 "Baran any more, not since Toen Caric."
@@ -841,7 +836,7 @@ msgstr ""
 "关系了。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:607
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:605
 msgid ""
 "I’m no longer sure. What’s between us remains, but knowing someone else has "
 "lain hands on him changes things. Mount up, and let’s get moving."
@@ -850,12 +845,12 @@ msgstr ""
 "上马，开拔。"
 
 #. [event]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:622
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:620
 msgid "Brena"
 msgstr "布雷纳"
 
 #. [message]: speaker=Brena
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:631
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:629
 msgid ""
 "Greetings. I am Brena, a knight errant. I saw you pursuing and fighting the "
 "foul undead. Are there more of them to be destroyed?"
@@ -864,65 +859,65 @@ msgstr ""
 "的亡灵吗？"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:636
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:634
 msgid ""
 "Aye. We think there’s a nest of them north-east of here. They’ve captured my "
 "brother."
 msgstr "是的。我认为他们在东北面还有老巢。他们抓走了我的弟弟。"
 
 #. [message]: speaker=Brena
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:641
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:639
 msgid ""
 "I bear a great hatred towards their kind. I will follow and fight them with "
 "you, if you permit."
 msgstr "我非常痛恨亡灵族类。如果您允许，我可以跟随你们一起对付他们。"
 
 #. [message]: role=Mercenary
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:646
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:644
 msgid "He would only slow us down!"
 msgstr "他只会拖慢我们的速度！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:651
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:649
 msgid "It is my place to decide this."
 msgstr "这事由我来决定。"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:653
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:651
 msgid "Oh, all right then. Come along with us."
 msgstr "噢，好吧。一起来吧。"
 
 #. [message]: speaker=Brena
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:657
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:655
 msgid "Thank you. My comrades and I will help you on your noble quest."
 msgstr "谢谢您。我和我的战友会在您高贵的征途上帮助您。"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:662
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:660
 msgid "I am sorry. We have not the time to spare."
 msgstr "抱歉。我们没有空闲时间了。"
 
 #. [message]: speaker=Brena
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:666
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:664
 msgid ""
 "Take this, then, for I see that you are on a quest. My comrades will help "
 "you whenever you call for them."
 msgstr "那请带上这个，我知道您正在征途之上。只需召唤，我的战友就会前来帮助您。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:681
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:679
 msgid "You receive 70 pieces of gold!"
 msgstr "你获得了70枚金币！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:710
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:708
 msgid ""
 "These elves have delayed us too long, the kidnappers’ trail will have faded "
 "by now."
 msgstr "那些精灵把我们拖太久了，绑架者的痕迹现在已经消失了。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:716
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:714
 msgid ""
 "More elves are arriving; even if they believe me, the kidnappers’ trail is "
 "sure to fade before we can follow."
@@ -931,7 +926,7 @@ msgstr ""
 "失了。"
 
 #. [message]: speaker=Nil-Galion
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:730
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:728
 msgid ""
 "Deluded fool, you are rescuing a necromancer. I can only hope that you are "
 "too late, and that our souls will rest in peace."
@@ -940,7 +935,7 @@ msgstr ""
 "够安息。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:740
+#: data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg:738
 msgid "Follow their back trail!"
 msgstr "跟上他们的足迹！"
 
@@ -950,27 +945,7 @@ msgid "Guarded Castle"
 msgstr "戒备森严的城堡"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:26
-#, fuzzy
-#| msgid ""
-#| "19 V, 363 YW\n"
-#| "Excerpt from the journal of Rotharik the Clanless\n"
-#| "\n"
-#| "The last of Mordak’s servants arrived this morning bearing the news of "
-#| "his death, as well as a bundle so well-bound it was barely recognizable "
-#| "as a man. Mordak was always reckless. This whole desperate scheme was "
-#| "his, and I suppose I could blame him for everything that we have suffered "
-#| "through if it still mattered. It was he who brought the wrath of the orcs "
-#| "down on us, too. But all the same, he managed to accomplish what he set "
-#| "out to do. I still cannot believe the finality of what has happened; "
-#| "until now we had always managed to make it through somehow.\n"
-#| "\n"
-#| "We had hoped to deliver the mage to Tairach in return for our lives. I do "
-#| "not know what the warlord wants with this man, but he matches the "
-#| "description. I suppose that Mordak’s plan would have worked perfectly if "
-#| "not for the appearance of the horse warriors. Now they are coming here, "
-#| "led by a man rumored to be this mage’s brother. If that is true, he will "
-#| "stop at nothing, no more than would I if they held Mordak."
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:25
 msgid ""
 "19 Scryer’s Bloom, 363 YW\n"
 "Excerpt from the journal of Rotharik the Clanless\n"
@@ -991,7 +966,7 @@ msgid ""
 "man rumored to be this mage’s brother. If that is true, he will stop at "
 "nothing, no more than would I if they held Mordak."
 msgstr ""
-"韦元363年5月19日\n"
+"韦元363年占卜花月19日\n"
 "摘自无部落者洛萨里克的日记\n"
 "\n"
 "今晨到来的魔达克的最后一批仆从带来了他的死讯，还有一包捆得严严实实几乎认不出"
@@ -1006,22 +981,7 @@ msgstr ""
 "的，那他绝不会停下脚步，就像如果他们抓走魔达克的话，我也不会。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:34
-#, fuzzy
-#| msgid ""
-#| "19 V, 363 YW\n"
-#| "Excerpt from the journal of Rotharik the Clanless\n"
-#| "\n"
-#| "I have done what I can to fortify this dilapidated castle. The orcs who "
-#| "came with us stand guard at the gates, and I am gathering all of my "
-#| "servants to me in the inner sanctum. But ill fate awaits. Whether I "
-#| "defeat this horse-warrior or no, the orcs will still come for me; they "
-#| "have been scouring the borderlands and raiding the northern farm country "
-#| "in search of us.\n"
-#| "\n"
-#| "Yet for some reason I fear these brothers more. If Mordak were here it "
-#| "would be different, but we are broken... and these two men are whole. In "
-#| "each other, in the ties that bind them, they have strength."
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:33
 msgid ""
 "19 Scryer’s Bloom, 363 YW\n"
 "Excerpt from the journal of Rotharik the Clanless\n"
@@ -1036,7 +996,7 @@ msgid ""
 "be different, but we are broken... and these two men are whole. In each "
 "other, in the ties that bind them, they have strength."
 msgstr ""
-"韦元363年5月19日\n"
+"韦元363年占卜花月19日\n"
 "摘自无部落者洛萨里克的日记\n"
 "\n"
 "我已经尽我所能来加固这座荒废的城堡。和我们一起来的兽人守在门口，而我则把我所"
@@ -1048,7 +1008,7 @@ msgstr ""
 "个人却是一个整体。在他们之间，在联结他们的纽带之中，充满了力量。"
 
 #. [side]: type=Dark Sorcerer, id=Rotharik
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:86
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:82
 msgid "Rotharik"
 msgstr "洛萨里克"
 
@@ -1057,81 +1017,81 @@ msgstr "洛萨里克"
 #. [unit]: role=Guard2, id=Guard2_leader, type=Rogue
 #. [unit]: role=Guard2, type=Thug
 #. [unit]: role=Guard2, type=Bandit
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:94
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:102
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:111
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:119
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:583
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:593
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:602
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:612
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:90
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:98
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:107
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:115
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:578
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:588
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:597
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:607
 msgid "Guard"
 msgstr "守卫"
 
 #. [unit]: id=Knago-Brek, type=Orcish Warrior
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:138
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:134
 msgid "Knago-Brek"
 msgstr "克纳戈-布雷克"
 
 #. [unit]: type=Orcish Grunt
 #. [unit]: type=Orcish Warrior
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:146
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:154
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:163
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:171
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:142
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:150
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:159
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:167
 msgid "Castle Guard"
 msgstr "城堡守卫"
 
 #. [time]: id=indoors_dark_castle
 #. similar string in the wesnoth-help textdomain
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:236
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:232
 msgid "Indoors (dark castle)"
 msgstr "室内（黑暗城堡）"
 
 #. [time]: id=indoors_dark_castle_lit
 #. similar string in th4e wesnoth-help textdomain
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:252
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:248
 msgid "Indoors (lit)"
 msgstr "室内（照亮）"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:309
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:304
 msgid "Rescue Baran"
 msgstr "解救巴兰"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:321
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:316
 msgid "Kill the dark sorcerer to get the cell key"
 msgstr "杀死黑暗巫师以拿到牢房钥匙"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:335
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:330
 msgid "Move Arvith to the cell with his brother to free him"
 msgstr "移动阿维斯至关押他弟弟的牢房以解救他"
 
 #. [objective]: condition=lose
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:348
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:147
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:292
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:343
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:143
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:287
 msgid "Death of Baran"
 msgstr "巴兰死亡"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:360
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:355
 msgid ""
 "When facing an unknown situation, take into account details from story and "
 "dialog to inform your strategy."
 msgstr "当面对未知的状况时，将故事与对话中的细节纳入考量，以定下你的策略。"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:369
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:364
 msgid ""
 "The dark sorcerer is a strong unit; attack him with multiple units at once "
 "and try to force him off his keep."
 msgstr "黑暗巫师是强大的单位；使用多个单位同时攻击他并尝试把他赶下城堡主楼。"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:379
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:374
 msgid ""
 "Markings or decorations on hexes may indicate something to be found. If you "
 "can, it is usually a good idea to investigate."
@@ -1140,7 +1100,7 @@ msgstr ""
 "意。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:416
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:411
 msgid ""
 "Arvith and his men halt outside of the castle, gazing for a moment at the "
 "hulking mass of stone looming in the fog. There is movement in the mist."
@@ -1149,42 +1109,42 @@ msgstr ""
 "刻。薄雾中有人影晃动。"
 
 #. [message]: speaker=Guard_leader
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:421
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:416
 msgid "Halt! Friend or foe? Give the password."
 msgstr "停下！是友是敌？说出口令。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:426
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:421
 msgid "The password is"
 msgstr "口令是"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:429
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:424
 msgid "Sithrak!"
 msgstr "西斯拉克！"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:432
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:427
 msgid "Eleben!"
 msgstr "艾勒本！"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:435
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:430
 msgid "Jarlom!"
 msgstr "伽罗姆！"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:438
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:433
 msgid "Hamik!"
 msgstr "哈米克！"
 
 #. [message]: speaker=Guard_leader
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:451
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:446
 msgid "Pass, friend."
 msgstr "通过吧，朋友。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:466
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:461
 msgid ""
 "The adept didn’t lead us astray after all. I’ll keep my word, distasteful as "
 "it may be; cut him loose, and let’s be rid of him."
@@ -1193,130 +1153,130 @@ msgstr ""
 "他。"
 
 #. [message]: speaker=Guard_leader
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:477
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:472
 msgid "Wrong! Die!"
 msgstr "错了！去死吧！"
 
 #. [message]: speaker=Knago-Brek
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:495
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:490
 msgid ""
 "Haha! We not kill people for long time. Weapon wants blood. We now kill "
 "humans!"
 msgstr "哈哈！我们好久没杀人。兵器要血祭。我们现在杀掉人类！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:500
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:495
 msgid ""
 "My sword-arm shall have a say in who will do the dying. Come on, men, let’s "
 "kill some orcs."
 msgstr "究竟谁会死，要看我握剑的手怎么说。上吧，弟兄们，我们来杀几个兽人。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:512
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:507
 msgid "One less braggart orc in the world."
 msgstr "世界上又少了一个爱吹牛的兽人。"
 
 #. [message]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:520
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:515
 msgid "Captain, what are <i>orcs</i> doing this far south?"
 msgstr "长官，<b>兽人</b>在这么南的地方干什么？"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:525
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:520
 msgid "Good question. Perhaps my brother will have found out."
 msgstr "好问题。也许我弟弟可以找到答案。"
 
 #. [message]: speaker=Guard2_leader
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:625
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:620
 msgid "Are you our relief arriving? Does this mean we get to leave here now?"
 msgstr "你们是来换班的吗？是不是说我们现在可以离开这儿了？"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:630
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:625
 msgid "Um, yes. Fine. You can go."
 msgstr "唔，是的。好。你走吧。"
 
 #. [message]: speaker=Guard2_leader
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:635
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:630
 msgid "Um, you’re supposed to give the password."
 msgstr "唔，你们得报上口令。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:640
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:635
 msgid "Oh, of course. I had nearly forgotten."
 msgstr "噢，这个自然。我差点忘了。"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:643
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:638
 msgid "Akranbral!"
 msgstr "阿克兰布雷尔！"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:646
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:641
 msgid "Drakanal!"
 msgstr "德拉卡纳尔！"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:649
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:644
 msgid "Xaskanat!"
 msgstr "卡斯卡纳特！"
 
 #. [option]
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:652
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:647
 msgid "Katklagad!"
 msgstr "卡特克拉加德！"
 
 #. [message]: speaker=Guard2_leader
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:665
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:660
 msgid "Thanks! Irritating little formality, isn’t it?"
 msgstr "多谢！这程序有点儿烦人，不是吗？"
 
 #. [message]: speaker=Guard2_leader
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:675
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:670
 msgid "That’s the wrong password! These aren’t our relief! Get them!"
 msgstr "口令错了！他们不是来换班的！抓住他们！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:683
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:678
 msgid ""
 "I think I should better support my men at the front to make sure we can free "
 "my brother."
 msgstr "我想我最好给前线的弟兄助战，这样才能确保解救我的弟弟。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:695
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:690
 msgid "Your hand or Tairach’s, death is still death... (argh)"
 msgstr "死在你手上还是泰拉奇手上都一样，终究难逃一死……（啊）"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:705
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:700
 msgid "‘Tairach’? Who or what is Tairach?"
 msgstr "“泰拉奇”？泰拉奇是什么人？还是什么东西？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:710
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:705
 msgid "There’s a key in his robes."
 msgstr "他的长袍里有把钥匙。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:720
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:715
 msgid ""
 "That may well be the key to the cell they’re holding Baran in! I will take "
 "it."
 msgstr "这很可能是他们关押巴兰的牢房的钥匙！我要拿走它。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:748
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:743
 msgid "It may be important, I best take it."
 msgstr "这肯定很重要，我最好带走它。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:766
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:761
 msgid "This castle seems as dark as a cave!"
 msgstr "这座城堡就像洞穴一样黑暗！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:772
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:767
 msgid ""
 "This castle is under a constant, <i>chaotic</i> time of day (equivalent to "
 "permanent night), except for illuminated hexes adjacent to lit stone walls "
@@ -1328,12 +1288,12 @@ msgstr ""
 "敌方单位会变强。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:792
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:787
 msgid "Look what I have found in here! I can count a hundred pieces of gold."
 msgstr "看看我在这儿找到了什么！我数到了一百枚金币。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:806
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:801
 msgid "Look what I have found in here! I can count fifty pieces of gold."
 msgstr "看看我在这儿找到了什么！我数到了五十枚金币。"
 
@@ -1341,7 +1301,7 @@ msgstr "看看我在这儿找到了什么！我数到了五十枚金币。"
 #. The player’s unit stepped in the space between two runes, and a Soulless appeared
 #: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:843
 msgid "What sort of creature have I summoned here?!"
-msgstr ""
+msgstr "我召唤出来的到底是什么东西？！"
 
 #. [message]: speaker=unit
 #: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:873
@@ -1432,12 +1392,12 @@ msgid "Minion of Tairach"
 msgstr "泰拉奇的走狗"
 
 #. [message]: speaker=Rotharik
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:1043
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:1042
 msgid "You are too late! Your brother is already dead! Muahahaha...!"
 msgstr "你太慢啦！你的弟弟已经死啦！呣哈哈哈哈哈……！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:1048
+#: data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg:1047
 msgid "Argh!!"
 msgstr "啊！！"
 
@@ -1447,24 +1407,7 @@ msgid "Return to the Village"
 msgstr "回到村庄"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:26
-#, fuzzy
-#| msgid ""
-#| "27 V, 363 YW\n"
-#| "Excerpt from the journal of Baran of Maghre\n"
-#| "\n"
-#| "Almost home now. The last week has been full of mixed feelings for me — "
-#| "blissful and difficult by turns. It was wonderful to be out of that "
-#| "dungeon cell and in the sunlight again without the threat of death or "
-#| "worse hanging over my head... but with that behind me, I turned to the "
-#| "almost equally daunting task of making amends with my brother.\n"
-#| "\n"
-#| "Arvith had largely forgiven me by the time he freed me from my cell. All "
-#| "the same, it has taken all of the past week for us to rebuild the sense "
-#| "of comfort in each other we once had. It is fortunate that we have been "
-#| "able to take our time getting back — we gave the Grey Woods a wide berth, "
-#| "and on our way around it we traveled through some truly beautiful "
-#| "countryside. It has given us plenty of time to talk."
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:25
 msgid ""
 "27 Scryer’s Bloom, 363 YW\n"
 "Excerpt from the journal of Baran of Maghre\n"
@@ -1482,7 +1425,7 @@ msgid ""
 "way around it we traveled through some truly beautiful countryside. It has "
 "given us plenty of time to talk."
 msgstr ""
-"韦元363年5月27日\n"
+"韦元363年占卜花月27日\n"
 "摘自玛格雷的巴兰的日记\n"
 "\n"
 "现在快到家了。最近一星期，我心里五味杂陈——时而喜悦，时而不安。能够从地牢中脱"
@@ -1496,27 +1439,7 @@ msgstr ""
 "交谈。"
 
 #. [part]
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:34
-#, fuzzy
-#| msgid ""
-#| "27 V, 363 YW\n"
-#| "Excerpt from the journal of Baran of Maghre\n"
-#| "\n"
-#| "Though I am more at ease now, my thoughts often turn back to Toen Caric. "
-#| "We should have been able to repel the orcs without great loss — the "
-#| "pincer attack Arvith devised would surely have carried the day but for "
-#| "me. It was reckless of me to leave my men behind — I wounded the warlord "
-#| "and forced him to flee the field, but the cost far outweighed the gain. "
-#| "Those under my command could have been saved if I had remained with "
-#| "them.\n"
-#| "\n"
-#| "I can hardly blame Arvith for having taken their deaths ill, and I can "
-#| "never undo the wrong that I have done, but I suppose that time heals some "
-#| "things. We return to the village as brothers once more.\n"
-#| "\n"
-#| "But I am still troubled. I wonder... is this sense of foreboding I feel "
-#| "merely a remnant of my time locked away in that dungeon, or is it a sign "
-#| "of something real?"
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:33
 msgid ""
 "27 Scryer’s Bloom, 363 YW\n"
 "Excerpt from the journal of Baran of Maghre\n"
@@ -1536,7 +1459,7 @@ msgid ""
 "merely a remnant of my time locked away in that dungeon, or is it a sign of "
 "something real?"
 msgstr ""
-"韦元363年5月27日\n"
+"韦元363年占卜花月27日\n"
 "摘自玛格雷的巴兰的日记\n"
 "\n"
 "虽然我现在轻松了很多，但我的思绪还总是会回到托恩·卡里克。我们本能以很小的代价"
@@ -1551,99 +1474,99 @@ msgstr ""
 "残余下来的，还是真要发生什么事情的预兆？"
 
 #. [side]: type=Orcish Warlord, id=Tairach
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:87
-#: data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg:56
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:83
+#: data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg:53
 msgid "Tairach"
 msgstr "泰拉奇"
 
 #. [side]: type=Longbowman, id=Reeve Hoban
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:116
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:112
 msgid "Reeve Hoban"
 msgstr "荷班地方官"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:139
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:135
 msgid "Find out what is happening in the village"
 msgstr "探明村子里发生了什么"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:155
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:151
 msgid ""
 "Recruit or Recall some high-move units to be able to see as far as possible "
 "through the fog for approaching units."
 msgstr "征募或召回一些移动力强的单位，尽可能地望穿迷雾，以看到正在接近的单位。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:171
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:166
 msgid ""
 "There. The village is just across those hills, and already I see men coming "
 "to greet us!"
 msgstr "在那。翻过那些小山就是村子了，我已经看见有人来接应我们了！"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:176
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:171
 msgid ""
 "No, they are fleeing from something. We must find out what is happening over "
 "there!"
 msgstr "不，他们是在逃跑。我们必须问清楚那边发生了什么！"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:181
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:176
 msgid "Men! Ready your arms!"
 msgstr "弟兄们！拿起武器！"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:186
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:181
 msgid "We should find Reeve Hoban. Maybe he knows what is going on here."
 msgstr "我们应该去找荷班地方官。也许他知道这里发生了什么。"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:201
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:196
 msgid "We’re almost there!"
 msgstr "我们快到了！"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:206
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:201
 msgid "That warlord! It’s..."
 msgstr "那个军阀！那是……"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:211
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:206
 msgid "Yes, I’d know that face anywhere. Especially after what you did to it."
 msgstr "是的，我到哪儿都能认得出那张脸。尤其是在你对那脸做过某事之后。"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:216
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:211
 msgid "The warlord from Toen Caric."
 msgstr "从托恩·卡里克来的军阀。"
 
 #. [message]: speaker=Tairach
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:221
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:216
 msgid "You! The mage who scarred me with fire! KILL THEM!"
 msgstr "你！用火焰毁我容的法师！<b>杀了他们！</b>"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:226
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:221
 msgid "Let’s finish what we started, brother."
 msgstr "让我们完成我们做了却没有完成的事吧，哥哥。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:231
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:226
 msgid "Aye. I’ll be the right arm, and you’ll be the left. Let’s go!"
 msgstr "好。我为右臂，你为左膀。我们上吧！"
 
 #. [message]: speaker=Reeve Hoban
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:250
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:245
 msgid "I am glad to see you returned."
 msgstr "我很高兴看到你们回来。"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:255
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:250
 msgid "No gladder than I am to be here. But what has happened to Maghre?"
 msgstr "不会比我回到这儿更高兴的。但玛格雷发生了什么？"
 
 #. [message]: speaker=Reeve Hoban
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:260
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:255
 msgid ""
 "Soon after you departed we were beset by orcs. With half the men of Maghre "
 "gone, we could not stop them."
@@ -1651,14 +1574,14 @@ msgstr ""
 "你离开后不久，我们就被兽人包围了。玛格雷一半的人都死了，我们没办法阻挡他们。"
 
 #. [message]: speaker=Reeve Hoban
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:265
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:260
 msgid ""
 "The orcish warlord aims to enslave us. We will not be able to hold out for "
 "much longer."
 msgstr "兽人军阀的目标是奴役我们。我们不能再抵挡多久了。"
 
 #. [message]: speaker=Reeve Hoban
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:270
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:265
 msgid ""
 "Have a care, his men are fell fighters and have killed many. Very few remain "
 "who can bear arms, but I will send them to aid you in battle."
@@ -1667,22 +1590,22 @@ msgstr ""
 "协助你们作战。"
 
 #. [objective]: condition=win
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:284
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:279
 msgid "Slay the Orcish Warlord to free the village"
 msgstr "杀掉兽人军阀以解救村庄"
 
 #. [objectives]
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:300
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:295
 msgid "You can use Reeve Hoban’s keep to recruit or recall additional units."
 msgstr "你可以使用荷班地方官的主楼来征募或召回更多的单位。"
 
 #. [message]: speaker=Tairach
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:341
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:336
 msgid "Today, you shall pay for disfiguring my face, mage!"
 msgstr "今天，你要为毁了我的容而付出代价，法师！"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:346
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:341
 msgid ""
 "I have already paid with the lives of my men at Toen Caric. It is time I "
 "righted that mistake and finished this once and for all."
@@ -1690,14 +1613,14 @@ msgstr ""
 "在托恩·卡里克，我的部下付出了生命的代价。是时候一劳永逸地纠正我的失误了。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:355
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:365
 msgid ""
 "It is finished. We’ve defeated him at last. It was good to have you at my "
 "side, Baran."
 msgstr "都结束了。我们终于击败他了。能和你并肩作战真好，巴兰。"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:360
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:370
 msgid ""
 "So much has been destroyed. It will be difficult to repair all that the orcs "
 "and undead have wrecked. And they could come again."
@@ -1707,7 +1630,7 @@ msgstr ""
 
 #. [message]: speaker=Arvith
 #. "you have my word" is a idiom for promising to do something
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:366
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:376
 msgid ""
 "I must go back to earning my living. But you have my word, little brother; "
 "if you are beset again, I will come."
@@ -1715,12 +1638,12 @@ msgstr ""
 "我得回去继续我的生计。不过我向你保证，弟弟。如果你又被包围了，我会回来的。"
 
 #. [message]: speaker=Arvith
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:384
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:394
 msgid "I don’t think we can rescue anyone from these villages. It is too late."
 msgstr "我觉得我们没办法从这些村子里救出任何人了。太迟了。"
 
 #. [message]: speaker=Baran
-#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:389
+#: data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg:399
 msgid "I was too weak to protect these people. Oh, why did this happen to me?!"
 msgstr "我太弱了，没办法保护这些人。哦，为什么会发生这种事？！"
 
@@ -1731,21 +1654,6 @@ msgstr "兄弟传说 — 尾声"
 
 #. [part]
 #: data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg:18
-#, fuzzy
-#| msgid ""
-#| "22 IX, 365 YW\n"
-#| "Excerpt from the journal of Arvith of Maghre\n"
-#| "\n"
-#| "Maghre is looking much better than the last time I saw it. Baran has done "
-#| "wonders in two years. The village is rebuilt, and the surrounding "
-#| "farmlands are restored and reoccupied. Despite my brother’s worries, our "
-#| "people have faced no new threats in that time.\n"
-#| "\n"
-#| "It has been more difficult to stay away in those two years, but I have my "
-#| "calling and Baran has his, and we have had little opportunity to meet "
-#| "again. But as the company and I are passing through this part of the "
-#| "kingdom with a new patron, I have asked leave of him to visit my brother "
-#| "and he gave it."
 msgid ""
 "22 Stillseed, 365 YW\n"
 "Excerpt from the journal of Arvith of Maghre\n"
@@ -1760,7 +1668,7 @@ msgid ""
 "But as the company and I are passing through this part of the kingdom with a "
 "new patron, I have asked leave of him to visit my brother and he gave it."
 msgstr ""
-"韦元365年9月22日\n"
+"韦元365年静种月22日\n"
 "摘自玛格雷的阿维斯的日记\n"
 "\n"
 "玛格雷比我上次看到它时好多了。巴兰在两年内创造了奇迹。村庄已经重建了，而周围"
@@ -1772,17 +1680,6 @@ msgstr ""
 
 #. [part]
 #: data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg:27
-#, fuzzy
-#| msgid ""
-#| "22 IX, 365 YW\n"
-#| "Excerpt from the journal of Arvith of Maghre\n"
-#| "\n"
-#| "This patron is, of all things, an elf. I never thought I’d befriend one, "
-#| "but he is less arrogant than the rest. Kalenz, he calls himself. He’s "
-#| "seen too much; I can tell that just by meeting his eyes. I think we will "
-#| "have to work for our pay soon.\n"
-#| "\n"
-#| "In the meantime, though, it’s good to relax and enjoy the peace."
 msgid ""
 "22 Stillseed, 365 YW\n"
 "Excerpt from the journal of Arvith of Maghre\n"
@@ -1794,7 +1691,7 @@ msgid ""
 "\n"
 "In the meantime, though, it’s good to relax and enjoy the peace."
 msgstr ""
-"韦元365年9月22日\n"
+"韦元365年静种月22日\n"
 "摘自玛格雷的阿维斯的日记\n"
 "\n"
 "令人惊讶的是，这次的主顾是一位精灵。我从没想过能和精灵成为朋友，不过他不像其"


### PR DESCRIPTION
对wesnoth-sota、sotbe、tb：

1. 同步了官方pot文件，并翻译完成；
2. 更新了元数据（如版权行中的年份、历史译员清单（加入vimacs）、Project-Id-Version）；
3. 移除了过时翻译条目。
