### PR TITLE
master版本的ei、l、thot、utbs、wof翻译更新

### DIFF
--- a/translations/wesnoth/po/wesnoth-ei/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-ei/zh_CN.po
@@ -1,71 +1,72 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
 # CloudiDust <cloudidust@gmail.com>, 2011.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.18\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2026-01-20 17:31 UTC\n"
-"PO-Revision-Date: 2026-01-30 20:23+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-08-18 15:19 UTC\n"
+"PO-Revision-Date: 2026-08-29 16:57+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.8\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=Eastern_Invasion
 #. [achievement_group]
 #. [scenario]: id=01_Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:37
+#: data/campaigns/Eastern_Invasion/_main.cfg:35
 #: data/campaigns/Eastern_Invasion/achievements.cfg:20
 #: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:19
 msgid "Eastern Invasion"
 msgstr "东部入侵"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:38
+#: data/campaigns/Eastern_Invasion/_main.cfg:36
 msgid "EI"
 msgstr "EI"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:42
+#: data/campaigns/Eastern_Invasion/_main.cfg:41
 msgid "1x enemies"
 msgstr "1倍敌军"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:42
+#: data/campaigns/Eastern_Invasion/_main.cfg:41
 msgid "Skirmish"
-msgstr "小规模战斗"
+msgstr "遭遇战"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:43
+#: data/campaigns/Eastern_Invasion/_main.cfg:42
 msgid "3x enemies"
 msgstr "3倍敌军"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:43
+#: data/campaigns/Eastern_Invasion/_main.cfg:42
 msgid "Incursion"
 msgstr "袭击"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:44
+#: data/campaigns/Eastern_Invasion/_main.cfg:43
 msgid "5x enemies"
 msgstr "5倍敌军"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:44
+#: data/campaigns/Eastern_Invasion/_main.cfg:43
 msgid "Invasion"
-msgstr "侵略"
+msgstr "入侵"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:88
+#: data/campaigns/Eastern_Invasion/_main.cfg:87
 msgid ""
 "There are rumors of undead attacks on the eastern border of Wesnoth. You, an "
 "officer in the Royal Army, have been sent to the eastern front to protect "
@@ -77,47 +78,47 @@ msgstr ""
 "\n"
 
 #. [campaign]: id=Eastern_Invasion
-#: data/campaigns/Eastern_Invasion/_main.cfg:90
+#: data/campaigns/Eastern_Invasion/_main.cfg:89
 msgid "(Intermediate level, 16 scenarios.)"
 msgstr "（中等级别，16幕场景。）"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:94
+#: data/campaigns/Eastern_Invasion/_main.cfg:93
 msgid "Newest Campaign Version Rewrite"
 msgstr "最新版本战役重写"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:100
+#: data/campaigns/Eastern_Invasion/_main.cfg:99
 msgid "Original Campaign Design"
 msgstr "原版战役设计"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:106
+#: data/campaigns/Eastern_Invasion/_main.cfg:105
 msgid "Prose and Story Editing, Code Preparation"
 msgstr "散文与故事编辑、代码准备"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:112
+#: data/campaigns/Eastern_Invasion/_main.cfg:111
 msgid "Artwork and Graphics Design"
 msgstr "插图和图形设计"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:130
+#: data/campaigns/Eastern_Invasion/_main.cfg:129
 msgid "Campaign Redesign Playtesters"
 msgstr "战役重制游戏测试者"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:142
+#: data/campaigns/Eastern_Invasion/_main.cfg:141
 msgid "Campaign Maintenance"
 msgstr "战役维护者"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:151
+#: data/campaigns/Eastern_Invasion/_main.cfg:150
 msgid "Previous Campaign Maintenance"
 msgstr "前战役维护者"
 
 #. [about]
-#: data/campaigns/Eastern_Invasion/_main.cfg:163
+#: data/campaigns/Eastern_Invasion/_main.cfg:162
 msgid "Others"
 msgstr "其他"
 
@@ -126,7 +127,7 @@ msgstr "其他"
 msgid ""
 "Complete the <i>Eastern Invasion</i> scenario with at least 10 surviving "
 "units."
-msgstr "在完成 <i>东部入侵</i> 场景时有至少10个存活单位。"
+msgstr "在完成 <b>东部入侵</b> 场景时有至少10个存活单位。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:33
@@ -136,7 +137,7 @@ msgstr "场景1：战术撤退"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:35
 msgid "Complete <i>The Escape Tunnel</i> before the undead arrive."
-msgstr "在亡灵到达之前完成<i>离脱隧道</i>场景。"
+msgstr "在亡灵到达之前完成 <b>离脱隧道</b> 场景。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:35
@@ -148,7 +149,7 @@ msgstr "场景2：快速通关"
 msgid ""
 "Complete <i>An Unexpected Appearance</i> without killing Mal-Tar, the dark "
 "adept."
-msgstr "在不杀黑暗狂徒玛尔-塔的情况下完成<i>意外的露面</i>。"
+msgstr "在不杀黑暗狂徒玛尔-塔的情况下完成 <b>意外的露面</b>。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:37
@@ -158,7 +159,7 @@ msgstr "场景3：仁慈"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:39
 msgid "Defeat both the bandit and elven leaders in <i>Elven Interlude</i>."
-msgstr "在<i>精灵的插曲</i>中同时击败强盗和精灵首领。"
+msgstr "在 <b>精灵的插曲</b> 中同时击败强盗和精灵首领。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:39
@@ -168,7 +169,7 @@ msgstr "场景4a：焦土政策"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:41
 msgid "Recruit the dunefolk in <i>Ill Humours</i>."
-msgstr "在<i>坏脾气</i>中征募沙丘游民。"
+msgstr "在 <b>坏脾气</b> 中征募沙丘游民。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:41
@@ -178,7 +179,7 @@ msgstr "场景4b：雇佣兵"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:43
 msgid "Rescue all 6 prisoners from <i>Mal Ravanal’s Capital</i>."
-msgstr "从<i>玛尔-拉瓦纳尔之都</i>救出全部 6 名俘虏。"
+msgstr "从 <b>玛尔-拉瓦纳尔之都</b> 救出全部 6 名俘虏。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:43
@@ -188,7 +189,7 @@ msgstr "场景4c：没有人（骑师）被落下"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:45
 msgid "Complete <i>Northern Outpost</i> without any peasants dying."
-msgstr "在没有任何农民死亡的情况下完成<i>北疆哨所</i>。"
+msgstr "在没有任何农民死亡的情况下完成 <b>北疆哨所</b>。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:45
@@ -199,7 +200,7 @@ msgstr "场景5：民族英雄"
 #: data/campaigns/Eastern_Invasion/achievements.cfg:47
 msgid ""
 "Defeat the necromancer in <i>Undead Crossing</i> before rescuing Dolburras."
-msgstr "在<i>亡灵渡口</i>中救出多尔布拉斯之前击败死灵法师。"
+msgstr "在<b>亡灵渡口</b>中救出多尔布拉斯之前击败死灵法师。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:47
@@ -209,7 +210,7 @@ msgstr "场景6a：一个小小的请求？"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:49
 msgid "Complete <i>Soradoc</i> without killing any enemy leaders."
-msgstr "不消灭任何敌方首领而完成<i>索拉多克</i>。"
+msgstr "不消灭任何敌方首领而完成<b>索拉多克</b>。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:49
@@ -219,7 +220,7 @@ msgstr "场景6b：忍者"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:51
 msgid "Refuse to enslave any ogres in <i>Capturing the Ogres</i>."
-msgstr "在<i>捕获食人魔</i>中拒绝奴役任何食人魔。"
+msgstr "在<b>捕获食人魔</b>中拒绝奴役任何食人魔。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:51
@@ -229,7 +230,7 @@ msgstr "场景7a：食人魔权利倡导者"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:53
 msgid "Kill 5 enemy leaders in <i>Ogre Crossing</i>."
-msgstr "在<i>食人魔渡口</i>中击杀5个敌方首领。"
+msgstr "在<b>食人魔渡口</b>中击杀5个敌方首领。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:53
@@ -239,7 +240,7 @@ msgstr "场景7b：狂乱的状况"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:55
 msgid "Ally with the dwarves in <i>Xenophobia</i>."
-msgstr "在<i>异种憎恶</i>中与矮人结盟。"
+msgstr "在<b>异种憎恶</b>中与矮人结盟。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:55
@@ -249,7 +250,7 @@ msgstr "场景8：和我的斧头"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:57
 msgid "Recruit the wild ogres in <i>Castle in the Ice</i>."
-msgstr "在<i>冰中城堡</i>一幕招募野生食人魔。"
+msgstr "在<b>冰中城堡</b>一幕招募野生食人魔。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:57
@@ -259,7 +260,7 @@ msgstr "场景9：哇哇……"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:59
 msgid "Find the legendary Staff of Power in <i>Dark Sanctuary</i>."
-msgstr "在<i>黑暗圣殿</i>中寻找传奇的力量之法杖。"
+msgstr "在<b>黑暗圣殿</b>中寻找传奇的力量之法杖。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:59
@@ -269,7 +270,7 @@ msgstr "场景10：脑子"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:61
 msgid "Find the Ring of Invisibility in <i>Captured</i>."
-msgstr "在<i>被俘</i>中找到隐身指环。"
+msgstr "在<b>被俘</b>中找到隐身指环。"
 
 # 引用自 https://zh.wikipedia.org/wiki/%E8%87%B3%E5%B0%8A%E9%AD%94%E6%88%92
 #. [achievement_group]
@@ -280,7 +281,7 @@ msgstr "场景11：众戒归一黑暗中"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:63
 msgid "Complete <i>Evacuation</i> by defeating all enemy leaders."
-msgstr "通过击败所有敌方首领完成<i>撤退</i>一幕。"
+msgstr "通过击败所有敌方首领完成<b>撤退</b>一幕。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:63
@@ -290,7 +291,7 @@ msgstr "场景12：B计划"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:65
 msgid "Recruit Gaennell, the dark adept, in <i>Spoils of War</i>."
-msgstr "在<i>战利品</i>中征募黑暗狂徒盖内尔。"
+msgstr "在<b>战利品</b>中征募黑暗狂徒盖内尔。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:65
@@ -300,7 +301,7 @@ msgstr "场景13：赎罪誓言"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:67
 msgid "Read the story of the Clans’ defeat in <i>The Drowned Plains</i>."
-msgstr "在<i>淹没的平原</i>中阅读关于氏族战败的故事。"
+msgstr "在<b>淹没的平原</b>中阅读关于氏族战败的故事。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:67
@@ -310,7 +311,7 @@ msgstr "场景14：历史学家"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:69
 msgid "Complete <i>Eleventh Hour</i> with no recalling and no droppable items."
-msgstr "在没有召回并且不带可卸下的道具的情况下完成<i>最后时刻</i>。"
+msgstr "在没有召回并且不带可卸下的道具的情况下完成<b>最后时刻</b>。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:69
@@ -320,7 +321,7 @@ msgstr "场景16：平行历史"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:71
 msgid "Kill no enemies before defeating Mal-Ravanal in <i>The Duel</i>."
-msgstr "在<i>决斗</i>中击败玛尔-拉瓦纳尔之前，不杀死任何敌人。"
+msgstr "在<b>决斗</b>中击败玛尔-拉瓦纳尔之前，不杀死任何敌人。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:71
@@ -330,7 +331,7 @@ msgstr "场景17a：和平主义者"
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:73
 msgid "Kill all enemies before defeating Mal-Ravanal in <i>All-In</i>."
-msgstr "在<i>全体上场</i>中击败玛尔-拉瓦纳尔之前，消灭所有敌人。"
+msgstr "在<b>全体上场</b>中击败玛尔-拉瓦纳尔之前，消灭所有敌人。"
 
 #. [achievement_group]
 #: data/campaigns/Eastern_Invasion/achievements.cfg:73
@@ -452,24 +453,24 @@ msgstr ""
 #. [side]: id=Dacyn, type=Fallen Mage
 #. [side]: id=Gweddry # TODO: he respawns even if he died last scenario, so we need to fix that
 #: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:78
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:226
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:40
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:225
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:39
 #: data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg:41
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:42
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:37
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:41
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:35
 #: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:28
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:270
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:65
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:82
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:33
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:37
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:56
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:30
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:30
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:269
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:64
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:80
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:32
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:36
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:54
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:29
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:29
 #: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:46
 #: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:58
 #: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:32
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:27
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:26
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:57
 #: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:240
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:91
@@ -500,7 +501,6 @@ msgstr "韦诺人"
 #. [side]: type=Dark Sorcerer, id=Mal-Mana, gender=female
 #. [side]: type=Death Knight, id=Naken-alvak
 #. [scenario]: id=07b_Ogre_Crossing
-#. [side]: type=Death Knight, id=Ducatithil
 #. [side]: type=Necromancer, id=Mal-Yrna, gender=female
 #. [side]: type=Necromancer, id=Mal-un-Darak
 #. [side]: type=Dark Sorcerer, id=Mal-un-Zanrad, gender=female
@@ -508,28 +508,28 @@ msgstr "韦诺人"
 #. [scenario]: id=16_Eleventh_Hour
 #. [side]: type=Dark Adept, id=Lethin
 #. [scenario]: id=17b_All-In
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:101
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:137
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:183
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:178
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:100
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:136
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:182
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:176
 #: data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg:53
 #: data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg:83
 #: data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg:113
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:64
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:119
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:278
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:37
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:135
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:59
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:191
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:244
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:299
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:373
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:154
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:62
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:117
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:276
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:36
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:131
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:56
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:189
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:242
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:297
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:371
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:151
 #: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:93
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:259
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:288
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:345
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:254
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:284
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:341
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:116
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:135
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:156
@@ -551,7 +551,7 @@ msgstr "亡灵"
 
 #. [side]: type=Death Knight, id=Nakeg-alvan # this guy reappears in S16 even if you kill him in S01. (maybe death knights can get re-animated)
 #. [unit]: type=Death Knight, id=Nakeg-alvan
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:105
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:104
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:670
 msgid "Nakeg-alvan"
 msgstr "纳克格-阿尔万"
@@ -563,9 +563,9 @@ msgstr "纳克格-阿尔万"
 #. In case a leader gets killed, there's some alias use between necromancers:
 #. if Mel Guthrak dies in S01, the pursuer in S02 is renamed Mal-Talar
 #. if Mal-Talar dies in S01, S02 can and S06b does rename to "Mal-Bakral"
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:145
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:215
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:248
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:144
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:213
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:246
 msgid "Mal-Talar"
 msgstr "玛尔-塔拉"
 
@@ -573,8 +573,8 @@ msgstr "玛尔-塔拉"
 #. [side]: type=Lich, id=Mel Guthrak
 #. See comments for Mal-Talar about which necromancer appears in S02.
 #. This guy reappears no matter what in S16 (reanimated as a lich).
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:189
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:170
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:188
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:168
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:662
 msgid "Mel Guthrak"
 msgstr "梅尔·古斯拉克"
@@ -584,84 +584,84 @@ msgstr "梅尔·古斯拉克"
 #. A female Dark Adept with portrait, can be converted to the player's side.
 #. Appears in S01, where she's an apprentice of Mel Guthrak, and sometimes copies his motions (plays her animation) when he recruits.
 #. She reappears in S13, where Terraent can recruit her to the player's side.
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:211
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1064
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:210
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1092
 msgid "Gaennell"
 msgstr "盖内尔"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:236
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:235
 msgid "Vugreddyr"
 msgstr "乌格里迪尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:297
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:296
 msgid "Survive until turns run out, then move any unit to 10,15"
 msgstr "存活直到回合耗尽，然后移动任意单位到 10,15"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:307
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:306
 msgid "Move any unit to the trapdoor just outside your keep (10,15)"
 msgstr "移动任意单位到你的营地外 (10,15) 位置的活板门"
 
 #. [objective]: condition=lose
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:317
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:228
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:510
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:316
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:226
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:508
 #: data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg:169
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:177
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:303
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:553
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:431
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:175
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:301
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:563
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:430
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:868
 msgid "Death of Gweddry or Dacyn"
 msgstr "格威德利或达辛死亡"
 
 #. [message]: speaker=Gweddry
 #. Probably only two or three watchmen
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:331
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:330
 msgid "Watchmen, report. What’s going on?"
 msgstr "警卫员，报告。发生了什么事？"
 
 #. [message]: speaker=Vugreddyr
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:335
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:334
 msgid "Help! Run for your lives!"
 msgstr "救命！快逃命！"
 
 #. [message]: speaker=Dacyn
 #. Speaking to Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:340
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:339
 msgid "See for yourself. Undead approach from the east."
 msgstr "自己看看。亡灵从东面来袭。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:344
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:343
 msgid "Soldiers, to arms!"
 msgstr "士兵们，武装起来！"
 
 #. [message]: speaker=Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:354
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:353
 msgid "Look! The old outpost is newly manned."
 msgstr "看！这个老哨所最近武装起来了。"
 
 #. [message]: speaker=Mel Guthrak
 #. Mal-Talar is a male dark sorcerer, he'll dispatch a messenger bat
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:359
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:358
 msgid "Interesting... you, Talar, send news of this development."
 msgstr "有意思……你，塔拉，把这个进展情况发出去。"
 
 #. [message]: speaker=$found_unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:426
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:425
 msgid "Sun’s up! They’re falling back!"
 msgstr "太阳出来了！他们在后退！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:440
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:439
 msgid "I sense a great power... no, it cannot be... I must not be seen."
 msgstr "我感到一股强大的力量……不，这不可能……别让我被发现了。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:484
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:483
 msgid ""
 "This is the resistance you spoke of, an untrained commander and a few fresh "
 "recruits?"
@@ -670,28 +670,28 @@ msgstr "这就是你所说的反抗力量：未经训练的指挥官和一群新
 #. [message]: speaker=Mal-Talar
 #. Mal-Ravanal is neither male nor female, so avoid structures using direct addresses or pronouns when possible
 #. Gender neutral pronouns or plural pronouns implying multiple entities are preferred, but you can use language default if that is not possible
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:490
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:489
 msgid "My deepest apologies! Please, forgive us. There will be no more delays."
 msgstr "我深表歉意！请原谅我们。不会再有延误了。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:494
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:493
 msgid "So you say."
 msgstr "你是这么说的。"
 
 #. [message]: speaker=Mal-Ravanal
 #. Mal-Ravanal has just animated 10 (more or less depending on difficulty) undead
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:543
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:542
 msgid "That is how you raise thralls, apprentice. Carry on."
 msgstr "学徒，这就是复活奴隶的方法。继续。"
 
 #. [message]: speaker=Mal-Talar
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:547
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:546
 msgid "We shall ensure their destruction!"
 msgstr "我们要确保他们的毁灭！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:557
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:556
 msgid ""
 "Blast it, they’ve been reinforced! And why did Dacyn leave? We’ll have to "
 "hold back the undead until he returns."
@@ -700,37 +700,37 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. a huge number of undead are spawning
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:677
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:676
 msgid "Wha— How did so many of them flank us? We’re cut off from Wesnoth!"
 msgstr "哇——怎么他们有这么多围着我们？我们和韦诺隔绝了！"
 
 #. [message]: speaker=Dacyn
 #. Dacyn doesn't really express much and doesn't like to explain himself
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:713
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:712
 msgid "Gweddry? Ah, you survive."
 msgstr "格威德利？啊，你还活着。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:717
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:716
 msgid ""
 "Dacyn, why did you flee the battle? Our situation has become rather "
 "desperate."
 msgstr "达辛，为什么你逃离战斗？我们的情况已经变得很绝望了。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:721
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:720
 msgid ""
 "Now is not the time for a lengthy report. Unless you intend to die, I "
 "suggest you escape through this trapdoor."
 msgstr "现在不是做长篇报告的时候。除非你想死，我建议你从这个活板门逃脱。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:761
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:760
 msgid "But we have orders to hold this outpost!"
 msgstr "可是我们接到命令要守住哨所！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:765
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:764
 msgid ""
 "You have not yet seen even one-hundredth of the undead armies. This outpost "
 "is already lost. Your death — as heroic as I am sure it would be — will "
@@ -740,22 +740,22 @@ msgstr ""
 "样英勇——不会对任何人有益。现在过来，没什么时间可以浪费了。"
 
 #. [message]
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:778
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:777
 msgid "I’m at the trapdoor! Follow me!"
 msgstr "我到活板门了！跟我走！"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:780
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:779
 msgid "Escape"
 msgstr "逃走"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:794
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:793
 msgid "Wait"
 msgstr "等等"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:829
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:828
 msgid "If you wish to die, there will be plenty of time for that later."
 msgstr "如果你想死，以后有足够的时间满足你的愿望的。"
 
@@ -766,10 +766,10 @@ msgstr "如果你想死，以后有足够的时间满足你的愿望的。"
 #. [message]: speaker=Fallen Clansman
 #. [message]: speaker=ghast_leader
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:845
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:549
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1120
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1137
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:844
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:545
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1116
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1165
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:922
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:926
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:1219
@@ -781,7 +781,7 @@ msgid "..."
 msgstr "……"
 
 #. [message]: speaker=Mal-Talar
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:862
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:861
 msgid "No! I was promised I could rule this province!"
 msgstr "不！我被许诺过我可以统治这个省的！"
 
@@ -789,13 +789,13 @@ msgstr "不！我被许诺过我可以统治这个省的！"
 #. [message]: speaker=$unit.id
 #. Gaennell gets to run away instead of dying
 #. the speaker is male
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:875
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:874
 #: data/campaigns/Eastern_Invasion/utils/traits.cfg:87
 msgid "Get me out of here!"
 msgstr "带我离开这里！"
 
 #. [message]: speaker=Mel Guthrak
-#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:889
+#: data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg:888
 msgid "You may defeat me now, but I will return!"
 msgstr "你现在可以击败我，但我会回来的！"
 
@@ -815,69 +815,69 @@ msgstr ""
 
 #. [side]: type=Dwarvish Steelclad, id=Knutan
 #. [side]: type=Dwarvish Lord, id=Pelathsil
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:55
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:69
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:53
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:68
 msgid "Dwarves"
 msgstr "矮人"
 
 #. [side]: type=Dwarvish Steelclad, id=Knutan
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:60
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:58
 msgid "Knutan"
 msgstr "努坦"
 
 #. [side]: type=Dwarvish Steelclad, id=Knutan
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:76
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:74
 msgid "Pelmaithodor"
 msgstr "佩尔梅托多尔"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:86
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:84
 msgid "Duduril"
 msgstr "杜德里尔"
 
 #. [side]: type=Troll, id=Kabak
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:110
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:108
 msgid "Trolls"
 msgstr "巨魔"
 
 #. [side]: type=Troll, id=Kabak
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:114
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:112
 msgid "Kabak"
 msgstr "卡巴克"
 
 #. [side]: type=Troll, id=Kabak
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:128
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:126
 msgid "Nag"
 msgstr "纳格"
 
 #. [side]: type=Troll, id=Kabak
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:138
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:148
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:136
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:146
 msgid "Hur"
 msgstr "胡尔"
 
 #. [then]
 #. [modify_unit]
 #. If Mal-Talar was killed in S01, use a different name.
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:211
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:481
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:209
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:479
 msgid "Mal-Bakral"
 msgstr "玛尔-巴克拉尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:224
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:506
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:222
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:504
 msgid "Move any unit to the tunnel exit"
 msgstr "移动任意单位至隧道出口"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:246
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:244
 msgid "Where are we? I can hardly see my own nose."
 msgstr "我们在哪儿？我几乎看不到自己的鼻子。"
 
 #. [message]: speaker=Dacyn
 #. "We" is not just Gweddry and Dacyn, but also all survivors from S01
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:251
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:249
 msgid ""
 "We are in a tunnel under the outpost. Smugglers originally dug it to sneak "
 "behind Wesnoth’s patrols. I believe it to be currently inhabited by trolls."
@@ -886,17 +886,17 @@ msgstr ""
 "着巨魔。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:307
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:305
 msgid "We must make haste to escape before the undead catch us."
 msgstr "在亡灵追上来之前我们必须赶快走。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:311
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:309
 msgid "Wait, before we go anywhere — who were those necromancers?"
 msgstr "等等，在继续前进之前——那些死灵法师是谁？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:315
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:313
 msgid ""
 "Is this really the time for questions? Suffice to say they represent an army "
 "much too powerful for us; perhaps too powerful for all of Wesnoth. We must "
@@ -907,12 +907,12 @@ msgstr ""
 
 #. [message]: speaker=unit
 #. speaker is a dwarf
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:334
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:332
 msgid "Who goes there?"
 msgstr "那边是谁？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:338
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:336
 msgid ""
 "We are soldiers of the King of Wesnoth. Make way, or help us get past these "
 "trolls."
@@ -920,14 +920,14 @@ msgstr "我们是韦诺国王麾下的士兵。请让出道路，或者帮助我
 
 #. [message]: speaker=Knutan
 #. in plain English, "Yes, we'll help anyone quarreling with the trolls. But what are you doing down here?"
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:347
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:345
 msgid ""
 "Aye, we’ll help anyone quarrelin’ wi’ them trolls. But what be ye doing down "
 "here?"
 msgstr "好，我们会帮助任何与巨魔为敌的人。但你们到这下面干什么？"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:351
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:349
 msgid ""
 "Undead are pursuing us, purging the land of all that lives. You should join "
 "us and flee!"
@@ -935,14 +935,14 @@ msgstr "亡灵正在追捕我们，清除这片土地上所有的生命。你们
 
 #. [message]: speaker=Knutan
 #. "My clan has lived in these caves for nearly a century. We'll not be scattered now by some sacks of bones"
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:356
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:354
 msgid ""
 "My clan ha’ lived in these caves fer near a century. We’ll no’ be scattered "
 "now by some sacks o’ bones."
 msgstr "俺的部落在这个洞穴里过了快一个世纪了，俺们不会为了一堆骨头分散开的。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:360
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:358
 msgid ""
 "Yes, I’m sure that will end well. Gweddry, we may be able to avoid the bulk "
 "of the trolls by going through the dwarves’ tunnel. I doubt they will need "
@@ -953,46 +953,46 @@ msgstr ""
 
 #. [message]: speaker=Duduril
 #. speaker is a dwarf, currently alone
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:378
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:376
 msgid "Humans! What be ye doin’ in our caves?"
 msgstr "人类！你们来我们洞穴干啥？"
 
 #. [message]: speaker=second_unit
 #. "you" meaning a single dwarf
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:383
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:381
 msgid "A horde of undead is pursuing us! You should come with us and escape."
 msgstr "一群亡灵正在追赶我们！你应该和我们一起逃跑。"
 
 #. [message]: speaker=Duduril
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:387
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:385
 msgid "Thursagan’s beard! I’ve got to go help the others!"
 msgstr "瑟萨冈的胡子！我必须去帮助其他人！"
 
 #. [message]: speaker=unit
 #. "troll treasure hole, keep out"
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:410
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:408
 msgid "TROL TREZZUR HOL: KEIP OWT"
 msgstr "巨麻臧宝同：不得人内"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:429
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:427
 msgid "It seems these trolls were hiding some gold. I count fifty gold pieces!"
 msgstr "看起来这些巨魔藏了些金子。我点到了五十枚金币！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:450
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:448
 msgid ""
 "I recognize the enchantment on that quiver. How did trolls come to possess "
 "such an artifact?"
 msgstr "我认出了那箭筒上的魔力。巨魔是如何拥有这样一件法器的？"
 
 #. [message]: speaker=Mel Guthrak
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:495
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:493
 msgid "I have found your hiding spot, fleshbag! Prepare to die!"
 msgstr "我找到你们的藏身之处了，生肉！受死吧！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:499
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:497
 msgid ""
 "He sounds awfully smug for finding an open trapdoor. Gweddry, we must escape "
 "through this tunnel’s eastern exit. It is unfortunate that it will take us "
@@ -1004,47 +1004,47 @@ msgstr ""
 "唯一的选择。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:533
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:531
 msgid "I see daylight! Follow me!"
 msgstr "我看到日光了！跟我走！"
 
 #. [message]: speaker=Knutan
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:559
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:557
 msgid "Maybe I ain’t been the wisest leader..."
 msgstr "也许我不是最有智慧的领袖……"
 
 #. [message]: speaker=Kabak
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:570
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:568
 msgid "From stone I come... now stone I return..."
 msgstr "我从石中来……现归石中去……"
 
 #. [message]: speaker=Mel Guthrak
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:581
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:579
 msgid "I die? But how?"
 msgstr "我死了？但怎么死的？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:585
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:583
 msgid "A small victory. He will be replaced soon enough; we must still flee."
 msgstr "一个小胜利。他很快会被替代，我们还是必须逃走。"
 
 #. [event]
 #. [side]: type=Dark Adept, id=Mal-Tar
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:630
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:628
 #: data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg:87
 #: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:365
 msgid "Mal-Tar"
 msgstr "玛尔-塔"
 
 #. [message]: speaker=Mal-Tar
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:638
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:636
 msgid ""
 "Hello? My masters said I should see what was making all the noise down in "
 "this old cave..."
 msgstr "你好？我的主人说我要看看是什么东西在这个古老洞穴里弄出这么大的声响……"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:642
+#: data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg:640
 msgid "We are discovered and surrounded. Now Wesnoth is doomed..."
 msgstr "我们被发现和包围了。现在韦诺被诅咒了……"
 
@@ -1069,8 +1069,8 @@ msgstr ""
 #. [then]
 #. brother of Mal-Kallat
 #: data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg:58
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:50
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:52
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:48
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:51
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:803
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:836
 msgid "Mal-Skraat"
@@ -1249,60 +1249,60 @@ msgstr ""
 "军，他们偶然发现了一个绿色山谷和一个未知的森林。"
 
 #. [side]: type=Elvish Lady, id=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:61
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:58
 msgid "Elves"
 msgstr "精灵"
 
 #. [side]: type=Elvish Lady, id=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:65
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:62
 msgid "Vaelya"
 msgstr "薇莉娅"
 
 #. [side]: type=Outlaw, id=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:115
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:112
 msgid "Mercenaries"
 msgstr "雇佣军"
 
 #. [side]: type=Outlaw, id=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:119
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:116
 msgid "Addogin"
 msgstr "阿道金"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:162
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:160
 msgid "Move any unit to the signpost in the northwest"
 msgstr "移动任意单位到西北方的路标"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:167
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:165
 msgid "Kill Addogin (bonus reward)"
 msgstr "杀了阿道金（附加奖励）"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:186
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:184
 msgid ""
 "Control 10 villages or kill Addogin to force the mercenaries to retreat."
 msgstr "控制10个村庄或者杀了阿道金以强迫雇佣军撤退。"
 
 #. [message]: speaker=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:203
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:201
 msgid "Greetings, travelers! I hope you find our forest hospitable."
 msgstr "你们好，旅行者！希望你们感受到我们森林的热情。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:207
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:205
 msgid "Indeed, and you have my thanks for allowing us entry."
 msgstr "的确，我非常感谢你允许我们进来。"
 
 #. [message]: speaker=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:211
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:209
 msgid ""
 "What brings you to our lands? Long has it has been since men of Wesnoth "
 "presented themselves to us."
 msgstr "是什么把你们带到了我们的领地？韦诺人很久没有在我们面前出现过了。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:215
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:213
 msgid ""
 "I’m afraid Wesnoth has been invaded by fell undead, although I am glad to "
 "see they have not yet entered this forest. We have come here seeking refuge "
@@ -1313,7 +1313,7 @@ msgstr ""
 
 #. [message]: speaker=Vaelya
 #. followed by a delay and then the elves switching from allies to enemies
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:220
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:218
 msgid ""
 "I am sorry to hear of your misfortune. Our scouts had spotted undead in this "
 "area, but I am shocked to hear that they are attacking Wesnoth. And if they "
@@ -1323,7 +1323,7 @@ msgstr ""
 "在攻击韦诺。如果他们在追捕你，那么……"
 
 #. [message]: speaker=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:233
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:231
 msgid ""
 "My heart aches with the weight of this decision, but if you are being "
 "pursued by undead I am afraid I cannot allow you entry. You are welcome to "
@@ -1334,7 +1334,7 @@ msgstr ""
 "在我们的土地外旅行，但我不能冒着给我的人民带来毁灭的风险。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:237
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:235
 msgid ""
 "So much for forest hospitality. Elf, you know full well that going around "
 "will take us days of forced march, time which we can hardly afford. We "
@@ -1344,12 +1344,12 @@ msgstr ""
 "们几乎负担不起。我们和你一样鄙视亡灵。让我们通过吧。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:241
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:239
 msgid "Vaelya, surely you can find it in your heart to grant us passage?"
 msgstr "薇莉娅，你在心里找不到允许我们通过的理由吗？"
 
 #. [message]: speaker=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:245
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:243
 msgid ""
 "I wish I could, but I would spare my people the fate of undeath. I must take "
 "precautions to protect these lands."
@@ -1358,37 +1358,37 @@ msgstr ""
 "地。"
 
 #. [message]: speaker=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:249
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:247
 msgid ""
 "In fact, I confess that since hearing of the undead I have stooped so low as "
 "to hire a mercenary company..."
 msgstr "事实上，我承认自从听说亡灵之后，我就卑微地雇佣了一队雇佣军……"
 
 #. [message]: speaker=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:253
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:251
 msgid "... Addogin, please escort these Wesnothians away to the east."
 msgstr "……阿道金，请把这些韦诺人送到东方去。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:261
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:259
 msgid "You heard the lady! Boys, it’s time to earn our keep!"
 msgstr "你听到了女士的话！男孩们，是时候自食其力了！"
 
 #. [unit]: type={ON_DIFFICULTY (Orcish Slayer) (Orcish Nightblade) (Orcish Nightblade)}, id=Nafga
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:272
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:270
 msgid "Nafga"
 msgstr "纳法加"
 
 #. [message]: speaker=Nafga
 #. What are your orders for me to perform, Addogin?
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:283
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:281
 msgid "And what about me?"
 msgstr "那我呢？"
 
 #. [message]: speaker=Addogin
 #. "you" being a single male Orcish Slayer or Orcish Nightblade
 #. later in the campaign, it's revealed that the necromancers are buying corpses, and a lot are being sold
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:289
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:287
 msgid ""
 "Into the forest with you. If it comes to bloodshed, strike at them from "
 "behind. And don’t even think of running off with any corpses before I can "
@@ -1398,12 +1398,12 @@ msgstr ""
 "前，也不要想带着任何尸体逃跑！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:308
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:306
 msgid "There must be some way to resolve this without fighting..."
 msgstr "一定有一种方法可以在不战斗的情况下解决这个问题……"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:312
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:310
 msgid ""
 "Finding another path westwards would cause great delay, which would cost "
 "Wesnoth many lives. We will fight our way through the mercenaries, through "
@@ -1413,7 +1413,7 @@ msgstr ""
 "雇佣军战斗，穿过精灵，从另一边出去。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:317
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:315
 msgid ""
 "... hmm, mercenaries are not known for their loyalty. If we can show we are "
 "gaining ground, they may turn and run. If we can defeat their leader, the "
@@ -1423,37 +1423,37 @@ msgstr ""
 "身逃跑。如果我们能够击败他们的首领，结果可能会更好。"
 
 #. [message]: speaker=Nafga
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:336
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:334
 msgid ""
 "Bloodshed, hahaha! Nafga will kill the humans and keep the bounty all for "
 "himself!"
 msgstr "血腥，哈哈哈！纳法加将会杀死人类，所有的赏金都归他自己！"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:344
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:342
 msgid "No amount of money is worth dying for. Forget this, it’s time to bail!"
 msgstr "再多的钱也不值得为之而死。忘了这件事，该离开了！"
 
 #. [message]: speaker=Vaelya
 #. to the remaining mercenaries, who are orcs and human outlaws
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:367
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:365
 msgid "No, we need your help! Please come back!"
 msgstr "不，我们需要你们的帮助！请你们回来！"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:371
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:369
 msgid "Sorry lady, but coin’s no good if you’re not alive to spend it."
 msgstr "对不起，女士，但如果你没命花钱，金币没有好处。"
 
 #. [message]: speaker=$found_unit.id
 #. the mercenaries decide it's time to retreat
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:398
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:396
 msgid "This ain’t lookin’ good. Those Wesnoth soldiers are <i>mean</i>."
 msgstr "这看起来不太好。那些韦诺士兵好<i>凶残</i>。"
 
 #. [message]: speaker=$second_unit.id
 #. capturing Addogin, spoken by the unit fighting him
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:418
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:416
 msgid ""
 "Oh no you don’t! You and your band of mercenaries have caused us enough "
 "trouble! How do we know you won’t rally your men and attack us again?"
@@ -1463,7 +1463,7 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. capturing Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:423
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:421
 msgid ""
 "I suppose we’ll have to bring him with us, at least for a time. Tie him up "
 "so he doesn’t run away."
@@ -1471,12 +1471,12 @@ msgstr ""
 "我认为我们不得不带他和我们一起，至少持续一段时间。把他绑住，这样他逃不掉。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:427
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:425
 msgid "Help! I was only doing my job!"
 msgstr "救命！我只是在做我的工作！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:463
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:461
 msgid ""
 "Addogin has joined your side, but will be <b><i>slowed</i></b> and "
 "<b><i>unable to attack</i></b> as long as he remains tied up."
@@ -1485,32 +1485,32 @@ msgstr ""
 "不能攻击</i></b>。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:467
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:465
 msgid "I’m gettin’ too old for this..."
 msgstr "我年纪变得太大，干不了这个了……"
 
 #. [message]: speaker=Nafga
 #. last breath
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:500
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:498
 msgid "No! This is the first and last time I have failed a mission!"
 msgstr "不！这是我第一次任务失败，也是最后一次！"
 
 #. [message]: speaker=Vaelya
 #. last breath
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:513
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:511
 msgid "I only wanted... to protect my people..."
 msgstr "我只是想……保护我的人民……"
 
 #. [message]: speaker=unit
 #. The valley of the River Weldyn, although there's also a city with the same name.
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:550
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:548
 msgid ""
 "I’ve made it through the forest and I can see the valley Weldyn open on the "
 "other side!"
 msgstr "我已经穿过森林，可以看到另一边的维尔帝河谷了！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:554
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:552
 msgid ""
 "Well done, we have crossed this forest without major delay. Now we must see "
 "what has become of Owaec and his garrison."
@@ -1519,20 +1519,20 @@ msgstr ""
 "他的驻军变成了什么样子。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:593
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:591
 msgid ""
 "What the?! Are you seeing this? Trees aren’t supposed to move like that."
 msgstr "什么？！你看到了吗？树不应该那样移动。"
 
 #. [message]: speaker=Vaelya
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:597
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:595
 msgid ""
 "The forest itself has come to our aid! Not in a hundred years have I "
 "witnessed such a wonder."
 msgstr "森林本身来帮助我们了！一百年来我从未见过如此奇观。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:601
+#: data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg:599
 msgid ""
 "The fighting has awoken woses from the forest. Now they will surely deny us "
 "passage, and this delay will mean the end of Wesnoth..."
@@ -1541,12 +1541,12 @@ msgstr ""
 "终结……"
 
 #. [scenario]: id=04b_Ill_Humors
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:7
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:5
 msgid "Ill Humours"
 msgstr "坏脾气"
 
 #. [part]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:22
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:20
 msgid ""
 "Pursued by a vengeful Mal-Skraat and his minions, Gweddry and Dacyn were "
 "forced eastward out of the Estmarks, into the near reaches of the uncharted "
@@ -1557,51 +1557,51 @@ msgstr ""
 
 #. [side]
 #. a group of Dunefolk
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:200
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:198
 msgid "Far Travelers"
 msgstr "远方旅行者"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:212
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:210
 msgid "Ikriaf"
 msgstr "伊克里夫"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:222
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:220
 msgid "Ragnabair"
 msgstr "拉格纳贝尔"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:232
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:230
 msgid "Abman"
 msgstr "亚布曼"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:242
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:240
 msgid "Nur al-Nuh"
 msgstr "努尔·努赫"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:252
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:250
 msgid "Muma"
 msgstr "牧玛"
 
 #. [objective]: condition=win
 #. Mal-Skraat is male
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:299
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:297
 msgid "Defeat Mal-Skraat"
 msgstr "击败玛尔-斯克拉特"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:312
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:570
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:310
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:580
 msgid ""
 "Any unit that begins or ends its turn adjacent to a swamp hex will become "
 "poisoned."
 msgstr "任何开始或结束其回合时和沼泽六角格相邻的单位都会中毒。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:343
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:341
 msgid ""
 "Ugh, the fumes from this swamp are horrific! I can barely see my nose and "
 "some of the men have started collapsing from sickness. I don’t think we can "
@@ -1611,7 +1611,7 @@ msgstr ""
 "认为我们不能再深入行军了。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:347
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:345
 msgid ""
 "We have already marched much too far eastward. We should now head northwest "
 "and try to reach Wesnoth’s northern river outpost. Owaec’s soldiers have "
@@ -1623,7 +1623,7 @@ msgstr ""
 "地点。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:351
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:349
 msgid ""
 "I had hoped to preserve the lives of our men, yet it seems we have no choice "
 "but to confront this infernal sorcerer."
@@ -1631,7 +1631,7 @@ msgstr ""
 "我希望拯救我们士兵的生命，但似乎我们除了面对这个邪恶的巫师之外别无选择。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:355
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:353
 msgid ""
 "This is a very dangerous place for us to fight. We must stay away from this "
 "swamp’s vapours, lest we become poisoned. And we should be cautious when "
@@ -1641,25 +1641,25 @@ msgstr ""
 "中毒。在冒险前行时我们应该小心；没法预测水下隐藏着什么看不见的东西。"
 
 #. [unit]: id=Safyam, gender=female, type=Dune Burner
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:369
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:367
 msgid "Safyam"
 msgstr "萨菲亚姆"
 
 #. [unit]: id=Hahid al-Ali, type=Dune Apothecary
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:385
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:383
 msgid "Hahid al-Ali"
 msgstr "哈希德·阿里"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:407
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:405
 msgid "Quiet, someone approaches..."
 msgstr "安静，有人靠近…"
 
 #. [message]
 #. [message]: speaker=Dacyn
 #. Speaker (not the spoken text), but used both for humans in S04b and later for the voices from the amulet
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:411
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2866
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:409
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2873
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:1063
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:2109
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:2123
@@ -1671,7 +1671,7 @@ msgstr "未知"
 #. male speaker talking to female
 #. alswdan is a fictional swamp herb
 #. suggested pronunciation is "ull-su-dahn"
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:416
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:414
 msgid ""
 "It must be here somewhere! I’m telling you, alswdan only grows in swamps, "
 "and this is the grandest one on the continent."
@@ -1682,7 +1682,7 @@ msgstr ""
 #. [message]
 #. [message]: speaker=Dacyn
 #. Speaker (not the spoken text), but used both for humans in S04b and later for the voices from the amulet
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:420
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:418
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:2116
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:1562
 msgid "Unknown 2"
@@ -1690,7 +1690,7 @@ msgstr "未知2"
 
 #. [message]
 #. female speaker talking to male, but "us" being a group of at least 5
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:423
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:421
 msgid ""
 "And <i>I’m</i> telling <i>you</i>, you’re going to get us killed wandering "
 "around these northlands! I haven’t seen home in years! Your ‘easy money’ "
@@ -1701,14 +1701,14 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. speaking to 1 male and 1 female
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:438
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:436
 msgid ""
 "Hail, strangers! Are you friend or foe? What brings you to this foul swamp?"
 msgstr "你好，陌生人！你是朋友还是敌人？是什么让你来到这个臭气熏天的沼泽地？"
 
 #. [message]: speaker=Hahid al-Ali
 #. speaking to Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:443
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:441
 msgid ""
 "Ah, natives! Perhaps you can help us! I am Hahid al-Ali, herbalist "
 "extraordinaire, and this is my assistant Safyam. We’ve journeyed to your "
@@ -1719,12 +1719,12 @@ msgstr ""
 
 #. [message]: speaker=Hahid al-Ali
 #. telling his female companion to harvest a herb
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:448
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:446
 msgid "Why, there’s one now! Safyam, if you would."
 msgstr "哎呀，现在有一个了！萨菲亚姆，如果你愿意的话。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:483
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:481
 msgid ""
 "Thanks to my cure made from this marvelous herb, she is now immune to the "
 "swamp’s ill humours! With more, I can make an antitoxin strong enough to "
@@ -1734,7 +1734,7 @@ msgstr ""
 "以制作出足够强大的解毒剂来治愈死亡的毒药！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:487
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:485
 msgid ""
 "If we help you find more of this ‘alswdan’, will you share your cure with "
 "us? Our people have been attacked by undead and we must now fight this dark "
@@ -1744,7 +1744,7 @@ msgstr ""
 "了亡灵的袭击，我们必须现在与这个黑暗巫师作战才能回家。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:491
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:489
 msgid ""
 "Ho ho, a haggler after my own heart! I don’t see why not. But if these "
 "undead are giving you such trouble, why not strike them in their capital? "
@@ -1758,7 +1758,7 @@ msgstr ""
 "们的城墙。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:495
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:493
 msgid ""
 "If you can find enough alswdan and pay a small fee, I’d be happy to "
 "inoculate all of your men and point you in the direction of the undead "
@@ -1768,65 +1768,17 @@ msgstr ""
 "们指引到亡灵要塞的方向。"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:538
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:544
 msgid "To travel west, defeat Mal-Skraat. <i>(normal)</i>"
 msgstr "击败玛尔-斯克拉特以去往西方。 <i>（普通）</i>"
 
-#. [objectives]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:541
-msgid ""
-"To travel east, collect 6 alswdan herbs and pay Hahid al-Ali $gold_cost "
-"gold. <i>(challenging)</i>"
-msgstr ""
-"要向东前进，收集6份奥苏丹草药，支付哈希德·阿里$gold_cost金币。<i>(挑战)</i>"
-
-#. [objectives]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:542
-msgid ""
-"To travel east, collect 5 alswdan herbs and pay Hahid al-Ali $gold_cost "
-"gold. <i>(challenging)</i>"
-msgstr ""
-"要向东前进，收集5份奥苏丹草药，支付哈希德·阿里$gold_cost金币。<i>(挑战)</i>"
-
-#. [objectives]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:543
-msgid ""
-"To travel east, collect 4 alswdan herbs and pay Hahid al-Ali $gold_cost "
-"gold. <i>(challenging)</i>"
-msgstr ""
-"要向东前进，收集4份奥苏丹草药，支付哈希德·阿里$gold_cost金币。<i>(挑战)</i>"
-
-#. [objectives]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:544
-msgid ""
-"To travel east, collect 3 alswdan herbs and pay Hahid al-Ali $gold_cost "
-"gold. <i>(challenging)</i>"
-msgstr ""
-"要向东前进，收集3份奥苏丹草药，支付哈希德·阿里$gold_cost金币。<i>(挑战)</i>"
-
-#. [objectives]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:545
-msgid ""
-"To travel east, collect 2 alswdan herbs and pay Hahid al-Ali $gold_cost "
-"gold. <i>(challenging)</i>"
-msgstr ""
-"要向东前进，收集2份奥苏丹草药，支付哈希德·阿里$gold_cost金币。<i>(挑战)</i>"
-
-#. [objectives]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:546
-msgid ""
-"To travel east, collect 1 alswdan herb and pay Hahid al-Ali $gold_cost gold. "
-"<i>(challenging)</i>"
-msgstr ""
-"要向东前进，收集1份奥苏丹草药，支付哈希德·阿里$gold_cost金币。<i>(挑战)</i>"
-
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:548
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:558
 msgid "<i>(herbs are spread in all directions around your starting keep)</i>"
 msgstr "<i>（草药分散在你的起始营地周边的所有方向）</i>"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:562
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:572
 msgid ""
 "Any unit that begins or ends its turn adjacent to a swamp hex will become "
 "poisoned. Hahid and Safyam are already immune."
@@ -1835,131 +1787,51 @@ msgstr ""
 "疫了。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:580
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:590
 msgid "The dunefolk will not follow you to the next scenario."
 msgstr "沙丘游民不会跟着你到下一幕场景。"
 
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:643
-msgid ""
-"I’ve found a sprig of alswdan and am now immune to the swamp’s poison! We’ll "
-"need 6 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要6份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:644
-msgid ""
-"female^I’ve found a sprig of alswdan and am now immune to the swamp’s "
-"poison! We’ll need 6 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要6份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:645
-msgid ""
-"I’ve found a sprig of alswdan and am now immune to the swamp’s poison! We’ll "
-"need 5 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要5份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:646
-msgid ""
-"female^I’ve found a sprig of alswdan and am now immune to the swamp’s "
-"poison! We’ll need 5 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要5份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:647
-msgid ""
-"I’ve found a sprig of alswdan and am now immune to the swamp’s poison! We’ll "
-"need 4 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要4份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
 #: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:648
 msgid ""
-"female^I’ve found a sprig of alswdan and am now immune to the swamp’s "
-"poison! We’ll need 4 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要4份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:649
-msgid ""
+"I’ve found a sprig of alswdan and am now immune to the swamp’s poison! We "
+"only need one more (and $gold_cost gold) to travel east."
+msgid_plural ""
 "I’ve found a sprig of alswdan and am now immune to the swamp’s poison! We’ll "
-"need 3 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要3份（以及"
-"$gold_cost金币）才能向东前进。"
+"need $herbs_needed more (and $gold_cost gold) to travel east."
+msgstr[0] ""
+"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们只需要再找到一片（以"
+"及$gold_cost|金币）就能向东前进了。"
+msgstr[1] ""
+"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们需要再找到"
+"$herbs_needed|片（以及$gold_cost|金币）才能向东前进。"
 
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:650
-msgid ""
-"female^I’ve found a sprig of alswdan and am now immune to the swamp’s "
-"poison! We’ll need 3 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要3份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:651
-msgid ""
-"I’ve found a sprig of alswdan and am now immune to the swamp’s poison! We’ll "
-"need 2 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要2份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
 #: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:652
 msgid ""
 "female^I’ve found a sprig of alswdan and am now immune to the swamp’s "
-"poison! We’ll need 2 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要2份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:653
-msgid ""
-"I’ve found a sprig of alswdan and am now immune to the swamp’s poison! We’ll "
-"need 1 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要1份（以及"
-"$gold_cost金币）才能向东前进。"
-
-#. [else]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:654
-msgid ""
+"poison! We only need one more (and $gold_cost gold) to travel east."
+msgid_plural ""
 "female^I’ve found a sprig of alswdan and am now immune to the swamp’s "
-"poison! We’ll need 1 more (and $gold_cost gold) to travel east."
-msgstr ""
-"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们还需要1份（以及"
-"$gold_cost金币）才能向东前进。"
+"poison! We’ll need $herbs_needed more (and $gold_cost gold) to travel east."
+msgstr[0] ""
+"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们只需要再找到一片（以"
+"及$gold_cost|金币）就能向东前进了。"
+msgstr[1] ""
+"我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！我们需要再找到"
+"$herbs_needed|片（以及$gold_cost|金币）才能向东前进。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:662
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:674
 msgid "I’ve found a sprig of alswdan and am now immune to the swamp’s poison!"
 msgstr "我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:663
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:675
 msgid ""
 "female^I’ve found a sprig of alswdan and am now immune to the swamp’s poison!"
 msgstr "我找到了一片奥苏丹的枝叶，现在我对沼泽的毒素免疫了！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:715
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:727
 msgid ""
 "Alas, my long, storied, and exceedingly profitable career has come to an "
 "end! Perhaps Safyam was right about the dangers of this place..."
@@ -1968,7 +1840,7 @@ msgstr ""
 "险的判断是对的……"
 
 #. [message]: speaker=Safyam
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:720
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:732
 msgid ""
 "My master has perished! It has been too many years since any of us have seen "
 "our homeland; we will return to mourn his passing."
@@ -1977,23 +1849,23 @@ msgstr ""
 "悼。"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:729
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:741
 msgid ""
 "Give Hahid $gold_cost gold; assault the undead fortress. <i>(challenging)</i>"
 msgstr "给哈希德$gold_cost金币；袭击亡灵要塞。<i>（挑战）</i>"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:739
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:751
 msgid "Give Hahid nothing; return westward towards Wesnoth. <i>(normal)</i>"
 msgstr "不给哈希德任何东西；向西朝韦诺方向返回。<i>（普通）</i>"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:749
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:761
 msgid "Give Hahid $gold_extra gold."
 msgstr "给哈希德$gold_extra金币。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:766
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:778
 msgid ""
 "Ho ho, that’s all the herbs I need! Now if you’ll give me those $gold_cost "
 "gold pieces you promised, I’d be happy to point you in the direction of that "
@@ -2004,7 +1876,7 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. speaking to Gweddry, although the previous message was spoken by Hahid
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:771
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:783
 msgid ""
 "Even if we do manage to find them, how do you expect us to defeat the undead "
 "in the very heart of their territory? I have already told you that this foe "
@@ -2015,7 +1887,7 @@ msgstr ""
 "敌人远远超出了我们能独自面对的范围。用我们有限的士兵对抗这个威胁是愚蠢的。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:801
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:813
 msgid ""
 "I’m afraid you don’t have the $gold_cost gold to pay for my information, so "
 "I must be off. Best of luck with that ‘Mal-Skraat’ you’re fighting!"
@@ -2025,7 +1897,7 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. to Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:822
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:834
 msgid ""
 "If the threat is as grave as you say, I believe we must take advantage of "
 "our position behind the undead lines. Even outnumbered, we may still be able "
@@ -2035,7 +1907,7 @@ msgstr ""
 "不足，我们仍然可能破坏他们的计划，并在他们城市内制造一些麻烦。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:826
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:838
 msgid ""
 "...so the great Gweddry intends to do what all of Wesnoth cannot. Very well. "
 "I cannot return to Wesnoth on my own, so it seems I have little choice but "
@@ -2045,14 +1917,14 @@ msgstr ""
 "诺，看来我只能加入你们的愚蠢行动了。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:847
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:859
 msgid ""
 "I heed Dacyn’s advice on this. Our armies are not strong enough to travel "
 "east."
 msgstr "我听从达辛的建议。我们的军队不足以东征。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:851
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:863
 msgid ""
 "Suit yourself! Now that I have what I need, it’s high time my friends and I "
 "returned to the Ashland."
@@ -2061,7 +1933,7 @@ msgstr ""
 
 #. [message]: speaker=Hahid al-Ali
 #. offering Hahid extra gold, but not having enough gold
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:881
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:893
 msgid ""
 "Ho ho, very funny, for a moment I thought you meant it! But really now, do "
 "you want my information or not?"
@@ -2070,7 +1942,7 @@ msgstr ""
 
 #. [message]: speaker=Hahid al-Ali
 #. offering Hahid extra gold
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:903
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:915
 msgid ""
 "What the-? You’re serious!? Well, forget herbalism, I need to find out more "
 "about this mystical land where men pay thrice what they owe!"
@@ -2079,19 +1951,19 @@ msgstr ""
 "给了三倍的欠款！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:907
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:919
 msgid ""
 "Friends, come, let us join these ‘Wesnothians’ and travel west towards the "
 "rest of their kind!"
 msgstr "朋友们，来吧，让我们加入这些“韦诺人”，向西去寻找他们同类的其他成员！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:911
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:923
 msgid "What about journeying east towards the undead fortress?"
 msgstr "向东前往亡灵要塞如何？"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:915
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:927
 msgid ""
 "Oh please, I knew you wouldn’t fall for that! I just wanted something to "
 "keep those skeletons busy while we left."
@@ -2099,7 +1971,7 @@ msgstr ""
 "哎呦，我知道你不会上当的！我只想找点东西让那些骷髅忙活一下，好让我们离开。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:939
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:951
 msgid ""
 "(The Dunefolk have joined you! You must now defeat Mal-Skraat and travel "
 "west. 10 turns have been added to the limit.)"
@@ -2108,7 +1980,7 @@ msgstr ""
 "制。）"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:964
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:976
 msgid ""
 "The dunefolk are leaving and without their aid we have no chance of even "
 "finding the undead capital. We must defeat Mal-Skraat and proceed westward."
@@ -2118,29 +1990,29 @@ msgstr ""
 
 # Translated by ollama with model glm4
 #. [message]: speaker=Mal-Skraat
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:981
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:857
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:993
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:856
 msgid "No, it can’t end like this! My sister has died unavenged..."
 msgstr "不，它不能这样结束！我妹妹已经死了，没人为她复仇……"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:986
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:998
 msgid ""
 "Good, now we should be able to reach what’s left of the northern outpost."
 msgstr "好的，现在我们应该可以到北疆哨所剩下的部分了。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:995
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:1007
 msgid "Thanks for nothing! What happened to helping me gather my herbs?"
 msgstr "谢谢了！帮助我收集草药的事怎么样了？"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:1031
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:1043
 msgid "...urhggg, I don’t feel so good..."
 msgstr "…呃呃，我感觉不太舒服…"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:1044
+#: data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg:1056
 msgid "The swamp’s vapors are overwhelming us... despite our precautions..."
 msgstr "沼泽的雾气令人窒息…尽管我们已做好预防…"
 
@@ -2159,38 +2031,38 @@ msgstr ""
 "他们面前矗立。"
 
 #. [side]: type=Dark Sorcerer, id=Mal-Rikna, gender=female
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:68
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:67
 msgid "Mal-Rikna"
 msgstr "玛尔-里克娜"
 
 #. [side]: type=Lich, id=Mal-Vakaz
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:97
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:96
 msgid "Mal-Vakaz"
 msgstr "玛尔-瓦卡兹"
 
 #. [side]: type=Death Knight, id=Rava-Krodaz
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:158
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:157
 msgid "Rava-Krodaz"
 msgstr "拉瓦-克罗达兹"
 
 #. [side]: type=Death Knight, id=Rava-Krovan
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:172
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:171
 msgid "Rava-Krovan"
 msgstr "拉瓦-克罗万"
 
 #. [scenario]: id=04c_Mal-Ravanals_Capital
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:279
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:278
 msgid "Jailer"
 msgstr "狱卒"
 
 #. [message]: speaker=Gweddry
 #. to a single captive
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:309
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:308
 msgid "How did these undead come to imprison you?"
 msgstr "这些亡灵是怎么把你关起来的？"
 
 #. [message]: speaker={ID}
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:313
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:312
 msgid ""
 "It is a sad tale. My allies and I were questing when we were ambushed and "
 "captured by ghostly warriors. Their leader has been toying with us, forcing "
@@ -2200,103 +2072,103 @@ msgstr ""
 "他们的领导者一直在玩弄我们，强迫我们为他们取乐而战斗。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:317
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:316
 msgid ""
 "No soldier deserves such treatment. We will try to free as many of you as "
 "possible."
 msgstr "没有一个战士值得被这样对待。我们会尽可能让你们自由的。"
 
 #. [message]: speaker={ID}
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:321
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:320
 msgid ""
 "Five of my comrades are still imprisoned. We will gladly enter your service "
 "in appreciation for our freedom."
 msgstr "我的五位同志仍然被关着。为答谢您给予的自由，我们很乐意加入您的军队。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:332
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:331
 msgid ""
 "A sun paladin! I had no idea there were any of your order still in Wesnoth."
 msgstr "一位太阳圣骑士！我没想到韦诺还有你们秩序中的人。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:337
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:336
 msgid "Aeraery"
 msgstr "艾拉瑞"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:344
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:343
 msgid ""
 "Thank you! My poor horse could barely breathe trapped among these reeds!"
 msgstr "谢谢！我可怜的马在这些芦苇中几乎无法呼吸！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:346
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:345
 msgid "Teoryn"
 msgstr "特奥林"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:353
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:352
 msgid ""
 "Bah, I didn’t need your help! Sooner or later, I would have gotten out of "
 "this cage on my own."
 msgstr "哎呀，我不需要你的帮助！迟早我会自己从笼子里出来的。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:355
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:354
 msgid "Yrthynaenc"
 msgstr "厄斯内恩克"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:363
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:362
 msgid ""
 "My thanks, friends. I had despaired of ever again riding free amongst the "
 "living."
 msgstr "谢谢，朋友。我曾绝望地以为再也不能在活人之间自由驰骋了。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:364
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:363
 msgid "Inyc"
 msgstr "伊尼克"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:371
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:370
 msgid ""
 "Vengeance upon the undead! I will make them pay for the abuse they’ve "
 "inflicted upon us!"
 msgstr "复仇亡灵！我要让他们为对我们施加的虐待付出代价！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:373
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:372
 msgid "Vobreddaent"
 msgstr "沃布里达恩特"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:380
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:379
 msgid ""
 "Truly you are heroes of legend to have fought so deep past the undead! I am "
 "forever in your debt."
 msgstr "你们是真正的传说中深入与亡灵战斗的英雄！我将永远欠你们的恩情。"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:416
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:415
 msgid "Escape by defeating one of the dark sorcerers"
 msgstr "击败一名黑暗巫师从而逃离"
 
 #. [objective]: condition=win
 #. when initially shown there are 6 imprisoned knights, the text doesn't change as they're freed
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:422
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:421
 msgid "Rescue the imprisoned knights"
 msgstr "救出被囚禁的骑士"
 
 #. [unit]: type=Terraent, id=Terraent
 #. the unique unit type is a Paladin variantion
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:449
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:448
 msgid "Terraent"
 msgstr "特拉恩特"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:467
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:466
 msgid ""
 "The Bitter Swamp’s ill reputation is, it seems, well merited. Mal-Ravanal’s "
 "fortress lies before us."
@@ -2304,7 +2176,7 @@ msgstr ""
 "苦涩沼泽的糟糕形象，看上去是，名副其实的。玛尔-拉瓦纳尔的堡垒就在我们面前。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:471
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:470
 msgid ""
 "Yes, and behind us undead forces are closing in, including that pest Mal-"
 "Skraat. What exactly is your plan? We have no means for victory with the "
@@ -2317,7 +2189,7 @@ msgstr ""
 "的骷髅身躯，他们的灵魂仍会留下，并轻易地占据另一个躯体。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:475
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:474
 msgid ""
 "To retreat, we need to kill one of these dark sorcerers that follow us. But "
 "we are already in the enemy capital and I believe we have a duty to hamper "
@@ -2327,29 +2199,29 @@ msgstr ""
 "认为我们有责任尽可能地阻止这些亡灵。并且看，我们不是唯一在这里战斗的人！"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:486
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:485
 msgid "In the name of all that is holy, Lich, I will strike you down!"
 msgstr "在所有神圣之名的名义下，巫妖，我将击败你！"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:490
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:489
 msgid "Try it, fleshbag."
 msgstr "试试吧，肉包。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:574
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:573
 #: data/campaigns/Eastern_Invasion/utils/character-definitions.cfg:82
 #: data/campaigns/Eastern_Invasion/utils/final_battle/final_battle.cfg:491
 msgid "Mal-Ravanal"
 msgstr "玛尔-拉瓦纳尔"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:577
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:576
 msgid "That tickled a bit!"
 msgstr "那有点痒！"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:584
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:583
 msgid ""
 "Well paladin, this has been amusing, but apparently we have a new group of "
 "guests to entertain. Back into the cage with you."
@@ -2357,7 +2229,7 @@ msgstr ""
 "好的圣骑士，这很有趣，但显然我们有一批新客人需要招待。你回到笼子里去吧。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:591
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:590
 msgid ""
 "Gratitude to you and yours, pious warriors! Now let us join forces to free "
 "my companions and cleanse this place in holy fire!"
@@ -2366,22 +2238,22 @@ msgstr ""
 "片土地！"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:616
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:615
 msgid "Silly fleshbags, did you come just to nourish our swamp?"
 msgstr "愚蠢的肉袋，你们是来滋养我们的沼泽的吗？"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:654
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:653
 msgid "Did you really think that your crude weapons would work?"
 msgstr "你真的认为你的粗糙武器会起作用吗？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:658
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:657
 msgid "Mal-Ravanal cannot be defeated right now. We must flee!"
 msgstr "现在无法击败玛尔-拉瓦纳尔。我们要逃跑！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:679
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:678
 msgid ""
 "Gweddry, we should not be here. They are merely toying with us right now, "
 "but all will be lost if Mal-Ravanal finds me amongst you!"
@@ -2391,14 +2263,14 @@ msgstr ""
 
 #. [message]: speaker=Mal-Ravanal
 #. Ravanal and Dacyn perk up a bit when talking to or referring to each other
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:707
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:683
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:706
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:681
 msgid "Wait a moment! That nauseating holier-than-thou aura..."
 msgstr "等一下！那种令人作呕的高高在上的气场……"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:711
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:687
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:710
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:685
 msgid ""
 "... ah, Dacyn, what an unexpected surprise! Last time we spoke, you blasted "
 "me before I could even finish telling you about my research."
@@ -2407,16 +2279,16 @@ msgstr ""
 "一顿。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:715
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:691
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:714
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:689
 msgid ""
 "If only it had ended back then. Stop this madness. Let this torment come to "
 "an end."
 msgstr "只愿那时就已结束。停止这疯狂吧。让这份折磨结束吧。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:722
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:695
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:721
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:693
 msgid ""
 "Torment? What torment? You’re the one who seems to be miserable. But don’t "
 "worry, if your goal was to become one of these mindless thralls, you came to "
@@ -2426,19 +2298,19 @@ msgstr ""
 "一，你就来对了地方。你知道他们是怎么说的。没有大脑，就没有痛苦！"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:823
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:822
 msgid ""
 "Don’t worry, old friend, these ghosts will take good care of you. Just stay "
 "still for a bit..."
 msgstr "别担心，老朋友，这些亡灵会好好照顾你的。就先待着别动……"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:832
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:831
 msgid "You were <b>friends</b> with this lich?!?"
 msgstr "你过去和这个巫妖是<b>朋友</b>？！？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:836
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:835
 msgid ""
 "Yes... We studied together many years ago. Ravan’s power was already most "
 "potent back then, but I fear it has become far greater now. None of you "
@@ -2448,23 +2320,23 @@ msgstr ""
 "大得多。你们谁也没有机会；我们必须马上逃！"
 
 #. [message]: speaker=Mal-Rikna
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:881
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:880
 msgid "Help, please, I never even liked that lich!"
 msgstr "救命，请帮帮我！我甚至从没喜欢过那个巫妖！"
 
 #. [message]: speaker=Mal-Skraat
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:885
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:884
 msgid "Useless mage, stop dying and start avenging my sister!"
 msgstr "无用的法师，别再死了，开始为我妹妹报仇！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:906
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:905
 msgid ""
 "Quickly, make for the western edge of the swamp! We have to get out of here!"
 msgstr "赶紧，赶到沼泽西部边缘！我们必须离开这里！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:910
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:909
 msgid ""
 "Did I not warn you? Coming here was a fool’s errand! We have been very lucky "
 "to escape with our lives. We must make with all haste to whatever remains of "
@@ -2474,14 +2346,14 @@ msgstr ""
 "必须尽快前往欧瓦埃克的北疆哨所残留的部分，希望不会被追赶。"
 
 #. [message]: speaker=$found_unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:935
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:934
 msgid ""
 "We cannot leave my companions behind! They have suffered grievously already "
 "and will surely be slain."
 msgstr "我们不能将我的同伴们留在身后！他们已经遭受重创，必将会被杀死。"
 
 #. [message]: speaker=$found_unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:943
+#: data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg:942
 msgid ""
 "Save yourselves and do not despair! As long as there are those who resist "
 "the darkness, hope will always remain."
@@ -2526,13 +2398,13 @@ msgstr ""
 "周疯狂的行军，当他们看到北疆哨所的城墙轮廓映衬在地平线上时，感到非常欣慰……"
 
 #. [side]: type=Dark Adept, id=Rilaka
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:139
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:135
 msgid "Rilaka"
 msgstr "里拉卡"
 
 #. [message]: speaker=Owaec
 #. "here lies the dead body of". An amulet was visible on this hex, a unit has moved to pick it up, which triggers this explanation why it's there.
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:229
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:225
 msgid ""
 "There lies Anwyan, our local priestess. She insisted on hiding the others "
 "first and was one of those who didn’t make it to the cellars in time."
@@ -2541,69 +2413,69 @@ msgstr ""
 "的人之一。"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:256
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:252
 msgid "Find the outlaw leader"
 msgstr "找到游寇首领"
 
 #. [objective]: condition=win
 #. Shodrano is a male Rogue or Assassin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:264
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:260
 msgid "Kill Shodrano"
 msgstr "击杀朔德拉诺"
 
 #. [objective]: condition=win
 #. Rilaka is a male Dark Adept
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:275
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:271
 msgid "Defeat Rilaka"
 msgstr "击败里拉卡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:285
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:153
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:533
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:165
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:208
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:287
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:452
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:718
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1468
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:281
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:150
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:531
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:162
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:205
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:288
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:451
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:724
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1469
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:279
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:1303
 msgid "Death of Gweddry, Dacyn, or Owaec"
 msgstr "格威德利、达辛或欧瓦埃克死亡"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:294
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:290
 msgid "Owaec is a leader and can recruit units when standing on a keep."
 msgstr "欧瓦埃克是一名领袖，站在城堡主楼的时候可以招募单位。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:303
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:299
 msgid "Capture any village to check it for outlaws."
 msgstr "占领任意村庄以从中找出游寇。"
 
 #. [message]: id=$|unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:382
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:378
 msgid "They’re here!"
 msgstr "他们在这里！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:441
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:689
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:706
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:723
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:740
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:437
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:685
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:702
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:719
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:736
 msgid "No outlaws in this village."
 msgstr "此村庄里没有流寇。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:470
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:466
 msgid "Alas! The northern outpost has been destroyed..."
 msgstr "唉！北疆哨所被摧毁了…"
 
 #. [message]: speaker=Dacyn
 #. Did you expect to find the northern outpost still standing?
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:476
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:472
 msgid ""
 "Did you expect anything else? Owaec has either fled or perished and the "
 "undead hordes now march toward the River Weldyn. They must seek to overrun "
@@ -2613,22 +2485,22 @@ msgstr ""
 "发。他们必须在国王集结军队之前攻占韦诺。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:487
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:483
 msgid "Raraery"
 msgstr "拉雷利"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:505
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:501
 msgid "Raetharvan"
 msgstr "雷萨尔万"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:521
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:517
 msgid "Hail, Gweddry!"
 msgstr "向您致意，格威德利！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:525
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:521
 msgid ""
 "Hail, Owaec! I am stunned and relieved to see that you are still well. How "
 "did you escape the undead?"
@@ -2637,7 +2509,7 @@ msgstr ""
 "的？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:529
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:525
 msgid ""
 "Many of these farmers dug deep cellars connected to a network of caves. I "
 "hid as many villagers as I could once our scouts spotted the undead. They "
@@ -2648,14 +2520,14 @@ msgstr ""
 "多地把村民藏起来。他们一定以为这些村庄已被遗弃，因为他们迅速向西移动，然而……"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:533
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:529
 msgid ""
 "... I was not able to save everyone. Gweddry, their deaths weigh heavy on my "
 "heart."
 msgstr "…我无法拯救所有人。格威德利，他们的死让我心如刀绞。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:537
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:533
 msgid ""
 "I am surprised you managed to save even yourself, much less anyone else. But "
 "compared to the havoc these undead seek to unleash on all Wesnoth, the "
@@ -2665,12 +2537,12 @@ msgstr ""
 "释放的破坏力相比，几个农民的死几乎不值得哀悼。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:541
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:537
 msgid "How can you say-"
 msgstr "你怎么可以说—"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:545
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:541
 msgid ""
 "For now, I must study and consider how these undead can be defeated, and "
 "then we should leave before more arrive. Will you join us?"
@@ -2679,7 +2551,7 @@ msgstr ""
 "们愿意加入我们吗？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:553
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:549
 msgid ""
 "No. I failed these villagers once. I will not do so again. They have "
 "survived the undead, but a gang of bandits exploits our weakness and now "
@@ -2691,7 +2563,7 @@ msgstr ""
 "遣骑兵进入村庄，他们就会躲进地窖里。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:557
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:553
 msgid ""
 "I fear that until the undead are defeated, these villagers will never be "
 "truly safe. But if we can drive these bandits out, will you join us? From "
@@ -2702,14 +2574,14 @@ msgstr ""
 "你会加入我们吗？达辛告诉我，韦诺需要所有的士兵才能生存下来。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:561
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:557
 msgid ""
 "If the situation is so dire, I am honor-bound to join you... but I know of "
 "no way to remove these bandits."
 msgstr "如果情况如此糟糕，我很荣幸能加入你们……但我不知道如何清除这些强盗。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:565
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:561
 msgid ""
 "You forget that I have many skills as the advisor to the Crown. I can reveal "
 "the bandits when our soldiers enter a village. However, this magic will "
@@ -2719,7 +2591,7 @@ msgstr ""
 "来。但是，我需要全神贯注在这魔法之上，我将无法在战斗中助拳。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:575
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:571
 msgid ""
 "Naw, wizard, you go help fight. We don’t need no fancy magic for this. I’ve "
 "dealt with plenty o’ thugs before. Maybe if you <i>untie me</i> I’ll help "
@@ -2729,7 +2601,7 @@ msgstr ""
 "如果你能<i>解开我的束缚</i>，我会帮你找到他们，怎么样？"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:579
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:575
 msgid ""
 "Do you promise you won’t simply flee if we set you free? This is a battle "
 "for all of Wesnoth. If we fail, it will spell doom not just for us, but also "
@@ -2739,59 +2611,59 @@ msgstr ""
 "我们，对你和你那小队雇佣兵也是灭顶之灾。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:583
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:579
 msgid ""
 "Eh, there’s always a necromancer or warlord o’ some kind one way or another. "
 "Me and my boys woulda been fine."
 msgstr "呃，总是有死灵法师或者某种类型的军阀。我和我的伙伴们本来没问题。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:587
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:583
 msgid ""
 "But yeah, sure, I ain’t runnin’. Just sayin’, as soon as this invasion "
 "business is done, I’m outta here."
 msgstr "但是，当然，我不会逃跑的。就这样说吧，等这场入侵结束，我就离开这里。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:591
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:587
 msgid ""
 "Very well, untie him! Owaec, we will aid you in driving out these bandits."
 msgstr "非常好，解开他的绳子！欧瓦埃克，我们将帮助您驱逐这些强盗。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:609
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:605
 msgid ""
 "Very well. Owaec, we will aid you in driving out these bandits. Dacyn, cast "
 "your spell!"
 msgstr "很好。欧瓦埃克，我们会帮助你驱逐这些强盗。达辛，施展魔咒吧！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:660
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:656
 msgid "(You may now recruit Horsemen and Cavalrymen!)"
 msgstr "（你现在可以征募骑师和骑兵了！）"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:693
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:689
 msgid "Pull aside that old rug, will ya? I think I see somethin’..."
 msgstr "拉开那块旧地毯，行吗？我觉得我看到了点东西……"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:710
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:706
 msgid "Check under the floorboards! There’s always somethin’ there."
 msgstr "检查地板下！那里总有什么东西。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:727
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:723
 msgid "Shh! Do ya hear that?"
 msgstr "嘘！你听到了吗？"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:744
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:740
 msgid "Lemme take a closer look..."
 msgstr "让我仔细看看…"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:767
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:763
 msgid ""
 "Every outlaw posse got a leader. Tear up enough cellars and he’ll turn up, "
 "then take him out and the rest’ll run for the hills."
@@ -2801,39 +2673,39 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. They retreated when their leader was captured in the previous scenario, which was "many days of mountainous travel" ago.
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:772
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:768
 msgid "Like your mercenary band did?"
 msgstr "就像你的雇佣军那样吗？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:779
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:775
 msgid ""
 "I believe there is a leader behind these outlaws. Kill him and we will face "
 "no further resistance."
 msgstr "我相信这些亡命徒背后有个首领。只要干掉他，就不会再有人阻碍我们。"
 
 #. [unit]: type=Rogue, id=Shodrano
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:798
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:794
 msgid "Shodrano"
 msgstr "朔德拉诺"
 
 #. [message]: speaker=Shodrano
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:808
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:804
 msgid "Gah, I’ve been found!"
 msgstr "哎呀，我被发现了！"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:812
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:808
 msgid "That’s the bandit leader! Kill him!"
 msgstr "那就是强盗首领！干掉他！"
 
 #. [message]: speaker=Shodrano
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:826
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:822
 msgid "This is how it ends..."
 msgstr "这就是结局……"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:848
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:844
 msgid ""
 "Huzzah!! At last, these villagers are liberated! Gweddry, thank you for your "
 "aid. I place my Clansmen and myself at your service."
@@ -2842,7 +2714,7 @@ msgstr ""
 "己都为你服务。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:863
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:859
 msgid ""
 "There is no more need for me to concentrate on this spell. However, we still "
 "need to deal with the adept."
@@ -2851,7 +2723,7 @@ msgstr "不需要我再专注于这个法术。然而，我们仍然需要对付
 #. [message]: speaker=Rilaka
 #. a male Dark Adept has just arrived, there's been an animation of him creating a camp, but he hasn't recruited yet
 #. his recruit list will be entirely L0 and L1 undead, no living units
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:952
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:948
 msgid ""
 "Ah ha! I knew this outpost wasn’t really abandoned! Too bad nobody else "
 "believed me. Maybe once I defeat you I’ll finally get the respect I deserve?"
@@ -2860,24 +2732,24 @@ msgstr ""
 "后，我就能得到应得的尊重了？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:956
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:952
 msgid "Defeat us, hmm? I have a better idea."
 msgstr "打败我们，嗯？我有个更好的主意。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:960
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:956
 msgid ""
 "Once again, undead threaten these villagers! In the name of the Clans, I "
 "will strike you down!"
 msgstr "再一次，亡灵威胁着这些村民！我以氏族的名义，必将击垮你们！"
 
 #. [message]: speaker=Rilaka
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:975
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:971
 msgid "No! I deserve better than this!"
 msgstr "不！我应得的比这更好！"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:995
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:991
 msgid ""
 "Huzzah!! May these be the first of many undead to fall before our hooves! "
 "Gweddry, thank you for your aid. I place my Clansmen and myself at your "
@@ -2887,31 +2759,31 @@ msgstr ""
 "的氏族和我自己都为你服务。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1002
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:998
 msgid "Now let us free these villagers from the outlaws terrorizing them!"
 msgstr "现在让我们解放这些被强盗恐吓的村民吧！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1055
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1051
 msgid ""
 "Now that both the outlaws and undead are defeated, we finally have some time "
 "to rest."
 msgstr "好啦，强盗和亡灵都被击败了，我们终于有一些时间休息了。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1059
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1055
 msgid ""
 "Good. Now leave me in peace while I consider how to combat this invasion."
 msgstr "好的。现在让我安静一会儿，思考如何应对这次入侵。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1076
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1072
 msgid "Some time later..."
 msgstr "过了一会儿……"
 
 #. [message]: speaker=Owaec
 #. to Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1095
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1091
 msgid ""
 "Mage, pull your nose out of your books for a moment, would you? Gweddry and "
 "I have some questions about this invasion you speak of."
@@ -2920,7 +2792,7 @@ msgstr ""
 "些疑问。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1102
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1098
 msgid ""
 "Back at the undead capital, the lich Mal-Ravanal referred to you as an old "
 "friend. What history is there between you?"
@@ -2928,7 +2800,7 @@ msgstr ""
 "此前在亡灵之都的时候，巫妖玛尔-拉瓦纳尔把你称为老朋友。你们之间有什么历史？"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1109
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1105
 msgid ""
 "What do you know of the dread lich they called Mal-Ravanal? Back at the "
 "southern outpost, you purposely hid yourself to avoid being seen."
@@ -2938,17 +2810,19 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. "you" being Owaec and Gweddry, they're both questioning him
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1126
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1122
 msgid ""
 "I suppose you have a right to know of the adversary we face. Mal-Ravanal "
 "was, at first, a mage of the realm like me. His fall began during the reign "
 "of our previous king, Haldric VII..."
 msgstr ""
+"我想你们有权知道我们所面对的敌人。玛尔-拉瓦纳尔起初和我一样，是王国的一名法"
+"师。他的堕落始于我们先王哈德里克七世在位期间……"
 
 #. [message]: speaker=Dacyn
 #. this is the same Eryssa from Northern Rebirth, now old
 #. Northern Rebirth happened in 535 YW, while the event being spoken about here happened in 589 YW (it's now 626 YW)
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1133
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1129
 msgid ""
 "The greatest seer in the land, an elderly Sylph named Eryssa, came to Weldyn "
 "and spoke of the emergence of a power that threatened to corrupt Wesnoth’s "
@@ -2964,7 +2838,7 @@ msgstr ""
 #. Ravan is also of an unspecified gender, and not assumed to be only human
 #. Same as Mal-Ravanal, translations can prefer plural pronouns or language default pronoun if the former is not possible
 #. Happened in 589 YW, it's now 626 YW.
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1140
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1136
 msgid ""
 "The King endeavoured to seek this peerless savant. In all the land, there "
 "were two magi that clearly stood out from the rest. Myself, and my good "
@@ -2979,7 +2853,7 @@ msgstr ""
 "当他走出来时，便宣布先知已经去世，并且她…选择了…我作为国王的新顾问。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1144
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1140
 msgid ""
 "Ravan took this quietly enough, or so I had thought, but it must have been "
 "more of a blow than I had realized. We drifted apart for a long while, and "
@@ -2990,7 +2864,7 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. Happened in 593 YW, it's now 626 YW. The Listra is a river.
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1154
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1150
 msgid ""
 "One day, I received a message. Ravan was calling me north across the Great "
 "River and past the Listra, to an ancient sanctuary that we had once explored "
@@ -3005,7 +2879,7 @@ msgstr ""
 "到了圣殿及其隐藏的密室。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1158
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1154
 msgid ""
 "Even now, that dreadful scene is burned into my memory. At a mere glance, I "
 "could already sense the taint of black magic on that cloaked form. Ravan’s "
@@ -3023,7 +2897,7 @@ msgstr ""
 "事情来消灭这个邪恶势力。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1162
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1158
 msgid ""
 "Before the incantation could finish, I summoned the utmost of my power and "
 "rended Ravan’s physical body. Yet even as I witnessed flesh and blood burn "
@@ -3039,14 +2913,14 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. "it" means the spirit of Mal-Ravanal; the Sylph prophesied about it sometime between 36 and 42 years ago.
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1176
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1172
 msgid ""
 "As it has now, to finally fulfill the prophecy that the Sylph spoke of all "
 "those years ago."
 msgstr "就像它现在这样，终于要实现当年那个风仙子所说的预言了。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1180
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1176
 msgid ""
 "Yes. But hope is not yet lost. After pondering the matter once more, I have "
 "come to a conclusion. I do not have the power to defeat Mal-Ravanal as I am "
@@ -3057,14 +2931,14 @@ msgstr ""
 "拉瓦纳尔。我们必须向北旅行，离开韦诺，回到我曾击败莱文的那座圣殿。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1184
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1180
 msgid ""
 "And leave our countrymen to fend for themselves in a time of war? This does "
 "not sit right with me."
 msgstr "然后让我们的同胞在战争时期自生自灭？这让我感到很不舒服。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1188
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1184
 msgid ""
 "If we fail to defeat Mal-Ravanal, no effort of ours will be sufficient to "
 "withstand the endless armies of the dead. Our blood is limited and the more "
@@ -3076,14 +2950,14 @@ msgstr ""
 "个巫妖，我们才能找到救赎。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1192
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1188
 msgid ""
 "Far though this journey may take us, if it is necessary to defeating this "
 "great evil, we have no choice but to make it."
 msgstr "纵然这次旅行路途遥远，若为了战胜这股巨大邪恶，我们别无选择，只能前行。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1201
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1197
 msgid ""
 "Very well. The Great River can be crossed near Soradoc. We could reach the "
 "garrison there, contact the Crown, and gather supplies for our journey."
@@ -3092,7 +2966,7 @@ msgstr ""
 "为我们的旅程收集补给。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1205
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1201
 msgid ""
 "The entire undead army is between us and Soradoc. They even may have already "
 "taken the city itself. We should avoid that battle and cross the Great River "
@@ -3102,7 +2976,7 @@ msgstr ""
 "该避免那场战斗，并继续向东越过泰河，到亡灵战线之后。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1209
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1205
 msgid ""
 "If undead are attacking Soradoc, that is all the more reason to travel west! "
 "I will not stand by and let my comrades die while I cravenly flee the battle."
@@ -3111,42 +2985,42 @@ msgstr ""
 "们在我胆怯地逃离战斗时死亡。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1213
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1209
 msgid ""
 "Peace, friends. You both speak wisely. Allow me to cast the deciding vote."
 msgstr "和平，朋友们。你们俩都说得很有道理。让我投下决定性的一票。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1217
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1213
 msgid "My decision is..."
 msgstr "我的决定是……"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1219
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1215
 msgid "Cross the Great River to the east, behind enemy lines. <i>(normal)</i>"
 msgstr "穿过泰河走向东方，越过敌军防线。<i>（普通）</i>"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1223
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1219
 msgid ""
 "We are not strong enough to fight the undead head-on. Let us cross the Great "
 "River to the east."
 msgstr "我们的实力不足以正面对抗亡灵。让我们穿过泰河到东方。"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1235
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1231
 msgid ""
 "Cross the Great River west in Wesnoth, near Soradoc. <i>(challenging)</i>"
 msgstr "穿越韦诺泰河西部，靠近索拉多克。<i>（挑战）</i>"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1239
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1235
 msgid ""
 "It is our duty to aid the king’s army at Soradoc and cross the river there."
 msgstr "我们有责任协助索拉多克的国王军队，并渡过那里的河流。"
 
 #. [message]: speaker=Rilaka
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1265
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1261
 msgid ""
 "I’m not so sure I can win this fight, but maybe I don’t need to defeat you "
 "myself to be respected... maybe I only need to tell the others to come "
@@ -3156,12 +3030,12 @@ msgstr ""
 "需要告诉其他人来消灭你就行了！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1271
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1267
 msgid "He’s run off to summon reinforcements! If only we had acted sooner..."
 msgstr "他跑去找增援了！如果我们早点行动就好了……"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1278
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1274
 msgid ""
 "Enough of this. We cannot afford to waste time with petty bandits while Mal-"
 "Ravanal ravages Wesnoth. Owaec, come with us or stay here and die, I care "
@@ -3171,7 +3045,7 @@ msgstr ""
 "欧瓦埃克，跟我们一起走，或者留在这里等死，我无所谓哪种方式。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1282
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1278
 msgid ""
 "Since we have failed to root out the bandit leader, I am honor-bound to stay "
 "and defend these villagers! If you wish to go, then go, but I shall not aid "
@@ -3181,7 +3055,7 @@ msgstr ""
 "不会帮助你们。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1286
+#: data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg:1282
 msgid "I would that I had acted with more haste..."
 msgstr "我希望我行动得更快……"
 
@@ -3202,51 +3076,51 @@ msgstr ""
 
 #. [side]: type=Necromancer, id=Mal-un-Karad
 #. male
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:48
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:45
 msgid "Mal-un-Karad"
 msgstr "玛尔-昂-卡拉德"
 
 #. [message]: speaker=Mal-un-Karad
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:91
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:88
 msgid ""
 "Fine, you can have the south shore! I’m going to stay nice and safe in my "
 "castle."
 msgstr "好的，你可以得到南岸！我将安全舒适地待在我的城堡里。"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:111
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:108
 #: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:68
 msgid "Monsters"
 msgstr "怪物"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:120
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:117
 msgid "Northern Alliance"
 msgstr "北方联盟"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:133
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:130
 msgid "Defeat Mal-un-Karad"
 msgstr "击败玛尔-昂-卡拉德"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:142
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:139
 msgid "Rescue Dolburras before he drowns"
 msgstr "在多尔布拉斯淹死前营救他"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:160
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:157
 msgid "Dolburras will take damage every turn until freed."
 msgstr "多尔布拉斯在被救出之前每回合会受到伤害。"
 
 #. [unit]: id=Dolburras, type=Dwarvish Steelclad
 #. male
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:177
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:174
 msgid "Dolburras"
 msgstr "多尔布拉斯"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:207
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:204
 msgid ""
 "We have done well to avoid conflict with the undead thus far. It is time to "
 "turn northward, toward our goal."
@@ -3254,13 +3128,13 @@ msgstr ""
 "我们到目前为止成功地避免了与亡灵的冲突。现在是时候向北，朝着我们的目标前进。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:211
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:593
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:208
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:591
 msgid "You still have yet to explain more about this goal."
 msgstr "你还是需要更多地解释这个目标。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:215
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:212
 msgid ""
 "Wait, look, a small force of undead have already fortified this ford. We "
 "will have to fight them to cross the Great River."
@@ -3271,21 +3145,21 @@ msgstr ""
 # Translated by ollama with model glm4
 #. [message]: speaker=Dolburras
 #. he's being held captive by a Banebow
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:220
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:217
 msgid ""
 "Let me out ’o this cage ye bag-o-bones! When the Alliance hears abo— "
 "<b>glug</b>"
 msgstr "让俺出这笼子你这个骨头袋子！当联盟听到——<b>咕噜</b>"
 
 #. [message]: speaker=Mal-un-Karad
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:227
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:224
 msgid ""
 "Hahahaha! This dwarf is too short to keep his head out of the water. I "
 "wonder how long he’ll last?"
 msgstr "哈哈哈！这个矮人太矮了，头都露不出水面。我不知道他能坚持多久？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:231
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:228
 msgid ""
 "The undead are torturing that dwarf for sport! This shall not stand; we must "
 "rescue him before he drowns!"
@@ -3293,8 +3167,8 @@ msgstr ""
 "亡灵正在以折磨那个矮人为乐！这样下去不行；我们必须在他溺死之前救他出来！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:236
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:307
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:233
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:304
 msgid ""
 "Ho ho, you know what you need? My patented* elixir of water breathing! <span "
 "color='#BCB088' size='x-small'><i>*not patented</i></span>"
@@ -3303,30 +3177,30 @@ msgstr ""
 "size='x-small'><i>*没有专利</i></span>"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:240
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:311
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:237
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:308
 msgid ""
 "One drink from this shimmering blue vial and you’ll move at full speed "
 "through swamps and shallow water!"
 msgstr "从这个闪亮的蓝色药瓶中喝一口，你将能以全速穿越沼泽和浅水区域！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:253
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:324
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:644
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:250
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:321
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:643
 msgid "Pleasure doing business with you!"
 msgstr "很高兴和你做生意！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:261
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:332
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:652
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:258
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:329
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:651
 msgid "Suit yourself; more for me!"
 msgstr "自便；给我多点！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:267
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:338
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:264
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:335
 msgid ""
 "Supplies are limited so <span strikethrough='true'>call now</span> buy now! "
 "<i>(elixirs only last for 1 scenario)</i>"
@@ -3335,21 +3209,21 @@ msgstr ""
 "在1个场景有效）</i>"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:269
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:340
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:660
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:266
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:337
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:659
 msgid "Buy the elixir (10 gold)."
 msgstr "购买药水（10金币）。"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:279
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:350
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:670
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:276
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:347
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:669
 msgid "Leave the elixir for Hahid."
 msgstr "留下药水给哈希德。"
 
 #. [message]: speaker=Mal-un-Karad
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:295
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:292
 msgid ""
 "I don’t know how you Wesnothians got here, but don’t even think about "
 "crossing here unless you want to become fish bait!"
@@ -3358,19 +3232,19 @@ msgstr ""
 
 #. [message]: speaker=Mal-un-Karad
 #. "Wake" doesn’t mean "raise undead" here. The reinforcements are sea creatures, they're alive but hidden underwater.
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:323
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:320
 msgid "Time to wake my reinforcements!"
 msgstr "是时候唤醒我的援军了！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:402
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:399
 msgid ""
 "In addition to summoning undead, this sorcerer has learned to command swarms "
 "of carnivorous fish!"
 msgstr "看上去，似乎除了召唤亡灵以外，这巫师也学会了如何召唤成群的肉食鱼！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:406
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:403
 msgid ""
 "A clever plan. The fish gnaw away flesh, leaving the skeletons ready for "
 "reanimation. They will make our crossing more difficult."
@@ -3378,35 +3252,35 @@ msgstr ""
 "一个聪明的计划。这些鱼把肉咬掉，留下骨架准备复活。这将使我们过河更加困难。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:445
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:442
 msgid "No! I thought I’d be safe here..."
 msgstr "不！我以为我在这里会安全……"
 
 #. [message]: speaker=Dolburras
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:491
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:488
 msgid "Glug... glug..."
 msgstr "咕噜…咕噜…"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:520
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:517
 msgid ""
 "I have failed in my duty to protect the helpless. I weep at his passing."
 msgstr "我未能履行保护无助者的职责。我对他的离世感到悲痛。"
 
 #. [message]: speaker=Dolburras
 #. "Many thanks to you! Feels go to be finally breathing properly again."
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:559
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:556
 msgid "Many thanks ta ye! Feels good ta be finally breathin’ proper again."
 msgstr "非常感谢！终于感觉呼吸正常了。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:563
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:560
 msgid "How did you come to be captured by these undead?"
 msgstr "你是如何被这些亡灵抓住的？"
 
 #. [message]: speaker=Dolburras
 #. "Ran into a whole blasted army of them marching from the Swamp of Dread. I think they're headed for Knalga! Someone ought to invade them for a change."
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:568
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:565
 msgid ""
 "Ran into a whole blasted army of ’em marchin’ from the Swamp o’ Dread. I "
 "think they be headed for Knalga! Someone oughta invade them for a change."
@@ -3415,12 +3289,12 @@ msgstr ""
 "略他们一次。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:572
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:569
 msgid "By the Clans! Do these undead mean to conquer all the world?"
 msgstr "以氏族之名！这些亡灵是否要征服整个世界？"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:576
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:573
 msgid ""
 "Dolburras, we are men of the King of Wesnoth, seeking the power to destroy "
 "these foul undead. Will you join us in our quest?"
@@ -3430,32 +3304,32 @@ msgstr ""
 
 #. [message]: speaker=Dolburras
 #. "Can't hardly go back to Knalga with all of the undead about! Yes, I'll join you."
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:581
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:578
 msgid ""
 "Kinna hardly go back ta Knalga with all them undead about! Aye, I’ll join ye."
 msgstr "有这么多亡灵在，俺不敢回纳尔迦了！好，俺要加入你们。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:607
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:604
 msgid ""
 "If we intend to save Wesnoth, we must press onward into the mountains. Let "
 "us be off."
 msgstr "如果我们打算拯救韦诺，我们必须向山脉进发。让我们出发吧。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:620
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:617
 msgid "Mel Wylyn"
 msgstr "梅尔·威林"
 
 #. [message]: speaker=Mal-un-Karad
 #. male Necromancer to female Dark Sorcerer
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:628
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:625
 msgid "What took you so long? We were supposed to change shifts days ago!"
 msgstr "你干嘛去了这么久？我们几天前就该换班了！"
 
 #. [message]: speaker=Mel Wylyn
 #. female Dark Sorcerer to male Necromancer
-#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:633
+#: data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg:630
 msgid ""
 "Aw, I’ve missed out on the fun! But look at it this way, now they stand no "
 "chance against the two of us."
@@ -3480,54 +3354,54 @@ msgstr ""
 "翼地接近，希望与韦诺的军队重新团聚。"
 
 #. [side]: type=Lancer, id=Yannic
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:60
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:58
 msgid "Yannic"
 msgstr "雅尼克"
 
 #. [side]: type=Dark Sorcerer, id=Mal-Mana, gender=female
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:303
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:301
 msgid "Mal-Mana"
 msgstr "玛尔-玛娜"
 
 #. [side]: type=Death Knight, id=Naken-alvak
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:377
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:375
 msgid "Naken-alvak"
 msgstr "纳肯-阿尔瓦克"
 
 #. [scenario]: id=06b_Soradoc
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:437
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:435
 msgid "West Barracks"
 msgstr "西部兵营"
 
 #. [scenario]: id=06b_Soradoc
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:438
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:436
 msgid "East Barracks"
 msgstr "东部兵营"
 
 #. [scenario]: id=06b_Soradoc
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:439
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:437
 msgid "Citadel"
 msgstr "要塞"
 
 #. [scenario]: id=06b_Soradoc
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:440
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:438
 msgid "Temple"
 msgstr "寺庙"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:489
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:487
 msgid "Move any unit to the northern path."
 msgstr "移动任意单位至北方的路径。"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:495
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:493
 msgid ""
 "Defeat as many enemy leaders as possible, and then move any unit to the "
 "northern path (easier next scenario)"
 msgstr "击败尽可能多的敌方首领，然后移动任意单位到北方的路径（更简单的下一幕）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:506
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:504
 msgid ""
 "Move Owaec next to Yannic, and then protect Yannic until you move any unit "
 "to the northern path (bonus item next scenario)"
@@ -3536,19 +3410,19 @@ msgstr ""
 "一场景奖励道具）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:520
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:518
 msgid ""
 "Protect Yannic until you move any unit to the northern path (bonus item next "
 "scenario)"
 msgstr "保护雅尼克直到你移动任何单位至北方的路径（下一场景奖励道具）"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:555
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:553
 msgid "The air is filled with smoke. I fear the town is already lost."
 msgstr "空气充满了浓烟。我担心这座小镇已经沦陷了。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:559
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:557
 msgid ""
 "Madness! How can the city have fallen? The garrison is stout-hearted and "
 "loyal to a fault. I know many of them personally! They would hold the city "
@@ -3558,7 +3432,7 @@ msgstr ""
 "很多人！他们一定会拼尽全力守卫这座城市直到生命的最后一息。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:563
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:561
 msgid ""
 "Were you expecting a victory parade? Soradoc will be the first of many if we "
 "cannot accomplish our goal."
@@ -3566,12 +3440,12 @@ msgstr ""
 "你期待着胜利的阅兵吗？如果我们无法完成目标，索拉多克将是众多城市中的第一个。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:567
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:565
 msgid "Wait, look, the flag of Wesnoth still flies over the western barracks!"
 msgstr "等等，看，韦诺的旗帜仍然飘扬在西部兵营之上！"
 
 #. [message]: speaker=Yannic
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:577
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:575
 msgid ""
 "Are you our reinforcements? Weldyn promised us aid days ago! The undead "
 "already control most of the city. We’re hiding our wounded in the temple, "
@@ -3581,7 +3455,7 @@ msgstr ""
 "分。我们把受伤的人藏在寺庙里，但如果再失去西区，我担心没有人能逃脱。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:581
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:579
 msgid ""
 "By the Clans, some of them yet live! We must move quickly if we are to "
 "rescue the garrison! If we can defeat this wave of undead, they may yet have "
@@ -3591,14 +3465,14 @@ msgstr ""
 "能击败这波亡灵，他们或许还有时间撤退。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:585
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:583
 msgid ""
 "I agree, but... there are many powerful undead besieging the city. Do we "
 "have the strength to defeat them all?"
 msgstr "我同意，但……有许多强大的亡灵围攻这座城市。我们是否有力量击败他们全部？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:589
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:587
 msgid ""
 "Maybe, maybe not. Remember that our true goal lies far to the north. Nothing "
 "we do here today will more than inconvenience Mal-Ravanal."
@@ -3607,7 +3481,7 @@ msgstr ""
 "拉瓦纳尔造成更多麻烦。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:597
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:595
 msgid ""
 "We should proceed north as quickly as we can. If we cannot save Soradoc, we "
 "can at least slip past the undead and escape, though they will certainly "
@@ -3617,12 +3491,12 @@ msgstr ""
 "会跟踪我们。"
 
 #. [message]: speaker=Naken-alvak
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:606
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:604
 msgid "Intruders... living men... from the southeast..."
 msgstr "入侵者…活人…来自东南方向…"
 
 #. [message]: speaker=Mal-Talar
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:613
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:611
 msgid ""
 "Ah, it’s the garrison that escaped me back at that border outpost. They "
 "won’t get lucky again this time!"
@@ -3630,12 +3504,12 @@ msgstr "啊，那就是在边境哨所逃走的驻军。他们这次不会再走
 
 #. [message]: speaker=Mal-Mana
 #. Mal-Mana dispatches a bat messenger to say she's spotted Dacyn.
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:621
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:619
 msgid "And see who is among them! I shall inform Mal-Ravanal at once."
 msgstr "并且看看到他们中有谁！我要立即通知玛尔-拉瓦纳尔。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:673
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:671
 msgid ""
 "Dacyn, is that you again? So this is where you ran off to. I would recognize "
 "your nauseating aura anywhere."
@@ -3644,7 +3518,7 @@ msgstr ""
 "息。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:677
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:675
 msgid ""
 "I should put you out of your misery right now, but then again, I wanted you "
 "to see the results of all my long years of research. I guess it can wait a "
@@ -3654,7 +3528,7 @@ msgstr ""
 "再等一等。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:701
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:699
 msgid ""
 "Well then, I know you’ll miss me, so here’s a little going-away present for "
 "you and your friends."
@@ -3662,32 +3536,34 @@ msgstr "那么，我知道你会想我，所以给你和你的朋友们一个小
 
 #. [message]: speaker=Gweddry
 #. there were originally 4 of them, and 3 are now defeated
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:764
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:762
 msgid ""
 "That’s almost all the undead leaders defeated! If time remains, we should "
 "introduce Owaec to the city garrison before we continue north."
 msgstr ""
+"亡灵首领差不多都被击败了！如果时间还来得及，我们应该在继续北上之前，把奥瓦克"
+"引荐给城防驻军。"
 
 #. [message]: speaker=Gweddry
 #. there were originally 4 of them, and 3 are now defeated
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:773
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:771
 msgid "That’s almost all the undead leaders defeated!"
 msgstr "那是差不多所有被击败的亡灵首领了！"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:783
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:781
 msgid ""
 "Who commands this garrison? Time is short. We must evacuate what’s left of "
 "your men before—"
 msgstr "谁指挥这个驻军？时间紧迫。我们必须疏散你们剩下的人——"
 
 #. [message]: speaker=Yannic
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:787
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:785
 msgid "Owaec? Is that you?"
 msgstr "欧瓦埃克？是你吗？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:791
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:789
 msgid ""
 "Yannic?! Well met friend, I haven’t seen you in years!! Ha, you never could "
 "stay out of trouble! How’s your horse, Clansman?"
@@ -3696,14 +3572,14 @@ msgstr ""
 "么样了？"
 
 #. [message]: speaker=Yannic
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:795
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:793
 msgid ""
 "Injured, along with those few of my men lucky enough to yet live. I am more "
 "than grateful for your timely arrival and help."
 msgstr "受伤了，连同那些仍然活着的少数同伴。我很感激你们及时到来并提供帮助。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:799
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:797
 msgid ""
 "Speaking of help, we require yours. I, the King’s High Advisor, seek a "
 "powerful magic east of the Listra to destroy these undead. We will require "
@@ -3713,7 +3589,7 @@ msgstr ""
 "来摧毁这些亡灵。为了这个旅途，我们需要的你们的士兵和物资。"
 
 #. [message]: speaker=Yannic
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:803
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:801
 msgid ""
 "... I would gladly offer all for the friend of a fellow Clansman, but as you "
 "can see, myself and what remains of my garrison are in little condition to "
@@ -3725,12 +3601,12 @@ msgstr ""
 "里。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:807
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:805
 msgid "Acceptable."
 msgstr "可以。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:811
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:809
 msgid ""
 "Bah, we come to aid you, not to seek <i>your</i> aid! We shall do our utmost "
 "to ensure you and your men survive this dark time."
@@ -3739,18 +3615,18 @@ msgstr ""
 "你的部下在这黑暗时期生存下来。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:842
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:840
 msgid ""
 "I’ve broken through the undead lines. Follow me before we are overwhelmed!"
 msgstr "我已经突破亡灵防线。在我们被亡灵淹没之前，跟我走！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:843
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:841
 msgid "The northern path is clear! Follow me, let us cross the Great River."
 msgstr "北方路径打通了！跟我走，我们一起渡过泰河。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:870
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:868
 msgid ""
 "We have failed to defeat even a single enemy leader! It galls me to flee, "
 "but this is a battle we cannot win."
@@ -3759,7 +3635,7 @@ msgstr ""
 "斗。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:871
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:869
 msgid ""
 "We have failed to defeat more than a single enemy leader! It galls me to "
 "flee, but this is a battle we cannot win."
@@ -3768,7 +3644,7 @@ msgstr ""
 "斗。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:872
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:870
 msgid ""
 "We have weakened the undead here, yet we cannot hope to defeat them all! It "
 "galls me to flee, but this is a battle we cannot win."
@@ -3777,14 +3653,14 @@ msgstr ""
 "们无法取胜的战斗。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:875
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:873
 msgid ""
 "We have done well to defeat the undead here. Their forces will be unable to "
 "pursue us; we shall have an uneventful river crossing."
 msgstr "我们在这里击败了亡灵。他们的军队无法追击我们；我们将平稳地渡河。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:876
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:874
 msgid ""
 "We have done well to defeat the undead here. They may still pursue as we "
 "cross the river, but far fewer than would otherwise have come."
@@ -3792,7 +3668,7 @@ msgstr ""
 "我们在这里击败了亡灵。他们可能会在我们渡河时追击，但比原本会来的少得多。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:877
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:875
 msgid ""
 "It galls me to flee before vanquishing the final undead leader, but enemy "
 "reinforcements will doubtlessly soon arrive."
@@ -3801,7 +3677,7 @@ msgstr ""
 "来。"
 
 #. [message]: speaker=Yannic
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:893
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:891
 msgid ""
 "Farewell, and good luck! You have bought us enough time to evacuate, and for "
 "that I will be ever grateful! May our paths cross again someday."
@@ -3810,59 +3686,59 @@ msgstr ""
 "天能再次相遇。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:897
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:895
 msgid "Farewell friend! May you find fairer fields unfouled by undead."
 msgstr "再见朋友！愿你找到更美好的不受亡灵污染的土地。"
 
 #. [message]: speaker=Yannic
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:911
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:909
 msgid "No, wait, you can’t just leave us here!"
 msgstr "不，等等，你们不能就这样把我留在这里！"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:915
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:913
 msgid ""
 "We flee?! My Clan would banish me for half as much cowardice! I am ashamed "
 "to call myself a Clansman."
 msgstr "我们逃跑？！氏族会因为我一半的懦弱而驱逐我！我真羞于自称是氏族人。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:924
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:922
 msgid ""
 "But alas, the garrison is slain. If only we had acted more swiftly, they "
 "might still have been saved."
 msgstr "然而，驻军已被歼灭。如果当时我们行动更迅速些，他们或许仍能得救。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:933
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:931
 msgid ""
 "With all enemy leaders still alive, we are sure to be destroyed when we "
 "attempt to cross the river..."
 msgstr "所有敌方首领都还活着，我们尝试过河时肯定会被毁灭……"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:935
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:933
 msgid ""
 "With three enemy leaders still alive, we are sure to be destroyed when we "
 "attempt to cross the river..."
 msgstr "三位敌方首领还活着，我们尝试过河时肯定会被毁灭……"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:937
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:935
 msgid ""
 "Several undead leaders yet remain, and they are sure to attack us while we "
 "attempt to cross the river."
 msgstr "几名亡灵首领还在，他们一定会趁我们过河时发动攻击。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:980
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:978
 msgid ""
 "We must not tarry here too long. Mal-Ravanal is fickle and may return to "
 "vanquish us all."
 msgstr "我们不得在此逗留太久。玛尔-拉瓦纳尔善变，可能回来击败我们所有人。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:994
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:992
 msgid ""
 "Look who’s still here! Dacyn, I thought you were wiser than this. I’ve "
 "changed my mind about letting you live. You know what they say, there’s no "
@@ -3872,7 +3748,7 @@ msgstr ""
 "说，机不可失时不再来！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:998
+#: data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg:996
 msgid "We have tarried here too long. All is now lost!"
 msgstr "我们在此逗留太久。现在一切已失！"
 
@@ -3883,54 +3759,54 @@ msgstr "捕捉食人魔"
 
 #. [side]
 #. [side]: type=Ogre, id=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:44
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:48
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:310
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:41
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:45
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:309
 msgid "Ogres"
 msgstr "食人魔"
 
 #. [message]: race=ogre
 #. The ogre is trying to escape, but Gweddry's units keep forcing him to change directions.
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:66
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:63
 msgid "Gah! Raa! Get out of my way!!"
-msgstr ""
+msgstr "嘎！啊！给我滚开！！"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:160
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:157
 msgid "(captured ogres will be made available for recall)"
 msgstr "（所捕捉的食人魔将可供召回）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:160
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:157
 msgid "Capture as many ogres as you can"
 msgstr "尽可能多地捕捉食人魔"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:170
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:167
 msgid ""
 "An ogre is captured when it starts a turn being unable to move more than one "
 "hex."
 msgstr "如果一只食人魔在它的回合内无法移动多于一格的距离，则会被捕捉。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:173
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:170
 msgid "If an ogre reaches the edge of the map, it will escape."
 msgstr "如果一只食人魔移动到了地图边缘，则它会逃脱。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:191
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:188
 msgid ""
 "Look, this valley is inhabited by a tribe of ogres. They do not seem very "
 "bright..."
 msgstr "看，这峡谷里住着一个食人魔部落。他们看起来不是很有活力……"
 
 #. [message]: race=ogre
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:195
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:192
 msgid "Guh... human? Human come! Run!"
 msgstr "嗝……人类？人类来啦！快跑！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:199
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:196
 msgid ""
 "Excellent, a source of slaves. If we surround and capture them, we can use "
 "them for risky missions and preserve our more valuable soldiers."
@@ -3939,7 +3815,7 @@ msgstr ""
 "护我们更宝贵的士兵。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:203
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:200
 msgid ""
 "Slaves?! No, these shall be great warriors fighting alongside us! My "
 "Clansmen shall capture them one by one."
@@ -3947,55 +3823,55 @@ msgstr ""
 "奴隶？！不，他们将成为与我们并肩作战的伟大战士！我的族人要逐个捕捉他们。"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:221
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:218
 msgid "Waah! Run!"
 msgstr "哇啊啊啊！快跑！"
 
 #. [value]
 #. ogres have intentionally bad grammar
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:225
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:222
 msgid "Me run life for!"
 msgstr "我跑命！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:228
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:225
 msgid "Ruuuunnnn!"
 msgstr "跑！！！！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:250
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:247
 msgid "We have let one escape. Let’s hope not all of them do!"
 msgstr "我们已经让一只食人魔跑掉了。但愿他们别都跑了！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:298
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:295
 msgid "$ogre_name surrender!"
 msgstr "$ogre_name|投降了！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:301
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:298
 msgid "Don’t hurt $ogre_name|!"
 msgstr "不要伤害$ogre_name|！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:304
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:301
 msgid "$ogre_name be good will! Promise!"
 msgstr "$ogre_name|会乖乖的！保证！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:367
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:364
 msgid ""
 "Taking slaves doesn’t feel right, even if it is for a good cause. I refuse "
 "to capture any of these ogres."
 msgstr "抓奴隶让我感到不对劲，即使是有好的理由。我拒绝捕捉这些食人魔。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:378
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:375
 msgid "Taking slaves just doesn’t feel right. I only captured one."
 msgstr "抓奴隶就是让我感到不对劲。我只抓了一个。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:382
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:379
 msgid ""
 "Unfortunate, but at least we have one. Ogres are unskilled fighters but much "
 "cheaper to equip than our other soldiers, and thus <i><b>cost much less gold "
@@ -4005,12 +3881,12 @@ msgstr ""
 "便宜得多，因此<i><b>召回所需金币少得多。</b></i>"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:389
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:386
 msgid "We failed to capture more than two of the ogres."
 msgstr "我们没能抓到超过两只食人魔。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:393
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:390
 msgid ""
 "Unfortunate, but at least we have some. Ogres are unskilled fighters but "
 "much cheaper to equip than our other soldiers, and thus <i><b>cost much less "
@@ -4020,13 +3896,13 @@ msgstr ""
 "便宜得多，因此<i><b>召回所需金币少得多。</b></i>"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:400
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:397
 msgid "We captured three ogres! I hope they will prove useful."
 msgstr "我们抓到了三只食人魔！但愿它们能有点用。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:404
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:414
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:401
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:411
 msgid ""
 "Well done. Ogres are unskilled fighters but much cheaper to equip than our "
 "other soldiers, and thus <i><b>cost much less gold to recall.</b></i>"
@@ -4035,7 +3911,7 @@ msgstr ""
 "召回所需金币少得多。</b></i>"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:410
+#: data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg:407
 msgid ""
 "We managed to capture many ogres! They will make a good addition to our "
 "troops."
@@ -4048,63 +3924,55 @@ msgstr "食人魔渡口"
 
 #. [part]
 #: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:17
-#, fuzzy
-#| msgid ""
-#| "The Ford of Parthyn is second only to Abez in its notoriety. It was here "
-#| "where Iliah-Malal’s ghostly army first wrought its terror, only to be "
-#| "routed by the legendary Delfador. It was here where Malin Keshar cast "
-#| "aside his humanity and began delving into the dark arts. And it was here "
-#| "where Gweddry and his men attempted their escape from Wesnoth and Mal-"
-#| "Ravanal’s undead hordes into the wild northlands."
 msgid ""
 "As the best river crossing for miles in either direction, and the site of "
 "many an old orc-raid, the Ford of Parthyn is second only to Abez in its "
 "notoriety. It is here where Gweddry and his men attempted their escape from "
 "Wesnoth and Mal-Ravanal’s undead hordes into the wild north."
 msgstr ""
-"帕辛滩的恶名仅次于雅碧滩。这是伊利阿-玛拉尔的幽灵军队首次制造恐怖，结果被传奇"
-"的德法多击败的地方。这是马林·凯沙丢弃了人性，开始钻研黑暗艺术的地方。而这也是"
-"格威德利和他的人试图逃离韦诺和玛尔-拉瓦纳尔的亡灵军团，进入荒野北陆的地方。"
+"作为上下游数里内最佳的渡河点，也是旧时多次兽人劫掠的发生地，帕辛浅滩的恶名仅"
+"次于雅碧。正是在这里，格威德利和他的部下试图逃离韦诺与玛尔-拉瓦纳尔的亡灵大"
+"军，逃往蛮荒的北方。"
 
 #. [side]: type=Ogre, id=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:40
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:37
 msgid "Grug"
 msgstr "格拉格"
 
 #. [side]: type=Saurian Ambusher, id=Izziasch
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:100
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:97
 msgid "Izziasch"
 msgstr "伊兹亚赫"
 
 #. [side]: type=Saurian Ambusher, id=Izziasch
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:109
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:106
 msgid "Saurians"
 msgstr "蜥蜴人"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:186
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:472
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:183
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:479
 msgid "Parthyn Guardpost"
 msgstr "帕辛哨所"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:193
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:190
 msgid "Defeat Izziasch"
 msgstr "击败伊兹亚赫"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:197
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:194
 msgid "Reach the north shore before Grug dies"
 msgstr "在格拉格死亡之前到达北岸"
 
 #. [note]
 #. "any human" specifically excludes undead, who don't count. It's not possible for the player to control dwarves, merfolk, etc at this point in the campaign.
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:213
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:210
 msgid "The ogres will join you once any human reaches the north shore."
-msgstr ""
+msgstr "一旦有任何人抵达北岸，食人魔就会加入你们。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:259
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:256
 msgid ""
 "And so we come to the Great River, northern border of Wesnoth. It will take "
 "some time for our men to cross; the undead will doubtless send their forces "
@@ -4115,7 +3983,7 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. the player killed all four undead leaders during S06b
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:267
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:264
 msgid ""
 "And so we come to the Great River, northern border of Wesnoth. It will take "
 "some time for our men to cross, but fortunately we are not being pursued."
@@ -4125,14 +3993,14 @@ msgstr ""
 
 #. [message]: speaker=Owaec
 #. This is the first time the protagonists have seen ogres; the routes through the campaign go through exactly one of S07a or S07b.
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:281
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:278
 msgid ""
 "Lo, on yonder shore lies a camp of ogres! I’ve heard them to be dimwitted, "
 "but friendly enough."
 msgstr "瞧，那边岸边有个食人魔营地！听说它们有点笨，但足够友好。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:286
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:283
 msgid ""
 "<span size='small'><i>Not unlike yourself?</i></span> Ogres have served the "
 "Crown in the past. Perhaps these ones can help us, either willingly or as "
@@ -4142,24 +4010,24 @@ msgstr ""
 "可以帮助我们，或者自愿或者作为奴隶。但在此之前，那些蜥蜴人肯定会攻击。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:290
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:287
 msgid "Lizard, Grug say leave!"
 msgstr "蜥蜴，格拉格叫你离开！"
 
 #. [message]: speaker=Izziasch
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:294
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:291
 msgid ""
 "Get out of my way! There are ssskeletons in my ssswamp... we’re leaving and "
 "you sshould too."
 msgstr "让开！我的沼泽里有骷髅嘶嘶……我们要走了，你们也应该走了嘶嘶。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:298
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:295
 msgid "Lizard dumb! You die now!"
 msgstr "蜥蜴蠢货！你完蛋了！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:302
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:299
 msgid ""
 "If we can reach the ogres in time, we may be able to convince them to aid "
 "us. But first we need to cross the river."
@@ -4168,7 +4036,7 @@ msgstr ""
 
 #. [event]
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:378
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:375
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:1177
 msgid "Tarek"
 msgstr "塔里克"
@@ -4177,7 +4045,7 @@ msgstr "塔里克"
 #. It’s a plague staff, giving both a plague attack and the ability to recruit animal walking corpses, but not human walking corpses.
 #. The pronoun "we" here is exclusive, meaning "we, not including you".
 #. The speaker is a horseman, a unit type that’s always male.
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:395
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:392
 msgid ""
 "Hail, Owaec and company! We retreat from Soradoc, but Yannic sent me to "
 "bring a prize we took from one of the necromancers we slew during our "
@@ -4189,7 +4057,7 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. About the plague staff.
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:400
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:397
 msgid ""
 "Fascinating... I’ve never had the chance to examine one of these up close "
 "before."
@@ -4197,7 +4065,7 @@ msgstr "迷人……我以前从没有机会近距离观察过这种东西。"
 
 #. [message]: speaker=Owaec
 #. Speaking to Tarek, a male horseman, about the plague staff.
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:405
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:402
 msgid ""
 "Our thanks! You are a fair rider, yet you bring a foul boon. I will not "
 "wield such a dark artifact, though I shall not begrudge its use by my "
@@ -4207,7 +4075,7 @@ msgstr ""
 "暗神器，尽管我也不嫉妒我的同伴们使用它。"
 
 #. [message]: speaker=ghast_leader
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:462
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:459
 msgid "Gruhhhh...."
 msgstr "咕啊啊啊……"
 
@@ -4216,7 +4084,7 @@ msgstr "咕啊啊啊……"
 #. Because of renaming fallbacks, this line must fit both:
 #. "Mal-Talar stayed outside the tunnel entrance", and
 #. "Mal-Talar was the main pursuer in S02".
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:506
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:503
 msgid ""
 "You won’t escape me again! This time there are no tunnels for you to hide in!"
 msgstr "你再也不会从我手中逃脱了！这次没有隧道给你藏身了！"
@@ -4224,12 +4092,12 @@ msgstr "你再也不会从我手中逃脱了！这次没有隧道给你藏身了
 #. [message]: speaker=Mal-Talar
 #. Name visible to the player is "Mal-Bakral", because Mal-Talar died in S01
 #. The line must fit even if the pursuer in S02 was also renamed "Mal-Bakral"
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:515
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:512
 msgid "There is no escape from me!"
 msgstr "不会有从我手中逃脱的机会了！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:541
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:538
 msgid ""
 "The first of our pursuers have arrived! We must make haste to cross before "
 "more dangerous undead arrive."
@@ -4237,7 +4105,7 @@ msgstr ""
 "第一波我们的追击者已经到达！在更多危险的亡灵到来之前，我们必须赶紧过河。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:548
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:545
 msgid ""
 "Our undead pursuers have arrived! Fortunately, their other leaders have been "
 "defeated. This is all we will have to face."
@@ -4246,68 +4114,68 @@ msgstr ""
 "面对的。"
 
 #. [message]: speaker=Naken-alvak
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:628
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:625
 msgid "Found you... Bleed you..."
 msgstr "找到你……吸干你……"
 
 #. [message]: speaker=Mal-Mana
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:708
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:705
 msgid "Don’t think you can get away so easily!"
 msgstr "别以为能那么容易逃走！"
 
 #. [message]
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:746
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:743
 msgid "Run away!"
-msgstr ""
+msgstr "快跑！"
 
 #. [message]: speaker=Izziasch
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:754
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:751
 msgid "Now to deal with these humansss!"
 msgstr "现在对付这些人类嘶嘶！"
 
 #. [message]: speaker=Grug
 #. one of the player's units has reached the north side of the river, triggering this conversation
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:780
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:777
 msgid "You who? Fight lizard?"
 msgstr "你谁？打蜥蜴？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:784
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:781
 msgid "Err, yes, we’re here to fight the lizards."
 msgstr "呃，是的，我们来这里打这些蜥蜴。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:788
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:785
 msgid ""
 "If we help you fight your enemies, will you come with us and help fight our "
 "enemies?"
 msgstr "如果我们帮你们打你们的敌人，你会和我们一起帮助我们打我们的敌人吗？"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:792
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:789
 msgid "Mmmm... Grug think..."
 msgstr "嗯嗯……格拉格想……"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:801
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:798
 msgid "... Grug head hurt. Grug say join you."
 msgstr "…格拉格头伤了。格拉格说加入你们。"
 
 #. [message]: speaker=Izziasch
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:856
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:853
 msgid "Curssessss!"
 msgstr "该死嘶嘶！"
 
 #. [message]: speaker=Owaec
 #. crossed the river
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:878
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:875
 msgid ""
 "Good, we have safely crossed! And we have gained the service of several "
 "ogres as well."
 msgstr "好，我们安全地渡过了！还得到了几个食人魔的协助。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:882
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:879
 msgid ""
 "Ogres are unskilled fighters but much cheaper to equip than our other "
 "soldiers, and thus <i><b>cost much less gold to recall</b></i>."
@@ -4317,18 +4185,18 @@ msgstr ""
 
 #. [message]: speaker=Owaec
 #. crossed the river
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:889
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:886
 msgid "Good, we have safely crossed!"
 msgstr "好，我们安全地渡过了！"
 
 #. [message]: speaker=Izziasch
 #. "they" meaning the undead, not the player's troops
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:926
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:923
 msgid "Cursessss! They’ve caught usss!"
 msgstr "该死嘶嘶！亡灵抓住我们了嘶嘶！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:930
+#: data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg:927
 msgid "We are caught as well..."
 msgstr "我們也被抓住了…"
 
@@ -4353,12 +4221,12 @@ msgstr ""
 "意外地发现了一个有人居住的山谷..."
 
 #. [side]: type=Dwarvish Lord, id=Pelathsil
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:60
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:59
 msgid "Pelathsil"
 msgstr "佩拉希尔"
 
 #. [side]: type=Orcish Nightblade, id=Bagork
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:122
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:121
 msgid "Bagork"
 msgstr "巴郭克"
 
@@ -4369,35 +4237,35 @@ msgstr "巴郭克"
 #. [side]: type=Orcish Warlord, id=Varrak-Klar
 #. [side]: type=Orcish Slurbow, id=Rakkha
 #. Whitefang Orcs, the same clan that attacked Parthyn at the start of Descent into Darkness
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:132
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:155
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:131
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:154
 #: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:46
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:80
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:145
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:170
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:79
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:144
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:169
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:82
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:195
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:43
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:42
 msgid "Clan Whitefang"
 msgstr "白牙氏族"
 
 #. [side]: type=Orcish Warlord, id=Prok-Bak
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:146
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:145
 msgid "Prok-Bak"
 msgstr "普罗克-巴克"
 
 #. [side]: type=Naga Centurion, id=Aleii, gender=female
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:202
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:201
 msgid "Aleii"
 msgstr "艾里伊"
 
 #. [side]: type=Naga Centurion, id=Aleii, gender=female
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:212
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:211
 msgid "Naga"
 msgstr "娜迦"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:269
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:270
 msgid ""
 "Gather as much gold as you can before turns run out.\n"
 "300 gold is the suggested minimum, but the more the better."
@@ -4406,26 +4274,26 @@ msgstr ""
 "建议最低为300金币，但是越多越好。"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:271
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:272
 msgid ""
 "(You’ll want as much gold as possible when you try to leave the wildlands!)"
 msgstr "（当你试图离开荒野时，你需要获得尽可能多的金币！）"
 
 #. [objective]: condition=win
 #. two male dwarves
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:277
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:278
 msgid "Move Dolburras next to Pelathsil."
 msgstr "移动多尔布拉斯到佩拉希尔旁边。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:295
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:296
 msgid ""
 "The next 4 scenarios have 100% gold carryover, but few villages and 0 "
 "starting gold."
 msgstr "接下来4个场景可以带走100%的金币，但是很少村庄，并且0起始金币。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:312
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:313
 msgid ""
 "Farmland, in these remote reaches? Our supply situation has become rather "
 "dire since abandoning the outposts, so we are fortunate to have found such a "
@@ -4435,14 +4303,14 @@ msgstr ""
 "我们很幸运地找到了这样一个肥沃的山谷。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:316
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:317
 msgid ""
 "Huh, maybe throwin’ in my lot with you ain’t so bad after all. This place "
 "would make for a good retirement."
 msgstr "嗯，也许加入你们并没有那么糟糕。这个地方会很适合退休生活。"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:328
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:329
 msgid ""
 "Hail, honorable dwarves! Winter comes fast on our heels and we seek "
 "provisions and supplies for our holy journey. Can you be of aid?"
@@ -4451,7 +4319,7 @@ msgstr ""
 "你们能提供帮助吗？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:336
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:337
 msgid ""
 "Hail, stout-hearted dwarves! Winter comes fast on our heels and we seek "
 "provisions and supplies for our journey north. Can you be of aid?"
@@ -4461,7 +4329,7 @@ msgstr ""
 
 #. [message]: speaker=Prok-Bak
 #. A 3-way battle between orcs, dwarves and nagas was just starting when our protagonists arrived on the scene
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:344
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:345
 msgid ""
 "Don’t bother asking those freeloading dwarves for anything! They can’t even "
 "manage to pay their tribute on time."
@@ -4469,7 +4337,7 @@ msgstr "不要去烦那些蹭免费资源的矮人了！他们连按时缴纳贡
 
 #. [message]: speaker=Pelathsil
 #. "To flames with your tribute! What's ours is ours, and don't any of you orcs or humans try to take it."
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:349
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:350
 msgid ""
 "To flames with yer tribute! What’s ours be ours, and don’t no orcs nor any "
 "o’ ye humans be tryin and takin’ it!"
@@ -4478,7 +4346,7 @@ msgstr ""
 
 #. [message]: speaker=Dolburras
 #. "No, these humans are good folk! You can trust us to help against the orcs. All we ask is some food and drink to reprovision."
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:360
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:361
 msgid ""
 "Nay, these humans be good folk! Ye can trust us to help against them orcs. "
 "All we be askin’ be some food and drink to reprovision."
@@ -4487,7 +4355,7 @@ msgstr ""
 "和饮料来补充体力。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:367
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:368
 msgid ""
 "Can we not work together, for our mutual benefit? All we ask is some food "
 "and drink to reprovision."
@@ -4497,7 +4365,7 @@ msgstr ""
 
 #. [message]: speaker=Pelathsil
 #. "Never! Not since the days of Relgorn and Delfador have any of our clan helped one of you gangly humans!"
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:374
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:375
 msgid ""
 "Never! Not since tha days o’ Relgorn and Delfador ha’ any o’ our clan helped "
 "one o’ ye gangly humans!"
@@ -4506,7 +4374,7 @@ msgstr ""
 "的人类！"
 
 #. [message]: speaker=Aleii
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:378
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:379
 msgid ""
 "Hsss... orcsss, dwarvesss, humansss. We have traveled far to find thisss "
 "warmth. I have called the vote; the clutch has ssspoken. These waters are "
@@ -4517,21 +4385,21 @@ msgstr ""
 
 #. [message]: speaker=Prok-Bak
 #. Whitefang Orcs, the same clan that attacked Parthyn at the start of Descent into Darkness
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:383
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:384
 msgid ""
 "That’s Whitefang territory you’re squatting in, snake! Show some respect for "
 "the Chief!"
 msgstr "你现在蹲在的地方是白牙领地，蛇！对酋长表示尊重！"
 
 #. [message]: speaker=Bagork
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:387
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:388
 msgid ""
 "And I bet they haven’t paid tribute either! Dwarves, snakes, humans, I say "
 "we kill ’em all!"
 msgstr "我打赌他们也没缴纳贡品！矮人、蛇、人类，我说咱们把他们全杀了！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:397
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:398
 msgid ""
 "Barbarians, the lot of you! I’m going to starve because you’re busy fighting "
 "like a hatch of desert scorplings. <span size='small'>Don’t know what I "
@@ -4542,7 +4410,7 @@ msgstr ""
 "span>"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:404
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:405
 msgid ""
 "Infuriating. We may find scant supplies in the coming winter, but we cannot "
 "risk starving in the wilds while undead ravage Wesnoth."
@@ -4551,7 +4419,7 @@ msgstr ""
 "候，我们不能冒着在荒野中饿死的危险。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:410
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:411
 msgid ""
 "Gweddry, we will have to reprovision despite this conflict. If we spend "
 "cautiously and control enough farms, we should be able to gather enough "
@@ -4563,7 +4431,7 @@ msgstr ""
 #. [message]: speaker=Dolburras
 #. to Gweddry
 #. "Ack, that Pelathsil has a skull full of mud. If you get me next to him, I'm sure I can talk some sense into him."
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:429
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:430
 msgid ""
 "Ack, that Pelathsil ha’ a skull full o’ mud. If ye get me next ta him I’m "
 "sure I can talk some sense into him."
@@ -4574,7 +4442,7 @@ msgstr ""
 #. [message]: speaker=Dolburras
 #. start of a discussion between two male dwarves
 #. "Oi, mud for brains! What do you think you're doing, fighting with these men of Wesnoth?"
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:446
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:447
 msgid ""
 "Oi, mud-fer-brains! What do ye think ye be doin’, fighin’ wi’ these men o’ "
 "Wesnoth?"
@@ -4582,13 +4450,13 @@ msgstr "哎，泥脑子！你以为自己在做什么，和这些韦诺人干架
 
 #. [message]: speaker=Pelathsil
 #. "Men of Wesnoth aren't dwarves! I am a dwarf lord, not a man friend."
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:451
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:452
 msgid "Men o’ Wesnoth ain’t dwarves! I be a dwarf lord, not a man-friend."
 msgstr "韦诺人不是矮人！俺是矮人领主，不是人类之友。"
 
 #. [message]: speaker=Dolburras
 #. "Yeah, and so instead you send your subjects to die on man-spears? What kind of lordship is that? If you don't want to help us, at least don't fight us!"
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:456
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:457
 msgid ""
 "Aye, and so instead ye send yer subjects to die on man-spears? What kind o’ "
 "lordship be that? If ye dinnae want ta help us, at least dinnae fight us!"
@@ -4598,7 +4466,7 @@ msgstr ""
 
 #. [message]: speaker=Pelathsil
 #. "A man-friend and a blood-traitor you are... but I suppose I can see your point. We won't fight you any longer."
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:461
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:462
 msgid ""
 "A man-friend and a blood-traitor ye be... but I suppose I can see yer point. "
 "We won’t be fightin’ ye any longer."
@@ -4607,7 +4475,7 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. to Gweddry or the player, but overheard by Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:502
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:503
 msgid ""
 "Remember, if we spend too much on soldiers now, we may struggle to save "
 "enough supplies to see us through the winter."
@@ -4615,14 +4483,14 @@ msgstr "记住，如果我们现在在士兵身上花费过多，可能难以积
 
 #. [message]: speaker=Owaec
 #. to Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:507
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:508
 msgid ""
 "And how do you expect us to capture farms without enough soldiers to take "
 "them?"
 msgstr "那你怎能期望我们在缺少足够士兵的情况下去占领农场呢？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:518
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:519
 msgid ""
 "... I have held my tongue long enough. While Wesnoth bleeds, the High "
 "Advisor leads us north to forage for food. And as our men and our people "
@@ -4635,58 +4503,58 @@ msgstr ""
 "小屋和一些未知力量。格威德利，你肯定觉得这很奇怪吧？"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:522
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:523
 msgid ""
 "I don’t know, Owaec. It is odd, but Dacyn’s light and wisdom are well-known "
 "throughout Wesnoth."
 msgstr "我不知道，欧瓦埃克。虽然很奇怪，但达辛的光明与智慧在韦诺是众所周知的。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:526
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:527
 msgid "So were his friend Ravan’s, if Dacyn’s story is to be believed."
 msgstr "所以，如果达辛的故事可信的话，他的朋友莱文也是如此。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:537
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:538
 msgid "Excited Grug fight friends help!"
 msgstr "激动格拉格战斗朋友帮忙！"
 
 #. [message]: speaker=Dolburras
 #. "It's a sad day when dwarf fights dwarf... can you not let us pass peacefully?"
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:552
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:553
 msgid ""
 "It be a sad day when dwarf fights dwarf... can ye not let us pass peaceable-"
 "like?"
 msgstr "矮人和矮人战斗，这真是一个悲伤的日子…你就不能让俺们和平地通过吗？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:556
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:557
 msgid "I’m not afraid of ye! Raise yer axe, foreigner!"
 msgstr "我不怕你！举起你的斧头吧，外族人！"
 
 #. [message]: speaker=Dolburras
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:569
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:570
 msgid "Ach, it’s been too long since I put my axe in an orc’s skull!"
 msgstr "啊，我已经很久没有用斧头砍兽人的脑袋了！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:573
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:574
 msgid "For the Chief!"
 msgstr "为了酋长！"
 
 #. [message]: speaker=Dolburras
 #. attacking a naga
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:587
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:588
 msgid "Ooch, what manner o’ creature be you?"
 msgstr "哎哟，你是个什么生物？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:591
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:592
 msgid "Your sssslayer!"
 msgstr "你这嘶嘶杀手！"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:605
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:606
 msgid ""
 "I have smote many evil orcs in my day, yet I have known some to show as much "
 "honor as any knight. Can we not resolve this peacefully?"
@@ -4695,12 +4563,12 @@ msgstr ""
 "人。难道我们不能和平解决这个问题吗？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:609
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:610
 msgid "The only honor here belongs to the Chief!"
 msgstr "唯一的荣誉属于酋长！"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:622
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:623
 msgid ""
 "Naga, I know little of your kind, yet I do not wish to make enemies of you "
 "so hastily. Can we not come to parley?"
@@ -4708,120 +4576,122 @@ msgstr ""
 "娜迦，我对你们这种生物所知甚少，但我不愿轻易与你们为敌。我们能否进行谈判？"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:626
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:627
 msgid "Thisss river is oursss!"
 msgstr "这条河是我们的嘶嘶！"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:655
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:656
 msgid "10 gold"
 msgstr "10金币"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:656
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:657
 msgid "These dwarves have a pile of 10 gold pieces!"
 msgstr "这些矮人有堆10金币的金币块！"
 
 #. [scenario]: id=08_Xenophobia
-#. These dwarves are lazy, having just 10 gold!
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:658
+#. (said by a dwarf) These dwarves are lazy, having just 10 gold!
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:659
 msgid "These dwarves be lazy, ’aving just 10 gold!"
 msgstr "这些矮人好懒，只有10金币！"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:659
+#. (said by an ogre)
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:661
 msgid "Dwarf have 10 gold!"
 msgstr "矮人有10金币！"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:660
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:662
 msgid "The zombie finds a pile of 10 gold pieces!"
 msgstr "这个僵尸找到了一堆10金币的金币块！"
 
 #. [scenario]: id=08_Xenophobia
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:662
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:669
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1705
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:664
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:672
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1684
 msgid "20 gold"
 msgstr "20金币"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:663
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:665
 msgid "These nagas have a pile of 20 gold pieces!"
 msgstr "这些娜迦有堆20金币的金币块！"
 
 #. [scenario]: id=08_Xenophobia
-#. Oi, this is 20 gold! Where do these reptiles even get it?
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:665
+#. (said by a dwarf) Oi, this is 20 gold! Where do these reptiles even get it?
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:667
 msgid "Oi, this be 20 gold! Wher’ do these reptiles even get it?"
 msgstr "哦，这是20金币！这些爬行动物在哪弄到的？"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:666
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:669
 msgid "Snake have 20 gold!"
 msgstr "蛇族有20金币！"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:667
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:674
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:670
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:678
 msgid "The zombie finds a pile of 20 gold pieces!"
 msgstr "这个僵尸找到了一堆20金币的金币块！"
 
 #. [scenario]: id=08_Xenophobia
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:670
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1705
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:673
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1684
 msgid "These orcs have a pile of 20 gold pieces!"
 msgstr "这些兽人有堆20金币的金币块！"
 
 #. [scenario]: id=08_Xenophobia
-#. Look at that, 20 gold pieces these orcs have stolen from dwarves!
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:672
+#. (said by a dwarf) Look at that, 20 gold pieces these orcs have stolen from dwarves!
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:675
 msgid "Look a’ that, 20 gold pieces these orcs done steal from dwarves!"
 msgstr "看那，这些兽人从矮人那里偷走的20个金币块！"
 
 #. [scenario]: id=08_Xenophobia
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:673
+#. (said by an ogre)
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:677
 msgid "Orc have 20 gold!"
 msgstr "兽人有20金币！"
 
 #. [message]: speaker=Bagork
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:691
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:693
 msgid "I will kill all of you!"
 msgstr "我要杀光你们！"
 
 #. [message]: speaker=second_unit
 #. The unit who killed Bagork responds to Bagork's last breath, which was "I will kill all of you!"
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:702
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:704
 msgid "Not likely."
 msgstr "看起来没戏。"
 
 #. [message]: speaker=Prok-Bak
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:712
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:714
 msgid "Chief Dra-Nak will hear of this!"
 msgstr "德拉-纳克酋长会听到的！"
 
 #. [message]: speaker=Aleii
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:723
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:725
 msgid "Thisss isss why we avoid outsssidersss..."
 msgstr "这嘶嘶就是嘶嘶为什么我们要躲避外来者嘶嘶……"
 
 #. [message]: speaker=Pelathsil
 #. "It seems those humans were mightier than I thought..."
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:738
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:740
 msgid "It seems yon humans be mightier than I kenned..."
 msgstr "你们人类看来比我所知道的要强……"
 
 #. [message]: speaker=Pelathsil
 #. "Foul orcs! Perhaps we should have allied with the humans..."
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:752
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:754
 msgid "Foul orcs! Mayhaps we should ha’ allied wi’ the humans..."
 msgstr "肮脏的兽人！我们也许该和人类结盟的……"
 
 #. [message]: speaker=Dacyn
 #. $gold is at least 300
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:772
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:774
 msgid ""
 "We are doing well. Our forces have already gathered $gold gold — plenty for "
 "the winter, and there is enough time remaining to gather even more."
@@ -4830,7 +4700,7 @@ msgstr ""
 "收集更多。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:778
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:780
 msgid ""
 "Gweddry, I urge you to gather at least 300 gold before we head further "
 "north. We cannot afford to tarry here while Wesnoth contends against Mal-"
@@ -4840,14 +4710,14 @@ msgstr ""
 "时，我们在这里逗留不起。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:800
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:802
 msgid ""
 "I’ve finished gathering the supplies from all our captured farms! We should "
 "have plenty for our journey ahead."
 msgstr "我已经完成收集了所有我们占领的农场的物资！我们接下来的旅程应该足够了。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:804
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:806
 msgid ""
 "Let us forge onward. We have almost reached our destination, and will soon "
 "have the power to save Wesnoth from Mal-Ravanal."
@@ -4856,7 +4726,7 @@ msgstr ""
 "量。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:812
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:814
 msgid ""
 "I’ve tried my best, but I still haven’t been able to gather very much gold. "
 "The farms we’ve captured simply don’t have enough supplies to sustain us for "
@@ -4866,7 +4736,7 @@ msgstr ""
 "进行长途旅行。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:816
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:818
 msgid ""
 "Without more provisions it will be difficult to travel further north, but "
 "neither can we afford to spend any more time here while Wesnoth battles Mal-"
@@ -4876,12 +4746,12 @@ msgstr ""
 "留也是我们负担不起的……"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:821
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:823
 msgid "Travel north regardless. <i>(challenging)</i>"
 msgstr "无论如何向北出发。 <i>（挑战）</i>"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:825
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:827
 msgid ""
 "Bah, a Clansman never succumbs to despair! Let us press forth and fight to "
 "save our homeland, whatever the odds!!"
@@ -4890,12 +4760,12 @@ msgstr ""
 "而战斗！！"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:830
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:832
 msgid "Restart the level."
 msgstr "重打这关。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:853
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:855
 msgid ""
 "I only hope we are not too late... If what we saw at Soradoc was any guide, "
 "Mal-Ravanal may soon overrun all of Wesnoth!"
@@ -4904,7 +4774,7 @@ msgstr ""
 "能会很快侵占整个韦诺！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:860
+#: data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg:862
 msgid ""
 "I only hope we are not too late! We have heard nothing of the undead "
 "invasion force since it overran us at the outposts. I wish we knew how "
@@ -4929,7 +4799,7 @@ msgstr ""
 "速变冷，使本已充满挑战的山脉变得更加危险。"
 
 #. [side]: type=Hurricane Drake, id=Kaslar Ro
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:75
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:74
 msgid "Kaslar Ro"
 msgstr "卡斯拉尔·若"
 
@@ -4938,58 +4808,58 @@ msgstr "卡斯拉尔·若"
 #. [side]: type=Drake Flameheart, id=Mortic
 #. [side]: type=Drake Arbiter, id=Goag
 #. [side]: type=Drake Warrior, id=Gra'ritos
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:84
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:117
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:83
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:116
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:143
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:72
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:100
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:127
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:71
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:101
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:130
 msgid "Drakes"
 msgstr "龙人"
 
 #. [side]: type=Sky Drake, id=Kegra
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:108
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:107
 msgid "Kegra"
 msgstr "凯格拉"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:184
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:183
 msgid "Beasts"
 msgstr "野兽"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:252
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:251
 msgid "Pudror"
 msgstr "普德罗"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:253
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:252
 msgid "Chief Bir-brish"
 msgstr "比尔-布里什酋长"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:255
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:254
 msgid "Huno"
 msgstr "胡诺"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:258
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:257
 msgid "Iprish"
 msgstr "伊普里什"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:437
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:436
 msgid "Move any unit to the abandoned castle."
 msgstr "移动任意单位至废弃的城堡。"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:442
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:441
 msgid "Move Grug next to an enemy ogre."
 msgstr "移动格拉格至一个敌方食人魔的旁边。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:460
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:738
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:459
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:743
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:291
 msgid "It is winter, daytime is shorter"
 msgstr "这是冬天，白天会变短"
@@ -4997,14 +4867,14 @@ msgstr "这是冬天，白天会变短"
 #. [note]
 #. The amount is likely between 1 and 10 per turn.
 #. With the current balancing it’s the same for every difficulty, starting at 1/turn and rising by 1 every 6 turns.
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:465
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:464
 msgid ""
 "Living units take $|frostbite_amount cold damage every turn. Damage "
 "increases every 6 turns."
 msgstr "活着的单位每回合受到 $|frostbite_amount 点冷冻伤害。每6回合伤害增加。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:480
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:479
 msgid ""
 "This winter cold chills my very bones! I long for the rolling plains of my "
 "homeland. I wonder how the horse lords fare against the grim undead; surely "
@@ -5014,7 +4884,7 @@ msgstr ""
 "亡灵；韦诺肯定接近胜利了吗？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:484
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:483
 msgid ""
 "Doubtful, but <i>our</i> victory is close. Across this river lies the "
 "abandoned sanctuary, and within lies an artifact that can destroy Mal-"
@@ -5024,7 +4894,7 @@ msgstr ""
 "彻底摧毁玛尔-拉瓦纳尔的法器。这就是我们的目标。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:488
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:487
 msgid ""
 "This area was deserted whence last I came, but I have heard rumors that a "
 "flight of drakes has taken up residence."
@@ -5034,19 +4904,19 @@ msgstr ""
 
 #. [message]: speaker=Terraent
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:498
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:505
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:497
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:504
 msgid ""
 "And listen! I hear the bone-chilling howls of wolves echoing among the peaks."
 msgstr "听着！我听到群狼令人毛骨悚然的吼声在山峰间回响。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:511
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:510
 msgid "Wolves and drakes, bah! I fear no mindless beasts!"
 msgstr "狼和龙人，啊！我不怕无脑的野兽！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:515
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:514
 msgid ""
 "Unlike yourself, drakes are very much intelligent. Their inner flame guards "
 "against our mages’ fire and their flight will serve them better than our "
@@ -5057,26 +4927,26 @@ msgstr ""
 
 #. [message]: speaker=Dolburras
 #. "Yes, and don't understimate wild beasts! I've known wolves to take a dwarf's arm clean off."
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:526
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:525
 msgid ""
 "Aye, and dinnae underestimate wild beasts! I’ve known wolves ta take a "
 "dwarf’s arm clean off."
 msgstr "是的，不要小看了野兽！我知道狼会把矮人的胳膊砍掉。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:530
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:529
 msgid "Still, we must press onwards to the icy castle."
 msgstr "尽管如此，我们还是必须向冰冷的城堡前进。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:537
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:536
 msgid ""
 "And wild beasts are not to be underestimated either! Still, we must press "
 "onwards to the icy castle."
 msgstr "野兽也不容小觑！尽管如此，我们还是必须向冰冷的城堡前进。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:627
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:626
 msgid ""
 "Fire and ice, eh? I have just the thing — behold the wondrous elixir of "
 "elements! Whoever drinks from this bubbling yellow vial will gain immunity "
@@ -5086,7 +4956,7 @@ msgstr ""
 "喝一口，将获得对甚至最热的火焰的免疫力！"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:631
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:630
 msgid ""
 "But wait, there’s more! The elixir of elements also bestows immunity to "
 "cold; perfect for enduring the frigid winter weather."
@@ -5095,7 +4965,7 @@ msgstr ""
 "天。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:658
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:657
 msgid ""
 "Act fast, this offer is for a limited time only! <i>(elixirs only last for 1 "
 "scenario)</i>"
@@ -5103,12 +4973,12 @@ msgstr "快快行动，这个优惠时效有限！<i>（药水仅在1个场景�
 
 #. [floating_text]
 #. other units are taking damage from the cold, but this unit is immune (through the elixir or yetiburger)
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:769
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:768
 msgid "resist"
 msgstr "抵抗"
 
 #. [message]: id=Gweddry,Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:825
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:824
 msgid ""
 "<i>Brrrr</i>, I can’t feel my fingers or toes! We’ll die of cold if we’re "
 "trapped out here for too long."
@@ -5117,7 +4987,7 @@ msgstr ""
 "的。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:829
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:828
 msgid ""
 "What am I even doin’ here? All I wanted was to make an honest living "
 "smashin’ in skulls, then retire somewhere warm..."
@@ -5126,14 +4996,14 @@ msgstr ""
 "休……"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:838
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:837
 msgid ""
 "The cold keeps getting worse! We have to reach that abandoned castle before "
 "we all freeze!"
 msgstr "天气越来越冷！我们必须在所有人都冻僵之前到达那个废弃城堡！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:848
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:847
 msgid ""
 "Gweddry, you should try to conserve our gold over the next few conflicts. We "
 "will be hard-pressed to find many villages in these lands and will surely "
@@ -5143,7 +5013,7 @@ msgstr ""
 "地上找到许多村庄，以后肯定需要更多金币。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:853
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:852
 msgid ""
 "(This and the next 3 scenarios have 100% carryover, but few villages and 0 "
 "starting gold.)"
@@ -5152,7 +5022,7 @@ msgstr ""
 "币。）"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:858
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:857
 msgid ""
 "(You’ll want as much gold as you can possibly get when you try to leave the "
 "wildlands!)"
@@ -5161,72 +5031,72 @@ msgstr "（当你试图离开荒野时，你需要获得尽可能多的金币！
 #. [message]: speaker=Gweddry
 #. [else]
 #. The speaker is normally whichever unit just moved. However, if that's Dacyn then Gweddry says it to avoid Dacyn talking to himself.
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:885
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:891
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:896
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:884
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:890
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:895
 msgid ""
 "Look, a ruined castle off in the distance! Is that the one we’re looking for?"
 msgstr "看，远处有一座损坏的城堡！那是我们要找的那个吗？"
 
 #. [else]
-#. Oi, do you see old castle ruin over there? It’s the one we’re looking for, isn’t it?
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:893
+#. (said by a dwarf) Oi, do you see old castle ruin over there? It’s the one we’re looking for, isn’t it?
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:892
 msgid ""
 "Oi, do ya ken ol’ castle ruin o’er yonder? It be one we lookin’ fer, eh?"
-msgstr ""
+msgstr "嘿，你认得远处那座古老城堡废墟不？就是咱要找的那个，对吧？"
 
 #. [else]
-#. I see a castle. It is very broken. Does the magic man want the broken castle?
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:895
+#. (said by an ogre) I see a castle. It is very broken. Does the magic man want the broken castle?
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:894
 msgid "Me see castle. Very broken. Magic man want broken castle?"
-msgstr ""
+msgstr "俺看见城堡。破得很。魔法人要破城堡？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:904
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:903
 msgid "No. The ruin we’re journeying towards lies across the river."
 msgstr "不。我们要去的废墟在河的另一边。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:951
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:950
 msgid "Tapok"
 msgstr "塔波克"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:956
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:955
 msgid "Ogho"
 msgstr "欧戈"
 
 #. [event]
 #. [side]: type=Drake Flameheart, id=Mortic
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:961
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:960
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:131
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:75
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:74
 msgid "Mortic"
 msgstr "莫提克"
 
 #. [message]: speaker=Tapok
 #. male Orcish Warlord talking to Mortic, a random-gender Drake Flameheart.
 #. "they" being two other male drakes
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1019
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1018
 msgid "Well? Are they ready?"
 msgstr "哦？他们准备好了吗？"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1021
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:372
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1020
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:371
 msgid "Ga’all"
 msgstr "盖尔"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1022
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:373
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1021
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:372
 msgid "Verash"
 msgstr "维拉什"
 
 #. [message]: speaker=Mortic
 #. random-gender Drake to two male drakes
 #. using the Morogor dialect from WoF (unless I messed it up)
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1027
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1026
 msgid ""
 "Ga’all, your Hunt has failed.\n"
 "Verash, your claws grow aged.\n"
@@ -5240,7 +5110,7 @@ msgstr ""
 
 #. [message]: speaker=Verash
 #. "Aspirant" is a drake military rank
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1035
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1034
 msgid ""
 "Aspirant Mortic,\n"
 "As you command."
@@ -5249,12 +5119,12 @@ msgstr ""
 "遵命。"
 
 #. [message]: speaker=Ogho
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1040
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1039
 msgid "C’mon wyrms, get moving!"
 msgstr "来吧，龙族，动起来！"
 
 #. [message]: speaker=Tapok
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1047
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1046
 msgid ""
 "Heh heh, quality tribute, as always. Be grateful for our generosity. Chief "
 "only asked for two this time!"
@@ -5262,7 +5132,7 @@ msgstr "嘿嘿，质量贡品，一如既往。要感激我们的慷慨。这次
 
 #. [message]: speaker=$their_unit_id
 #. speaker is a drake, probably Mortic
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1075
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1074
 msgid ""
 "An unknown creature approaches.\n"
 "Paler than an Orc.\n"
@@ -5275,7 +5145,7 @@ msgstr ""
 "告吾汝族。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1082
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1081
 msgid ""
 "We are men, of Wesnoth! We come in peace, seeking magic to help in our war "
 "against an undead horde."
@@ -5283,7 +5153,7 @@ msgstr ""
 "我们是人类，来自韦诺！我们和平地来到这里，寻求魔法来帮助我们对抗亡灵部落。"
 
 #. [message]: speaker=$their_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1086
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1085
 msgid ""
 "Dra-Nak warned us.\n"
 "You men of Wes-Noth speak of peace.\n"
@@ -5298,19 +5168,19 @@ msgstr ""
 "再无贡品可付。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1094
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1093
 msgid "No, wait, we just want to-"
 msgstr "不，等一下，我们只是想——"
 
 #. [message]: speaker=$their_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1098
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1097
 msgid "Our Hunt must continue."
 msgstr "吾等狩猎未可中断。"
 
 #. [message]: speaker=Mortic
 #. letting us know that they're just a small and relatively weak Drake Flight but it sets us up to meet some strong ones later
 #. "aspirant" is a drake military rank
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1157
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1156
 msgid ""
 "I am Aspirant.\n"
 "Yet in these northlands, even prey bares its fangs,\n"
@@ -5330,33 +5200,33 @@ msgstr ""
 
 #. [message]: speaker=Grug
 #. Grug to Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1186
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1185
 msgid "Grug make ogre friendly! Talk ogre Grug make friend."
 msgstr "格拉格让食人魔友好！说食人魔格拉格交朋友。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1190
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1189
 msgid "I think he’s saying he wants to talk with the wild ogres?"
 msgstr "我想他是在说想要和野生食人魔交谈？"
 
 #. [message]: speaker=$their_unit_id
 #. speaker is a hostile ogre
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1248
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1247
 msgid "Guuuh... human?"
-msgstr "咕…人类？"
+msgstr "咕……人类？"
 
 #. [message]: speaker=$our_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1252
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1251
 msgid "Err, hello?"
 msgstr "呃，你好？"
 
 #. [message]: speaker=$their_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1256
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1255
 msgid "Human! Human human human!"
 msgstr "人类！人类，人类，人类！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1260
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1259
 msgid "They don’t look very friendly..."
 msgstr "他们看起来不是很友好……"
 
@@ -5364,55 +5234,55 @@ msgstr "他们看起来不是很友好……"
 #. [message]: speaker=$their_unit_id
 #. player's ogre (but not Grug, who gets different lines) to hostile ogre
 #. hostile ogre to Grug
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1311
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1370
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1310
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1369
 msgid "Guuuh... who you?"
-msgstr "咕…谁你？"
+msgstr "咕……谁你？"
 
 #. [message]: speaker=$their_unit_id
 #. hostile ogre to player's ogre
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1317
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1316
 msgid "Uhhhh... who <i><b>you</b></i>?"
-msgstr "啊…谁<i><b>你</b></i>？"
+msgstr "啊……谁<b>你</b>？"
 
 #. [message]: speaker=$our_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1321
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1320
 msgid "Me... friend? New friend?"
 msgstr "我……朋友？新朋友？"
 
 #. [message]: speaker=$their_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1326
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1325
 msgid "New friend! Me no fight friend."
 msgstr "新朋友！我不打朋友。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1374
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1373
 msgid "Grug me! Me friend human."
 msgstr "格拉格我！我朋友人类。"
 
 #. [message]: speaker=$their_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1379
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1378
 msgid "Uhhhh... friend... human?"
 msgstr "呃……朋友……人类？"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1383
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1382
 msgid "You too friend human! Help human fight good."
 msgstr "你也朋友人类！帮助人来战斗好。"
 
 #. [message]: speaker=$their_unit_id
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1388
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1387
 msgid "OK, me help human fight! Human good!"
 msgstr "好，我帮助人类战斗！人类好！"
 
 #. [scenario]: id=09_Castle_in_the_Ice
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1426
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1425
 msgid "25 gold"
 msgstr "25金币"
 
 #. [event]
 #. circa 25 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1436
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1435
 msgid ""
 "This shipwreck was carrying chests of gold! Most of them are buried under "
 "the ice, but I can still reach $gold pieces."
@@ -5421,56 +5291,60 @@ msgstr ""
 "$gold 金块。"
 
 #. [event]
-#. My beard, a shipwreck full of gold chests! Though only $gold pieces are not under the blasted ice! I have to return here after this war’s over.
+#. (said by a dwarf) My beard, a shipwreck full of gold chests! Though only $gold pieces are not under the blasted ice! I have to return here after this war’s over.
 #. circa 25 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1439
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1438
 msgid ""
 "Me beard, a shipwreck full o’ gold chests! Tho’ only $gold pieces not under "
 "blasted ice! Hafta return ’ere after this war’s o’er."
 msgstr ""
+"俺的胡子啊，一艘装满金箱子的沉船！虽说只有$gold|枚金币没在那该死的冰下面！等"
+"仗打完了得回这儿来。"
 
 #. [event]
-#. I see a shipwreck. I see a lot of gold in the ice. I cannot take it. $gold gold pieces are not deep. I can take them.
+#. (said by an ogre) I see a shipwreck. I see a lot of gold in the ice. I cannot take it. $gold gold pieces are not deep. I can take them.
 #. circa 25 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1442
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1441
 msgid ""
 "Me see ship break. Me see in ice lot gold. No can take. $gold gold no deep. "
 "Can take."
-msgstr ""
+msgstr "俺看见船破了。俺看见冰里好多金子。拿不了。$gold|金币埋得不深。能拿。"
 
 #. [event]
 #. circa 25 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1444
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1443
 msgid ""
 "The zombie finds an old shipwreck and manages to scratch out $gold gold "
 "pieces frozen in the ice. The rest of the chests are too deep."
 msgstr ""
+"僵尸发现了一艘古老的沉船，设法从冰中刮出了$gold|枚金币。其余的箱子埋得太深"
+"了。"
 
 #. [event]
 #. circa 30 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1468
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1467
 msgid ""
 "This ruined town still has some valuables! I count enough to be worth $gold "
 "gold pieces."
 msgstr "这个废弃小镇还有一些宝贝！我数了一下，值$gold金币。"
 
 #. [event]
-#. This town is a ruin, though I’ve found some baubles worth $gold gold.
+#. (said by a dwarf) This town is a ruin, though I’ve found some baubles worth $gold gold.
 #. circa 30 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1471
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1470
 msgid "This town’s a ruin, tho’ I done find some baubles worth $gold gold."
-msgstr ""
+msgstr "这座镇子已成废墟，不过俺倒是找到了些值$gold|金币的小玩意儿。"
 
 #. [event]
-#. This town is very empty. I have found some shiny things. They are worth $gold gold pieces.
+#. (said by an ogre) This town is very empty. I have found some shiny things. They are worth $gold gold pieces.
 #. circa 30 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1474
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1473
 msgid "Town very empty. Me find shinies. Shinies for $gold gold."
-msgstr ""
+msgstr "镇子空空的。俺找到亮晶晶。亮晶晶值$gold|金币。"
 
 #. [event]
 #. circa 30 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1476
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1475
 msgid ""
 "The zombie searches the ruined town and finds some valuables worth $gold "
 "gold pieces."
@@ -5478,47 +5352,47 @@ msgstr "僵尸搜索了这个废弃小镇并找到了一些宝贝，值$gold金�
 
 #. [event]
 #. circa 15 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1500
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1499
 msgid ""
 "This drake only had $gold gold pieces in his camp. Not much of a dragon "
 "hoard..."
 msgstr "这个龙人营地里只有$gold金币。对于一个龙群并不多…"
 
 #. [event]
-#. Meh, this drake got just $gold gold. I would expect more from a bunch of walking furnaces.
+#. (said by a dwarf) Meh, this drake got just $gold gold. I would expect more from a bunch of walking furnaces.
 #. circa 15 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1503
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1502
 msgid ""
 "Meh, this drake got just $gold gold. Woulda expect more from a bunch o’ "
 "walkin’ furnaces."
-msgstr ""
+msgstr "嘁，这龙人身上才$gold|金币。俺本指望一群行走的熔炉能更有点油水。"
 
 #. [event]
-#. The drake has $gold gold pieces. The drake is mean. I am going to take the gold.
+#. (said by an ogre) The drake has $gold gold pieces. The drake is mean. I am going to take the gold.
 #. circa 15 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1506
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1505
 msgid "Hot lizard have $gold gold. Lizard mean. Me take gold."
-msgstr ""
+msgstr "热蜥蜴有$gold|金币。蜥蜴凶。俺拿金币。"
 
 #. [event]
 #. circa 15 gold pieces
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1508
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1507
 msgid "The zombie finds $gold gold pieces in the drake camp."
 msgstr "僵尸在龙人的营地里找到了 $gold 金币块。"
 
 #. [message]: type=Yeti
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1529
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1528
 msgid "GROARRR!!!"
 msgstr "嗷嗷嗷！！！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1540
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1539
 msgid "I’ve never tried Yeti meat. I wonder what it tastes like?"
 msgstr "我从来没有尝过雪人肉。我想知道它是什么味道？"
 
 #. [message]: speaker=Dacyn
 #. the player has moved a unit (any unit) to the castle
-#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1563
+#: data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg:1562
 msgid "This is the place! Let us enter."
 msgstr "是这个地方了！我们进去吧。"
 
@@ -5542,7 +5416,7 @@ msgstr "地精"
 #. [event]
 #: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:261
 msgid "Injured Yeti"
-msgstr ""
+msgstr "受伤的雪人"
 
 #. [message]: speaker=unit
 #. a significant hint, exploring would take a long time with no reward
@@ -5553,72 +5427,71 @@ msgid ""
 msgstr "呃，蚂蚁。我怀疑这里没有什么有价值的东西，只有那种糟糕的蜜食。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:544
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:550
 msgid "Study Guard"
 msgstr "书房守卫"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:573
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2917
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:514
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:579
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2924
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:513
 msgid "Cowardly Goblin"
 msgstr "懦弱的地精"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:580
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1921
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:586
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1926
 msgid "Thirsty Goblin"
 msgstr "口渴的地精"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:585
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:591
 msgid "Dushab"
 msgstr "杜沙布"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:620
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2236
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:626
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2242
 msgid "Goblin Leader"
 msgstr "地精首领"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:678
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:684
 msgid "Move Dacyn, Gweddry, and reinforcements into the gate"
 msgstr "移动达辛、格威德利和援军到大门"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:685
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:691
 msgid "Find both gate keys"
 msgstr "找到两个大门的钥匙"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:692
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:698
 msgid "Move Dacyn, Gweddry, and reinforcements into the inner gate"
 msgstr "移动达辛、格威德利和援军到内部的大门"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:699
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:705
 msgid "Defeat the sanctum guard"
 msgstr "击败密室守卫"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:706
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:712
 msgid "Retrieve the amulet"
 msgstr "取回护身符"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:711
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:717
 msgid "Survive the orcish assault"
 msgstr "活过兽人的袭击"
 
 #. [note]
-#. TODO in 1.19 add "... and end your turn"
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:729
-msgid "To enter the castle, move Dacyn into the gated area."
-msgstr "要进入城堡，移动达辛到大门区域。"
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:734
+msgid "To enter the castle, move Dacyn into the gated area and end your turn."
+msgstr "要进入城堡，移动达辛到门后的区域内并结束回合。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:735
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:740
 msgid ""
 "Dacyn has been here before and will have better outcomes when stepping on "
 "runes."
@@ -5626,7 +5499,7 @@ msgstr "达辛之前来过这里，踩上符文会有更好的结果。"
 
 #. [message]: speaker=Dacyn
 #. Iliah-Malal was the male lich antagonist of Delfador's Memoirs, around 160 years ago
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:763
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:768
 msgid ""
 "We have arrived. This is a long-abandoned sanctum that you may know as the "
 "lair of the mage Iliah-Malal."
@@ -5636,7 +5509,7 @@ msgstr ""
 #. [message]: speaker=Dacyn
 #. once again Dacyn is an unreliable narrator and does not speak absolute truth, he only says what he knows
 #. in fact the Amulet by itself can't do what he says it does, that's just his assumption
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:769
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:774
 msgid ""
 "It is here that I seek Iliah-Malal’s Amulet of the Veil, an artifact "
 "possessing the power to open gates between the land of the living and that "
@@ -5650,12 +5523,12 @@ msgstr ""
 "我曾经认为这样的力量用起来太危险了；我现在不再那么幼稚了。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:775
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:780
 msgid "Iliah-Malal? I know that name from the histories..."
 msgstr "伊利阿-玛拉尔？我从历史中知道这个名字…"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:784
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:789
 msgid ""
 "All this time... all this time I thought we were questing towards a noble "
 "goal. Searching for a legendary sword, an ancient tome, a holy relic."
@@ -5664,7 +5537,7 @@ msgstr ""
 "的卷轴、一件神圣的遗物。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:788
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:793
 msgid ""
 "Instead, our quest brings us to the lair of a necromancer?! How can you "
 "possibly mean to make use of anything ever possessed by such an evil? As "
@@ -5675,7 +5548,7 @@ msgstr ""
 "这种邪恶持有过的东西？作为韦诺的士兵，我们有义务为光明而战，而不是黑暗！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:792
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:797
 msgid ""
 "Do not be so shortsighted. With the power to open portals to the Land of the "
 "Dead, I can pull Mal-Ravanal’s spirit out of this world. Then, the spells "
@@ -5688,7 +5561,7 @@ msgstr ""
 "为成堆的白骨。我运用这股力量是为了伊迪亚的利益，而不是为了你的荣誉。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:796
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:801
 msgid ""
 "Dacyn, I am uneasy about this course of action. I know little of the Land of "
 "the Dead, but everything I have heard suggests-"
@@ -5696,7 +5569,7 @@ msgstr ""
 "达辛，我对这行动计划感到不安。我对冥界知之甚少，但我所听到的每一件事都表明——"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:800
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:805
 msgid ""
 "You would violate the dead’s eternal peace to fight a war, yet you call me "
 "shortsighted?! And while our homeland bleeds, you have the gall to speak of "
@@ -5707,7 +5580,7 @@ msgstr ""
 "论一切生命的福祉？！疯狂！作为一个光明法师，你应该更明白！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:804
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:809
 msgid ""
 "I have had enough of your second-guessing. You, fool of a horse boy, know "
 "nothing of the mystic arts, yet you mask your ignorance by cowering behind a "
@@ -5719,7 +5592,7 @@ msgstr ""
 "不断壮大的军队中。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:808
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:813
 msgid ""
 "Unlike you, I have the knowledge and power to defeat the undead, and I "
 "intend to use it to destroy Mal-Ravanal. Will you wallow in your "
@@ -5729,14 +5602,14 @@ msgstr ""
 "会沉浸在你的短视中吗，还是你打算帮助我保护所有生命？"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:817
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:822
 msgid ""
 "I will help you. We have come this far, and it seems a waste to turn back "
 "now."
 msgstr "我会帮你的。我们已经走了这么远，现在回头似乎很浪费。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:821
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:826
 msgid ""
 "By the Clans, I will not!! Would that I had perished in battle against the "
 "undead! Better that than living to see Wesnoth’s high mage succumb to the "
@@ -5746,7 +5619,7 @@ msgstr ""
 "级法师屈服于黑暗的诱惑要强。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:825
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:830
 msgid ""
 "Gweddry, if you truly wish to aid this madman, I will guard the outer gates "
 "for you. But I will not enter that evil stronghold. I would sooner perish "
@@ -5756,7 +5629,7 @@ msgstr ""
 "邪恶要塞。我宁愿死去，也不愿靠近达辛那恶心的护身符一步。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:834
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:839
 msgid ""
 "Ah, I still remember this place quite clearly. Now that I think of it, Ravan "
 "had always been very interested in the magic of darkness. Apparently, the "
@@ -5769,19 +5642,19 @@ msgstr ""
 "想起来，那全是胡说八道。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:838
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:843
 msgid "The irony seems lost on you."
 msgstr "这个讽刺似乎对你来说毫无意义。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:842
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:847
 msgid ""
 "Back then this place was full of traps and undead, and it will no doubt be "
 "worse now that the wild beasts have had a chance to move in."
 msgstr "那时这个地方充满了陷阱和亡灵，如今野兽有机会进入，无疑会更糟。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:853
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:858
 msgid ""
 "Ravan sealed this place before our last meeting. I need a moment to remember "
 "the incantation."
@@ -5790,7 +5663,7 @@ msgstr "莱文在和我们上次见面之前封印了这个地方。我需要一
 #. [message]: speaker=Dacyn
 #. the "red star" refers to the Ruby of Fire, and the "red stone" refers to the Amulet of the Veil FYI but these are not to be explicitly mentioned
 #. the "black pool" would be located near or under Weldyn, but again not to be explicitly mentioned
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:863
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:868
 msgid ""
 "The red star blazes,\n"
 "The red stone bleeds.\n"
@@ -5803,26 +5676,26 @@ msgstr ""
 "世界之间的黑暗张开巨口。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:890
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:895
 msgid ""
 "Ugh, spellcasting always gives me the shivers. There’s a reason the more "
 "civilized people of my homeland don’t trifle with magic!"
 msgstr "呃，施法总是让我毛骨悚然。这就是我家乡更文明的人不随意玩弄魔法的原因！"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:894
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:899
 msgid "For a mage of the Light, the words you speak are dark indeed."
 msgstr "对于一位光明法师，你说的这些话真的很黑暗。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:898
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:903
 msgid ""
 "I’m a simple man. I use simple tools and weapons. This magic stuff is givin’ "
 "me the creeps."
 msgstr "我是一个普通人。我用简单的工具和武器。这魔法玩意儿让我毛骨悚然。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:908
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:913
 msgid ""
 "This antechamber only has room for eight. I must go to retrieve the "
 "artifact, and Gweddry has agreed to accompany me, so that leaves room for "
@@ -5833,7 +5706,7 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. the player needs to choose 6 troops
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:927
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:932
 msgid ""
 "Gweddry, are you still choosing your troops? I must end my turn in the "
 "antechamber to cycle the gate and enter the sanctuary."
@@ -5841,50 +5714,50 @@ msgstr ""
 "格威德利，你还在挑选部队吗？我必须在前室结束我的回合，以旋转大门并进入圣殿。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:946
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:951
 msgid "I will not aid in this evil quest."
 msgstr "我不会帮助这个邪恶的任务。"
 
 #. [message]: speaker=Dacyn
 #. somewhat like an airlock
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1000
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1005
 msgid "I am ready to cycle the gates. Gweddry, shall we proceed?"
 msgstr "我准备转动大门了。格威德利，我们继续吗？"
 
 #. [option]
 #. 6 soldiers
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1003
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1008
 msgid "Yes, these are the soldiers I want."
 msgstr "是的，这些是我要的战士。"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1011
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2487
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:850
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1016
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2494
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:849
 msgid "No, not yet."
 msgstr "不，还没有。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1020
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1025
 msgid ""
 "Gweddry, you agreed to accompany me. We must both enter this antechamber "
 "before I cycle the gates."
 msgstr "格威德利，你同意陪我的。在转动大门之前，我们都必须进入这个前室。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1080
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1085
 msgid "Cave scary! Grug no like!"
 msgstr "洞穴可怕！格拉格不喜欢！"
 
 #. [message]: speaker=Gweddry
 #. the torches were already burning before any of Gweddry's party entered the castle
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1088
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1093
 msgid "The torches are lit..."
 msgstr "火炬是亮的……"
 
 #. [message]: speaker=Dolburras
 #. "I have seen my fair share of dark caves, but something about this place is making me shake."
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1101
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1106
 msgid ""
 "I ha’ seen my fair share o’ dark caves, but summat ’bout this place be "
 "givin’ me the shakes."
@@ -5893,40 +5766,40 @@ msgstr "俺见过不少阴暗的山洞，但关于这个地方的某些东西却
 #. [message]: speaker=Terraent
 #. at the moment he's seeing the inside of a castle, the lit torches, and a wild yeti
 #. there's nothing particularly unholy to focus on
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1116
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1121
 msgid "May this unholy place be cleansed by the Light!"
 msgstr "愿这邪恶之地被光明净化！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1200
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1205
 msgid "GROWWR!!"
-msgstr ""
+msgstr "吼嗷嗷！！"
 
 #. [message]: speaker=unit
 #. 200, 160, or 130 gold
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1215
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1220
 msgid "This yeti was rich! I count $gold gold in its hoard."
 msgstr "这个雪人真是有钱！我在它的宝藏中数出了$gold金币。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1220
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1225
 msgid "Ho ho, northerners’ gold, now that begins to make this all worth it!"
 msgstr "嚯嚯，北方人的金币，现在这一切才显得值得！"
 
 #. [message]: speaker=narrator
 #. a signpost. "Study" as in a room with a reading desk and small library
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1240
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1245
 msgid "East: Study and Vaults"
 msgstr "东面：书房和地窖"
 
 #. [message]: speaker=narrator
 #. a signpost
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1258
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1263
 msgid "West: Laboratory and Experiment Testing"
 msgstr "西面：实验室和实验测试"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1309
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1314
 msgid ""
 "I have triggered a trap. As long as I stay on this rune I will be safe, but "
 "once I step away, fire spirits will rise from the lava."
@@ -5936,19 +5809,19 @@ msgstr ""
 
 #. [message]: speaker=unit
 #. the feeling that they've triggered a trap
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1320
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1325
 msgid "Uh oh..."
 msgstr "啊哦……"
 
 #. [message]: speaker=unit
 #. no obvious effect yet, it triggers when that unit moves again
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1329
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1334
 msgid "Oh, nothing happened."
 msgstr "哦，没事发生。"
 
 #. [message]: speaker=Dacyn
 #. a walking corpse of a rat or spider
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1337
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1342
 msgid ""
 "That corpse has triggered a trap. When next it moves, fire spirits will rise "
 "from the lava."
@@ -5956,7 +5829,7 @@ msgstr "那具尸体触发了一个陷阱。当它下一次移动时，火灵将
 
 #. [message]: speaker=Dacyn
 #. the rune is on the floor in front of the door (using one of the terrains that make the rune occupy most of the hex)
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1389
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1394
 msgid ""
 "This gate is locked, and I recognize the petrification trap concealed within "
 "its guardian rune. I should avoid trying to open it."
@@ -5965,17 +5838,17 @@ msgstr ""
 
 #. [message]: speaker=unit
 #. the rune is on the floor in front of the door (using one of the terrains that make the rune occupy most of the hex)
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1400
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1405
 msgid "Looks like this gate is locked. I wonder if this rune opens it?"
 msgstr "看起来这个大门锁住了。我好奇这个符文能否打开它？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1447
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1452
 msgid "That was a petrification rune. It should wear off in a few moments."
 msgstr "这是一道石化符文。它将在几分钟后消失。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1454
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1459
 msgid ""
 "We are fortunate, that enemy has triggered a petrification rune. Be warned "
 "though, it will only last a few moments."
@@ -5983,7 +5856,7 @@ msgstr "我们很幸运，敌人激活了一个石化符文。但是请注意，
 
 #. [message]: speaker=unit
 #. the unit triggers the trap immediately
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1508
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1513
 msgid ""
 "Hmm, looks like a magic lamp. I’ve heard stories that these can grant "
 "wishes. Today must be my lucky day!"
@@ -5991,13 +5864,13 @@ msgstr ""
 "嗯，看起来像是个魔法灯。我听说过这些可以许愿的故事。今天肯定是我幸运的一天！"
 
 #. [message]: speaker=Jinn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1545
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1550
 msgid "WHO DARES DISTURB MY SLUMBER?"
 msgstr "谁敢打扰我的睡眠？"
 
 #. [message]: speaker=unit
 #. an item on a display rack, ready to be worn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1559
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1564
 msgid ""
 "This fine silken cloak would be priceless back in Wesnoth, but is useless to "
 "us here."
@@ -6005,54 +5878,54 @@ msgstr "在这片丝绸斗篷在韦诺肯定是无价之宝，但在这里对我
 
 #. [message]: speaker=unit
 #. 70, 55, or 45 gold
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1579
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1584
 msgid "This chest contains $gold gold!"
 msgstr "这个箱子里面有$gold金币！"
 
 #. [message]: speaker=unit
 #. there was a closed chest on this hex, and it's been opened
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1599
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1604
 msgid "It’s full of... toilet paper?!?"
 msgstr "里面全是…厕纸…？！？"
 
 #. [message]: speaker=unit
 #. and the unit immediately does that, changing a closed-gate terrain to open-gate
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1614
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1619
 msgid "I can unlock this gate from the inside."
 msgstr "我可以从里面打开这扇门。"
 
 #. [message]: speaker=Study Guard
 #. the Study Guard is a Deathblade (or Draug on hard difficulty) that's stood immobile in the doorway
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1635
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1640
 msgid "Who. Comes?"
 msgstr "谁。来？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1639
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1644
 msgid "Err... don’t mind me, I’m just taking a look around."
 msgstr "呃…别介意，我只是随便看看。"
 
 #. [message]: speaker=Study Guard
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1643
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1648
 msgid "Master. Is away. Intruders. Must die."
 msgstr "大师。不在。入侵者。必须死。"
 
 #. [message]: speaker=unit
 #. a quote from the journal written in SotA, also quoted in DiD
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1677
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1682
 msgid ""
 "What’s this? Looks like a book on necromancy? <i>‘To become a lich, one must "
 "first-</i>"
 msgstr "这是什么？看起来是本关于死灵术的书？ <i>欲成巫妖，身必先—</i>"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1681
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1686
 msgid "Drop that at once! That journal is dangerous!"
 msgstr "立刻放下！这本日记很危险！"
 
 #. [message]: speaker=Dacyn
 #. a book on necromancy
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1701
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1706
 msgid ""
 "I recognize this volume. Such a thing could be dangerous in the wrong hands. "
 "Perhaps I should hold on to it... for safekeeping."
@@ -6061,7 +5934,7 @@ msgstr ""
 "管。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1708
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1713
 msgid ""
 "... I recognize this volume. It is fortunate that I found it first; such a "
 "thing could be dangerous in the wrong hands. Perhaps I should hold on to "
@@ -6071,12 +5944,12 @@ msgstr ""
 "该把它保存起来……妥善保管。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1727
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1732
 msgid "There are a few loose pages on the ground here..."
 msgstr "这里有几页书散落在地上……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1731
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1736
 msgid ""
 "<i>Journal of Ravan — 13 Blackfire, 588 YW.\n"
 "\n"
@@ -6099,7 +5972,7 @@ msgstr ""
 "们将能够回答我一直在思考的一些问题。然而，似乎还有一块拼图仍然缺失。</i>"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1737
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1742
 msgid ""
 "<i>Journal of Ravan — 21 Whitefire, 589 YW.\n"
 "\n"
@@ -6121,7 +5994,7 @@ msgstr ""
 "碎，难以理解。他们试图告诉我什么？</i>"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1750
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1755
 msgid ""
 "This volume has something to do with a dwarf named Tharga... Thursag-"
 "something? The text is very faded."
@@ -6129,7 +6002,7 @@ msgstr ""
 "这卷书和一个矮人有点关系，他的名字叫萨嘎……瑟萨格-什么？文字已经褪色了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1761
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1766
 msgid ""
 "<i>Journal of Ravan — 5 Bleeding Moon, 597 YW.\n"
 "\n"
@@ -6150,7 +6023,7 @@ msgstr ""
 
 #. [message]: speaker=unit
 #. just flavortext, could be any books that are irrelevant to the story
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1775
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1780
 msgid ""
 "This shelf appears to be full of accounting ledgers detailing the movement "
 "of funds and goods hundreds of years ago."
@@ -6158,26 +6031,26 @@ msgstr "这个架子看起来装满了详细记录数百年前资金和货物流
 
 #. [message]: speaker=unit
 #. a wooden crate, using the items/box.png image
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1789
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1794
 msgid "This box is empty."
 msgstr "这个盒子是空的。"
 
 #. [message]: speaker=unit
 #. a wooden crate, using the items/box.png image
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1801
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1806
 msgid "Yuck, this box is full of pickled fingers!"
 msgstr "呸，这个盒子装满了腌制的手指！"
 
 #. [message]: speaker=unit
 #. a barrel, using items/barrel.png
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1813
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1818
 msgid ""
 "This cask of wine is from nearly 200 years ago! If only I was allowed to "
 "drink while on duty."
 msgstr "这桶酒是将近200年前酿造的！要是我能在干活的时候喝酒就好了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1827
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1832
 msgid ""
 "These three orbs must be ancient, but still pulse with some kind of dark "
 "energy. Just standing near them gives me a splitting headache."
@@ -6186,7 +6059,7 @@ msgstr ""
 "裂。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1840
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1845
 msgid ""
 "I’ve found a key! It must be magical; it started glowing as soon as I "
 "touched it."
@@ -6194,50 +6067,50 @@ msgstr "我找到一把钥匙！它一定有魔力；我碰一下就发光了。
 
 #. [message]: speaker=Cowardly Goblin
 #. Cowardly Goblin is male, and appears in just two events. This one, and the end-of-level event.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1873
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1878
 msgid "Aaah, humans! Run away!"
 msgstr "啊，人类！快跑！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1880
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1885
 msgid ""
 "I guess there are goblins living here. Well, that explains the lit torches."
 msgstr "我猜这里住着地精。嗯，这就解释了这些点着的火炬。"
 
 #. [message]: speaker=Thirsty Goblin
 #. the goblin has moved to a hex with a green potion bottle. After this he drinks it, gets poisoned, and then turns into a walking corpse.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1895
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1900
 msgid "Hey, this looks tasty!"
 msgstr "嘿，这看起来很美味！"
 
 #. [message]: speaker=unit
 #. the player's unit has moved to a hex with a blue potion, drunk it, and become slowed
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1954
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1959
 msgid "Ugh, my head hurts. Was this room always spinning?"
 msgstr "呃，我的头好疼。这个房间是不是一直都在旋转？"
 
 #. [message]: speaker=unit
 #. the player's unit has moved to a hex with a yellow potion, drunk it, and become poisoned
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1982
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:1987
 msgid ""
 "Blech, this tastes awful! Whatever used to be in here, it went bad long ago."
 msgstr "啧啧，真难喝！不管之前是什么东西，早就变质了。"
 
 #. [message]: speaker=unit
 #. the player's unit has moved to a hex with a grey potion, drunk it, and ...
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2005
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2010
 msgid "ACK! I’M DYING!"
 msgstr "啊！我要死了！"
 
 #. [message]: speaker=unit
 #. the grey potion
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2014
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2019
 msgid "Hah, just messing with you, it’s only water."
 msgstr "哈，只是逗你玩，这只是水而已。"
 
 #. [message]: speaker=second_unit
 #. the player's unit is outside the room with all of this in
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2043
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2048
 msgid ""
 "Look, a key! But it’s guarded by all those goblins... and there are ghouls "
 "in cages!"
@@ -6245,7 +6118,7 @@ msgstr "看，一把钥匙！但它被所有那些地精守卫着…并且还有
 
 #. [message]: speaker=second_unit
 #. the player's unit is outside the room with ghasts and goblins in, and there are a lot of campfires in there too
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2048
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2053
 msgid ""
 "The goblins’ eyes must be blinded by their fires. I still haven’t been "
 "spotted."
@@ -6253,66 +6126,66 @@ msgstr "地精们的眼睛一定被他们的火焰熏瞎了。我还没被发现
 
 #. [message]: speaker=unit
 #. rune on the floor that will open floor-to-ceiling gates
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2072
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2077
 msgid ""
 "Hmm, it looks like this rune is connected to those cages. I’ll bet I could "
 "get one of them open..."
 msgstr "嗯，看起来这个符文连接着那些笼子。我敢打赌我能打开其中一个……"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2074
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2079
 msgid "Yes, release some ghouls."
 msgstr "是的，释放一些食尸鬼。"
 
 #. [message]: speaker=Goblin Leader
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2098
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2181
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2103
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2186
 msgid "Aaahh!! The monsters have escaped!"
 msgstr "啊啊！！怪物逃跑了！"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2109
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2192
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2114
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2197
 msgid "No, keep them locked up."
 msgstr "不，让它们继续锁着。"
 
 #. [message]: speaker=Dacyn
 #. rune on the floor that will open floor-to-ceiling gates
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2133
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2138
 msgid ""
 "Ah, this is the control for the experiment testing cages. Should I open them?"
 msgstr "啊，这是实验测试笼子的控制装置。我应该打开它们吗？"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2135
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2140
 msgid "Yes, release all the ghouls."
 msgstr "是，释放所有食尸鬼。"
 
 #. [message]: speaker=Goblin Leader
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2219
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2224
 msgid "Humans! Get them!"
 msgstr "人类！抓住他们！"
 
 #. [message]: speaker=Goblin Leader
 #. death of a wolf rider's mount
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2240
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2246
 msgid "Noooo, wolfieeee!!!"
 msgstr "不，狼崽子！！！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2255
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2262
 msgid "Look what I found! This key started glowing as soon as I touched it."
 msgstr "看看我找到了什么！我一碰这个钥匙，它就开始发光了。"
 
 #. [message]: speaker=unit
 #. although there's no filter on this event, the location is only reachable by a flying unit, presumably a walking corpse bat or walking corpse drake
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2294
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2301
 msgid "Ruuuh... Brains..."
 msgstr "噜呜……脑子……"
 
 #. [message]: speaker=narrator
 #. This is an easter egg, and the details don't matter because there's no way to get the staff out of the room.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2300
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2307
 msgid ""
 "This legendary magical staff has the power to reshape reality at will! "
 "Unfortunately, this zombie is not intelligent enough to understand the "
@@ -6322,7 +6195,7 @@ msgstr ""
 "发现的物品的意义，仅仅感受到一个无生命的房间。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2342
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2349
 msgid ""
 "The Amulet should be just beyond that gate, within the inner sanctum. We "
 "will have to find a pair of magical keys to open the door."
@@ -6330,7 +6203,7 @@ msgstr ""
 "护身符应该就在那扇门后，位于内室之中。我们得找到一对魔法钥匙才能打开这道门。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2357
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2364
 msgid ""
 "Both keys are found! We can now enter the inner sanctum and retrieve the "
 "Amulet."
@@ -6338,33 +6211,33 @@ msgstr "两把钥匙都找到了！我们现在可以进入内室，取回护身
 
 #. [message]: speaker=Gweddry
 #. by this time Owaec is probably fighting orcs
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2388
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2395
 msgid "I hope Owaec hasn’t gotten into any trouble outside..."
 msgstr "我希望欧瓦埃克在外面没碰上任何麻烦……"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2414
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2421
 msgid "Are we ready to enter the inner sanctum?"
 msgstr "我们是否准备好进入内殿？"
 
 #. [option]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2416
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2423
 msgid "Yes, I’m ready."
 msgstr "是的，我准备好了。"
 
 #. [command]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2423
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2430
 msgid "Sanctum Guard"
 msgstr "密室守卫"
 
 #. [message]: speaker=Gweddry
 #. looking at it from about 3 indoor hexes away
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2459
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2466
 msgid "Is that... the Amulet?"
 msgstr "这是……护身符？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2463
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2470
 msgid ""
 "Yes. We now look upon one of the most powerful artifacts ever to taint "
 "Irdya. But first, we must clear out this room."
@@ -6373,23 +6246,23 @@ msgstr ""
 "这个房间。"
 
 #. [message]: speaker=Sanctum Guard
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2467
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2474
 msgid "TRESPASSERS!"
 msgstr "入侵者！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2471
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2478
 msgid "Prepare for incoming undead!"
 msgstr "准备迎接亡灵！"
 
 #. [event]
 #. [side]: type=Orcish Sovereign, id=Chief Dra-Nak
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2504
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2908
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:42
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2511
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2915
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:41
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:119
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:29
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:28
 msgid "Chief Dra-Nak"
 msgstr "德拉-纳克酋长"
 
@@ -6397,34 +6270,34 @@ msgstr "德拉-纳克酋长"
 #. the wyrms being the drakes in S09
 #. Talking about Owaec, who's waiting outside the sanctum, probably on a keep.
 #. Owaec probably hasn't recruited, but the entire recall list is available to him so they're presumably "here".
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2520
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2527
 msgid "What do we have here? This is what those wyrms were groveling about?"
 msgstr "我们这里有什么？这就是让那些巨龙低声下气的东西吗？"
 
 #. [message]: speaker=Chief Dra-Nak
 #. he's a chief from the Whitefangs because he's not the only one, just a particularly powerful one
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2525
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2532
 msgid ""
 "I’m Dra-Nak, Chief from the Whitefang clan. What’re you doing so far away "
 "from home, human?"
 msgstr "我是德拉-纳克，白牙氏族的酋长。你这么远离家乡是干什么的，人类？"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2529
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2536
 msgid ""
 "I am a lord of the Horse Clans, and we are here on Wesnoth business. You "
 "would do well not to bother us."
 msgstr "我是一位马背氏族领主，我们在此处理韦诺的事务。你们最好别来打扰我们。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2533
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2540
 msgid ""
 "Wesnoth business, huh. ...you’re not the first group of deserters I’ve "
 "caught fleeing the undead."
 msgstr "韦诺的事情，呵。…你们不是第一群被我抓住的逃离亡灵的逃兵。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2537
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2544
 msgid ""
 "I’ll tell you what. I’m a fair orc, I won’t take advantage of your "
 "situation. Maybe I can help you. Let’s make a deal."
@@ -6433,7 +6306,7 @@ msgstr ""
 "协议吧。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2541
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2548
 msgid ""
 "Those necromancers down south are paying me good coin to keep them supplied "
 "with corpses. Hand over, let’s say, eight of your soldiers as tribute, and "
@@ -6444,7 +6317,7 @@ msgstr ""
 "作为贡品，你们就可以自由地去做你的事了。我甚至还会分给你们一部分利润！"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2545
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2552
 msgid ""
 "Today I have been called shortsighted, then a coward, and now a deserter?! "
 "My honor will stand no more insult! Begone, fetid orc, lest I mount your "
@@ -6455,13 +6328,13 @@ msgstr ""
 
 #. [message]: speaker=Chief Dra-Nak
 #. This is the start of the second night, and around 4 orcs will enter the map this turn, and 3 more next turn.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2550
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2557
 msgid "(grinning) I was hoping you’d say that!"
 msgstr "（咧嘴笑）我就期望你会这么说！"
 
 #. [message]: speaker=Owaec
 #. this is a reminder to the player that Owaec is a leader and can recruit.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2567
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2574
 msgid ""
 "Gweddry may command the whole of our party, but do not forget that I too can "
 "recruit and recall! I will need soldiers to hold the line against these orcs."
@@ -6469,42 +6342,50 @@ msgstr ""
 "格威德利可以指挥我们整个队伍，但别忘了，我也可以征募和召回！我需要士兵来抵挡"
 "这些兽人。"
 
+#. [dummy]: id=amla_dummy
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2676
+msgid "AMLAs"
+msgstr "满级奖励"
+
+#. [dummy]: id=amla_dummy
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2677
+msgid ""
+"This veteran fighter has advanced one or more times past his maximum level, "
+"gaining increased damage each time."
+msgstr "这位资深战士已在最高等级之上进阶了一次或多次，每次都会获得伤害提升。"
+
 #. [message]
-#. Turn 21 (start of the fourth night) the second wave of orcs arrive and announce their plans.
-#. Around 6 orcs have just arrived, with 5 more next turn.
-#. There were 7 orcs in the first wave on turns 9 and 10, but the player has probably already handled them.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2637
+#. Medium-sized groups of orcs are arriving every 2 days to attack the player. This is one message they might say when they arrive.
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2725
 msgid "Time to chop some human heads!"
 msgstr "是时候砍些人类的脑袋了！"
 
 #. [message]
-#. Turn 33 (start of the sixth night) the next wave of orcs arrive.
-#. The latest group is 7 orcs, with more a turn behind them.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2651
+#. Medium-sized groups of orcs are arriving every 2 days to attack the player. This is one message they might say when they arrive.
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2732
 msgid "Keep attacking, hit ’em while the sun’s down!"
 msgstr "继续进攻，趁日落时分打击他们！"
 
 #. [message]
-#. Turn 45 (start of the eigth night) the next wave of orcs arrive.
-#. The latest group is 7 orcs, with more a turn behind them.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2665
+#. Medium-sized groups of orcs are arriving every 2 days to attack the player. This is one message they might say when they arrive.
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2739
 msgid "Chief’s orders, let’s get them!"
 msgstr "酋长的命令，抓住他们！"
 
 #. [message]
-#. Turn 51 (start of the ninth night), and from here on they're arriving every night rather than one night in two.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2678
+#. Medium-sized groups of orcs are arriving every 2 days to attack the player. This is one message they might say when they arrive.
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2746
 msgid "Burn and pillage!"
 msgstr "焚城掠地！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2768
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2775
 msgid "Excellent. Now..."
 msgstr "优秀。现在……"
 
 #. [message]: speaker=Gweddry
 #. before he picks up the amulet
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2775
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2782
 msgid ""
 "Wait, Dacyn, before you pick that up... are you sure this is the right "
 "decision? Even if you can wield it safely, something this evil will "
@@ -6514,7 +6395,7 @@ msgstr ""
 "此邪恶的东西无疑会腐蚀任何拥有它的人。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2779
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2786
 msgid ""
 "Why, I’m incredibly touched by your deep show of affection. I’m sure that "
 "will be of great comfort when thousands are massacred after Wesnoth loses "
@@ -6525,7 +6406,7 @@ msgstr ""
 
 #. [message]: speaker=Dacyn
 #. there's a short pause between the "deep show of affection" message and this one
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2789
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2796
 msgid ""
 "No, Gweddry, I am not sure. But I know of no other way to defeat Mal-"
 "Ravanal. I have tried once before. Even as a mage, Ravan’s powers near "
@@ -6537,7 +6418,7 @@ msgstr ""
 "许只有德法多大师才有机会。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2793
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2800
 msgid ""
 "This Amulet will give us the edge that I need. With it, I can open a gate to "
 "the Land of the Dead and pull Mal-Ravanal’s unholy spells out of this world."
@@ -6546,7 +6427,7 @@ msgstr ""
 "玛尔-拉瓦纳尔的邪恶咒语抽出这个世界。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2797
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2804
 msgid ""
 "But if what you said is true, the very same could be said of Ravan. How do "
 "you know you will not fall down the same path as well?"
@@ -6555,7 +6436,7 @@ msgstr ""
 "道路上堕落呢？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2806
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2813
 msgid ""
 "You are right, Gweddry. I cannot know. But I must try. If I do not, Wesnoth "
 "— nay, all of Irdya — will surely fall to ruin. As long as I try, there is "
@@ -6567,26 +6448,26 @@ msgstr ""
 "义。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2810
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2817
 msgid "(picks up the amulet)"
 msgstr "（拿起护身符）"
 
 #. [message]: speaker=Dacyn
 #. [message]
 #. on putting on the amulet, he's been dropped to 1 hp
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2858
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2868
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2865
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2875
 msgid "AAAAHHHH!"
 msgstr "啊啊啊啊！"
 
 #. [message]: speaker=Gweddry
 #. "everyone" being 6 units, or less
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2873
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2880
 msgid "Dacyn! Everyone stand back, give him some air."
 msgstr "达辛！各位站在后面，给他点空气。"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2877
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2884
 msgid ""
 "... do not fear, I am unharmed. I just... need a moment to catch my breath."
 msgstr "…别怕，我没事。我只是…需要一点时间喘口气。"
@@ -6594,7 +6475,7 @@ msgstr "…别怕，我没事。我只是…需要一点时间喘口气。"
 #. [message]: speaker=Chief Dra-Nak
 #. A wall of the inner sanctum (where the amulet was) has just exploded, revealing a cave that extends off the west edge of the map.
 #. Introduction implying that Whitefang has other chiefs, but that Dra-Nak is particularly powerful.
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2942
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2949
 msgid ""
 "Hah, did you think you were safe hiding back in here? Nobody can escape from "
 "Dra-Nak, greatest chief east of the Listra."
@@ -6604,7 +6485,7 @@ msgstr ""
 
 #. [message]: speaker=Cowardly Goblin
 #. male speaker
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2947
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2954
 msgid ""
 "See see! I told you there were humans in here! And I showed you the secret "
 "passage! Reward reward?"
@@ -6612,13 +6493,13 @@ msgstr "看看！我告诉你这里有人类！我还给你展示了秘密通道
 
 #. [message]: speaker=Chief Dra-Nak
 #. gives the Cowardly Goblin some gold
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2952
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2959
 msgid "Sure, here you go. You did well."
 msgstr "当然，给你。你做得很好。"
 
 #. [message]: speaker=Chief Dra-Nak
 #. presumably still 8 humans, unless the player has lost some
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2963
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2970
 msgid ""
 "As for you humans, you might as well convince your friends outside to "
 "surrender. Otherwise, we’ll slaughter you all starting with that injured old "
@@ -6629,7 +6510,7 @@ msgstr ""
 "始，把你们全部屠杀。我之前给你们公平做事的机会，但现在我们按我的方式办事。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2967
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2974
 msgid ""
 "I don’t know what these orcs want with us, but we can’t hope to escape with "
 "Dacyn so badly hurt."
@@ -6638,7 +6519,7 @@ msgstr ""
 "脱。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2971
+#: data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg:2978
 msgid "Very well, orc, we will surrender."
 msgstr "很好，兽人，我们投降。"
 
@@ -6648,7 +6529,7 @@ msgid "Captured"
 msgstr "被俘"
 
 #. [part]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:15
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:14
 msgid ""
 "After their surrender, Gweddry, Dacyn, and Owaec were promptly taken before "
 "the orcish chieftain, Dra-Nak. The rest were thrown into the prisons to "
@@ -6658,13 +6539,13 @@ msgstr ""
 "人则被投入监狱，等待审问……"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:94
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:413
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:93
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:410
 msgid "Prisoners"
 msgstr "囚犯"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:103
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:102
 msgid "Bats"
 msgstr "蝙蝠"
 
@@ -6672,7 +6553,7 @@ msgstr "蝙蝠"
 #. In S11, an orc with so much gold for recruitment that the player can't beat them, acts as a turn limit.
 #. In S12, a leader with a high but not unbeatable amount of gold.
 #. However, if Chief Dra-Nak survived S11 then S12's Varrak-Klar will be changed to an Orcish Sovereign and renamed to appear to be the Chief pursuing the escapees.
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:129
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:128
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:70
 msgid "Varrak-Klar"
 msgstr "瓦拉克-克拉尔"
@@ -6680,97 +6561,97 @@ msgstr "瓦拉克-克拉尔"
 #. [side]: type=Orcish Slurbow, id=Rakkha
 #. In S11, an orc with so much gold for recruitment that the player can't beat them, acts as a turn limit.
 #. In S12, a leader with a high but not unbeatable amount of gold.
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:155
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:154
 #: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:183
 msgid "Rakkha"
 msgstr "拉克哈"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:473
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:472
 msgid "Boja"
 msgstr "博加"
 
 #. [effect]: type=impact
 #. [effect]: type=impact, type=impact
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:633
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:649
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1076
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1090
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:632
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:648
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1081
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1095
 msgid "unarmed"
 msgstr "未武装"
 
 #. [message]: speaker=narrator
 #. Exactly four units are in this jail cell, identified as "role=escapee ..." in the po hints.
 #. 3 were in Gweddry's recall list, but escapee sidekick 2 deserted from another Wesnoth commander
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:687
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:686
 msgid ""
 "Several of Gweddry’s men find themselves locked away in a crude orcish cell."
 msgstr "格威德利的几位部下发现自己被关在一间粗陋的兽人牢房里。"
 
 #. [message]: role=escapee sidekick 1
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:692
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:691
 msgid "We’ve got to get out of here!"
 msgstr "我们得离开这儿！"
 
 #. [message]: role=escapee sidekick 2
 #. Speaker is the male deserter, however the other units don't know his backstory yet
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:697
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:696
 msgid "I’m sure your commanders will come and save us!"
 msgstr "我相信你的指挥官会来救我们的！"
 
 #. [message]: role=escapee sidekick 0
 #. Male speaker talking to male deserter, also the huge enemies changed in 1.17 from trolls to orcs
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:702
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:701
 msgid "What? Didn’t you see those huge orcs drag them away? It’s hopeless!"
 msgstr "什么？你没看到那些庞大的兽人把他们拖走了吗？没救了！"
 
 #. [message]: role=escapee sidekick 0
 #. Female speaker talking to male deserter, also the huge enemies changed in 1.17 from trolls to orcs
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:704
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:703
 msgid ""
 "female^What? Didn’t you see those huge orcs drag them away? It’s hopeless!"
 msgstr "什么？你没看到那些庞大的兽人把他们拖走了吗？没救了！"
 
 #. [message]: role=escapee leader
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:708
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:707
 msgid "Be quiet, you three! There’s something back here..."
 msgstr "安静，你们三个！这儿好像有……"
 
 #. [message]: role=escapee leader
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:713
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:712
 msgid ""
 "Look! There’s a gap in the wall over here. I think I can slip through if I "
 "clear away some of these rocks..."
 msgstr "看！这边墙上有条裂缝。我想要是能移开这些石块我就能挤过去了……"
 
 #. [message]: role=escapee leader
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:741
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:740
 msgid "Come on! This way!"
 msgstr "来吧！往这边走！"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:748
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:747
 msgid "Find Gweddry, Dacyn and Owaec"
 msgstr "找到格威德利、达辛和欧瓦埃克"
 
 #. [objective]: condition=lose
 #. Initially shown with 4 escapees.
 #. Later shown meaning all of the released prisoners. Some can die, just not all.
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:753
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1205
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:752
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1206
 msgid "Death of the escapees"
 msgstr "逃出的囚犯们死亡"
 
 #. [message]: speaker=unit
 #. the escapees' cell door
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:772
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:771
 msgid "The door won’t open from this side."
 msgstr "这扇门不能从这边打开。"
 
 #. [message]: role=escapee sidekick 1
 #. The speaker is male. The deserter, "escapee sidekick 2", will always be male.
 #. The other escapees, including the speaker, are 3 random units from the player's recall list.
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:792
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:791
 msgid ""
 "$deserter_name, I don’t recognize you, and you look like you’ve been locked "
 "up longer than the rest of us. How did you get here?"
@@ -6781,7 +6662,7 @@ msgstr ""
 #. [message]: role=escapee sidekick 1
 #. The speaker is female. The deserter, "escapee sidekick 2", will always be male.
 #. The other escapees, including the speaker, are 3 random units from the player's recall list.
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:795
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:794
 msgid ""
 "female^$deserter_name, I don’t recognize you, and you look like you’ve been "
 "locked up longer than the rest of us. How did you get here?"
@@ -6790,7 +6671,7 @@ msgstr ""
 "怎么到这里的？"
 
 #. [message]: role=escapee sidekick 2
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:800
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:799
 msgid ""
 "When the undead burned Tath, I got... lost. I have family up north, but I "
 "didn’t even get across the ford before some orcs captured me. They marched "
@@ -6801,58 +6682,58 @@ msgstr ""
 
 #. [message]: role=escapee leader
 #. The speaker is male
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:805
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:804
 msgid "(scowling) A deserter. We should lock you back in your cell."
 msgstr "（皱眉）一个逃兵。我们应将你重新锁回你的牢房。"
 
 #. [message]: role=escapee leader
 #. The speaker is female
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:807
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:806
 msgid "female^(scowling) A deserter. We should lock you back in your cell."
 msgstr "（皱眉）一个逃兵。我们应将你重新锁回你的牢房。"
 
 #. [message]: role=escapee sidekick 2
 #. "you" being an audience of three units
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:812
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:811
 msgid ""
 "No, please, you don’t understand! The undead are everywhere! I didn’t want "
 "to die like all my friends..."
 msgstr "不，求求你，你不明白！亡灵无处不在！我不想像我的朋友们一样死去……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:826
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:825
 msgid "Do you hear something coming from those pits?"
 msgstr "你听到那些坑里有声音吗？"
 
 #. [message]: race=bats
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:834
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:833
 msgid "Neep! Neep!"
 msgstr "呢！呢！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:848
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:847
 msgid "Ack! Get away from me!"
 msgstr "啊！离我远点！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:861
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:860
 msgid "This tunnel seems to go deeper into the caves. We can’t go that way."
 msgstr "这隧道似乎通向洞穴深处。我们不能往那边走。"
 
 #. [message]: role=escapee sidekick 0
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:878
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:877
 msgid ""
 "How do we know these caves aren’t all dead ends? We might be stuck wandering "
 "until we die of thirst!"
 msgstr "我们怎么知道这些洞穴不全是死胡同？我们可能会被困着到处乱逛直到渴死！"
 
 #. [message]: role=escapee leader
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:882
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:881
 msgid "You’re welcome to go back to your cell."
 msgstr "你可以回到你的牢房。"
 
 #. [message]: role=escapee sidekick 2
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:900
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:899
 msgid ""
 "Even if we do find your commanders and escape, maybe we should consider "
 "staying in the north? It’s tranquil, and quiet.... and there’s no undead..."
@@ -6861,12 +6742,12 @@ msgstr ""
 "没有亡灵……"
 
 #. [message]: role=escapee sidekick 0
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:904
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:903
 msgid "I didn’t come all this way just to give up at the words of a deserter!"
 msgstr "我一路走来，并不是为了在一个逃兵的话面前放弃的！"
 
 #. [message]: role=escapee leader
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:908
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:907
 msgid ""
 "Let’s focus on escaping the orcs before worrying about the future. Now "
 "quiet, I smell something foul up ahead."
@@ -6874,7 +6755,7 @@ msgstr ""
 "让我们先集中精力逃离兽人，然后再考虑未来。现在安静点，我闻到前方有异味。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:926
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:925
 msgid ""
 "Ugh, here’s where that wretched stench is coming from. This must be the "
 "orcish storeroom, full of their discarded gear and trash. At least we can "
@@ -6884,12 +6765,12 @@ msgstr ""
 "和垃圾。至少我们能找到一些合适的武器。"
 
 #. [floating_text]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:934
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:933
 msgid "weapons restored"
-msgstr ""
+msgstr "复原的武器"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:955
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:954
 msgid ""
 "And look, our captured equipment and provisions are here too! I’ve recovered "
 "supplies worth $gold_amount_S11 gold."
@@ -6897,7 +6778,7 @@ msgstr ""
 "看，我们的战利品和补给也在这里！我已找回了价值$gold_amount_S11金币的物资。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:989
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:988
 msgid ""
 "The other prison cells should be to the north of that chamber. If we can get "
 "past those guards we could set everyone free."
@@ -6906,28 +6787,28 @@ msgstr ""
 "人了。"
 
 #. [message]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:998
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:997
 msgid "But there’s too many of them!"
 msgstr "但它们的人太多了！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1002
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1001
 msgid "Hmm... I have an idea."
 msgstr "呣……我有个主意。"
 
 #. [message]: id=$unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1060
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1059
 msgid "So, how do I look?"
 msgstr "那，我看上去如何？"
 
 #. [message]: id=$unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1064
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1063
 msgid "I’ll try to slip past the guards. You wait here."
 msgstr "我去试试溜过那些守卫。你们在这儿等着。"
 
 #. [message]: speaker=Chief Dra-Nak
 #. Gweddry, Dacyn and Owaec are being held by guards in front of Dra-Nak's throne
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1111
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1110
 msgid ""
 "You’ve been a difficult prize to capture, but well worth the cost! Human "
 "corpses may not sell as well as dwarf or drake tribute, but with this many "
@@ -6938,7 +6819,7 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. The nearest guards are orcs, but there are drakes guarding the edge of the room.
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1116
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1115
 msgid ""
 "Drakes, surely you can see that this orc does not have your best interests "
 "at heart? He is bleeding your numbers to fund his empire while your leader "
@@ -6948,7 +6829,7 @@ msgstr ""
 "助他的帝国，而你们的领导者却在一旁袖手旁观！"
 
 #. [message]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1120
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1119
 msgid ""
 "I follow the Ways of our Flight.\n"
 "Mortic is Aspirant.\n"
@@ -6959,7 +6840,7 @@ msgstr ""
 "吾从其命。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1148
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1147
 msgid ""
 "You Wesnothians still don’t get it? These weaklings <i>need</i> me! Before I "
 "came, this place was a wasteland, with drake, dwarf, and naga fighting over "
@@ -6969,7 +6850,7 @@ msgstr ""
 "矮人和娜迦在争夺残羹剩饭，还在雪中流血。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1152
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1151
 msgid ""
 "I united them all under my banner, bringing <i>peace</i> and <i>order</i> to "
 "these mountains! And once I sell you off, we will have enough money and "
@@ -6981,7 +6862,7 @@ msgstr ""
 "子民开启一个全新的黄金时代！"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1156
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1155
 msgid ""
 "You murder your allies and call it peace? Bah, this place will only know "
 "peace once you are dead!"
@@ -6990,7 +6871,7 @@ msgstr ""
 
 #. [message]: speaker=Chief Dra-Nak
 #. Owaec has attacked the orc
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1185
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1186
 msgid ""
 "Hah, that almost hurt! I’m gonna enjoy shipping you lot down south. Maybe "
 "this time, the necromancers will let me watch..."
@@ -7000,7 +6881,7 @@ msgstr ""
 
 #. [message]: speaker=unit
 #. speaker is the escapee wearing the orc disguise, there are around 10 guards
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1192
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1193
 msgid ""
 "Opening the cells should confuse the guards for a moment. But I better not "
 "get too close to them..."
@@ -7009,20 +6890,20 @@ msgstr "打开牢门应该可以把守卫们迷惑一段时间。但我最好还
 #. [objective]: condition=win
 #. At least one cell is still locked. There's one with 8 Wesnothians, one with 6 Wesnothians,
 #. and one containing 4 Wesnothians plus 2 Drakes.
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1200
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1201
 msgid "Release the other prisoners"
 msgstr "释放其他囚犯"
 
 #. [message]: speaker=unit
 #. while the speaker is still in disguise
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1277
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1278
 msgid ""
 "Here’s one of the prison cells! As soon as I open this, all hell is going to "
 "break loose."
 msgstr "这是牢房之一！我一打开这个，所有地狱中的人都会逃脱。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1294
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1295
 msgid ""
 "I’m already well-equipped, but we’ll have to pay upkeep to arm and armor "
 "each prisoner I free. I hope we’ll have enough gold left over for the next "
@@ -7033,40 +6914,40 @@ msgstr ""
 
 #. [message]: speaker=unit
 #. prompt to the player
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1328
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1329
 msgid "Open the cell?"
 msgstr "打开牢房？"
 
 #. [option]
 #. choice when prompted "open the cell?"
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1331
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1332
 msgid "Yes! <i>(freed units will incur upkeep)</i>"
 msgstr "是的！<i>（释放的单位将产生维护费用）</i>"
 
 #. [option]
 #. choice when prompted "open the cell?"
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1362
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1363
 msgid "Not yet..."
 msgstr "还不到时候……"
 
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1369
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1370
 msgid "Huzzah, we’re free at last!"
 msgstr "万岁，我们终于自由了！"
 
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1370
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1371
 msgid "Hooray, we’re rescued!"
 msgstr "太好了，我们得救了！"
 
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1371
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1372
 msgid "Yes! Get us out of here!"
 msgstr "是！带我们离开这里吧！"
 
 #. [message]: speaker=Ga'all
 #. Ga'all and Verash are drakes from S10
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1376
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1377
 msgid ""
 "I am free!\n"
 "Never again shall I be prisoner!"
@@ -7076,7 +6957,7 @@ msgstr ""
 
 #. [message]: speaker=Verash
 #. Ga'all and Verash are drakes from S10, this is followed by Verash killing Ga'all
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1382
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1383
 msgid ""
 "You disobey the Aspirant.\n"
 "For your treachery,\n"
@@ -7087,46 +6968,46 @@ msgstr ""
 "你的惩罚是死亡。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1449
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1450
 msgid "The guards are distracted! Let us make our daring escape!"
 msgstr "守卫被引开了！让我们大胆地逃跑！"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1454
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1455
 msgid "Move Gweddry, Dacyn, or Owaec to the south-west exit"
 msgstr "移动格威德利，达辛或欧瓦埃克至西面出口"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1458
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1459
 msgid "Release the remaining prisoners"
 msgstr "释放剩下的囚犯"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1476
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1477
 msgid "Save as much gold as possible for the next scenario!"
 msgstr "尽可能为下一个场景多保存一些金币！"
 
 #. [message]: speaker=Chief Dra-Nak
 #. shouted to the two leaders who are positioned outside the orcs' caves, happens 2 turns after the main escape starts
 #. combined with removing shroud to reveal that those two leaders recruited last turn (and have full castles on normal or hard)
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1548
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1527
 msgid "The prisoners are escaping! Get in here and stop them!"
 msgstr "囚犯们正在逃跑！进来阻止他们！"
 
 #. [message]: speaker=Rakkha
 #. orc leader who was guarding against external threats sends troops into the orcs' throneroom
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1563
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1542
 msgid "Protect the Chief!"
 msgstr "保护酋长！"
 
 #. [message]: speaker=Varrak-Klar
 #. orc leader who was guarding against external threats sends troops into the orcs' throneroom
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1568
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1547
 msgid "Into the caves!"
 msgstr "进入洞穴！"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1578
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1557
 msgid ""
 "Guess we’re on the run again! My mercenary boys back home woulda made short "
 "work o’ these Whitefang punks... I sure am missin’ the Estmarks right about "
@@ -7136,13 +7017,13 @@ msgstr ""
 "真的很想念东界了。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1585
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1564
 msgid "Everyone hurry, we have to get out of here!"
 msgstr "大家赶快，我们得离开这儿！"
 
 #. [message]: speaker=Owaec
 #. 3 turns after the main escape starts
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1608
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1587
 msgid ""
 "Such carnage in this dark confined cave... how I long to once again gaze "
 "upon the rolling plains of my homeland. These lands are cold, but the "
@@ -7153,7 +7034,7 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. "there" being the Horse Clans' plains
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1613
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1592
 msgid ""
 "Wesnoth’s best horses and much of Weldyn’s food comes from there. I’m sure "
 "it’s well-defended, despite never having visited there myself."
@@ -7163,7 +7044,7 @@ msgstr ""
 
 #. [message]: speaker=Owaec
 #. "them" being the Horse Clans' plains
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1618
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1597
 msgid ""
 "There is naught that I can speak that would truly do them justice! You will "
 "have to see the plains yourself to appreciate their majesty."
@@ -7172,101 +7053,103 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. "their" being the Horse Clans' plains
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1623
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1602
 msgid "Then let us return quickly to Wesnoth to aid in their defense!"
 msgstr "让我们赶快回到韦诺，帮助他们的防守！"
 
 #. [message]: speaker=Chief Dra-Nak
 #. Boja is the name of the cave bear
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1638
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1617
 msgid "Hey, who are you? Boja, sic ’em!"
 msgstr "嘿，你是谁？博加，抓住他们！"
 
 #. [message]: speaker=$unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1642
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1621
 msgid "Uh oh!"
 msgstr "啊哦！"
 
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1700
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1679
 msgid "70 gold"
 msgstr "70金币"
 
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1700
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1679
 msgid "You’ve pillaged 70 orcish gold pieces!"
 msgstr "你掠夺了70块兽人的金币！"
 
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1701
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1680
 msgid "115 gold"
 msgstr "115金币"
 
 #. [scenario]: id=11_Captured
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1701
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1680
 msgid "You’ve pillaged 115 orcish gold pieces!"
 msgstr "你掠夺了115块兽人的金币！"
 
 #. [message]: speaker=unit
 #. goblin with a ring of invisibility
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1722
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1701
 msgid "Oooh so shiny, my precious... what a great gift from the Chief..."
 msgstr "哇哦，这么闪亮，我的宝贝……这是酋长送来的大礼……"
 
 #. [message]: speaker=unit
 #. goblin with a ring of invisibility (although not enough sense to wear it when running away)
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1727
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1706
 msgid "Aaah! Who’re you?! Run away run away!"
 msgstr "啊！你是谁？！快跑，快跑！"
 
 #. [message]: speaker=second_unit
 #. unit who discovered the goblin with a ring of invisibility
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1734
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1713
 msgid "Hmm, looks like he dropped something."
 msgstr "嗯，他好像掉了什么东西。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1752
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1731
 msgid ""
 "This looks like a disused mineshaft. I don’t feel any fresh air, so we "
 "shouldn’t expect to escape this way."
 msgstr ""
+"这看起来像是一处废弃的矿井。我感觉不到任何新鲜空气，所以别指望能从这条路逃出"
+"去。"
 
 #. [message]: speaker=unit
 #. if the disguised unit runs out of the caves alone, without rescuing any other prisoners
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1774
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1753
 msgid "Phew! I made it."
 msgstr "哟！我成功了。"
 
 #. [message]
 #. if the disguised unit runs out of the caves alone, without rescuing any other prisoners
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1784
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1763
 msgid "Where are you going?! Come back!"
 msgstr "你去哪儿？！回来！"
 
 #. [message]: speaker=unit
 #. One of the main heroes gets outside, triggering the victory condition
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1802
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1781
 msgid "I’ve reached the exit! We’ll have to make a run for it!"
 msgstr "我已经到达出口！我们必须赶紧跑！"
 
 #. [message]
 #. The player didn’t open all the cells before moving a hero to the exit and triggering the victory event
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1807
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1786
 msgid "Wait, you can’t leave us behind!"
 msgstr "等等，你们不能把我们落下！"
 
 #. [message]: speaker=Chief Dra-Nak
 #. immediate response to Boja's death
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1833
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1812
 msgid "You killed my bear, you filthy humans! You’ll pay for that!"
 msgstr "你们杀了我的熊，你们这些肮脏的人类！你们会为此付出代价的！"
 
 #. [message]: speaker=Chief Dra-Nak
 #. [message]: speaker=Varrak-Klar
 #. last breath event for Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1870
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:970
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1849
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:969
 msgid ""
 "Curse you all! Why couldn’t you have just died as tribute like everyone "
 "else? Now my glorious golden Empire will never be..."
@@ -7276,7 +7159,7 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. die event for Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1891
+#: data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg:1870
 msgid "Look, he was carrying the key to their treasury!"
 msgstr "看，他拿着他们金库的钥匙！"
 
@@ -7597,18 +7480,17 @@ msgstr "唉，我做了什么？如此多的韦诺勇士，被遗弃在荒野中
 
 #. [message]
 #. Said by any left-behind unit except ogres (they can't speak fluently) and Hahid al-Ali (it would be very out of character for him).
-#. TODO in 1.19: the "we" in this is a typo. It should be "you must ride ..."
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:703
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:702
 msgid ""
-"At least you three commanders are safe. From here, we must ride swift, ride "
+"At least you three commanders are safe. From here, you must ride swift, ride "
 "strong, and ride to save all of Wesnoth!"
 msgstr ""
-"至少你们三位指挥官是安全的。从这里开始，你们必须迅速行动，全力以赴，拯救韦诺"
-"的所有人！"
+"至少你们三位指挥官平安无事。从此刻起，你们必须策马疾驰、奋勇前行，去拯救整个"
+"韦诺！"
 
 #. [message]: speaker=Owaec
 #. either got everyone across or left behind at most one L2 or L3 unit
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:711
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:710
 msgid ""
 "Huzzah, we have escaped the northerners! A true Clansman would never "
 "willingly leave his companions behind, and so have we clutched victory from "
@@ -7618,7 +7500,7 @@ msgstr ""
 "利，从失败的口中夺回！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:728
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:727
 msgid ""
 "Yes, yes, (cough)(cough) that’s all well and good. With the bridge "
 "destroyed, the orcs cannot (cough) cross, but what of the drakes?"
@@ -7626,7 +7508,7 @@ msgstr ""
 "是的，是的，（咳）（咳）这都很好。桥梁被毁，兽人不能（咳）通过，但龙人呢？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:735
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:734
 msgid ""
 "(cough) And with the drakes defeated, (cough)(cough) no enemies will be able "
 "to pursue us. Now, it is finally time for us to once again travel toward "
@@ -7637,7 +7519,7 @@ msgstr ""
 
 #. [message]: race=orc
 #. Spoken to Mortic, but at this point it's possible that all the orc leaders are dead, in which case it doesn't get said.
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:753
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:752
 msgid ""
 "Useless pathetic ugly weakling wyrms! Fly across and chase after them, or "
 "we’ll sell you <i>all</i> to the necromancers!"
@@ -7647,7 +7529,7 @@ msgstr ""
 
 #. [message]: speaker=Mortic
 #. to his fellow drakes, and any surviving orcs
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:761
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:760
 msgid ""
 "Dra-Nak is dead,\n"
 "His armies weakened,\n"
@@ -7659,7 +7541,7 @@ msgstr ""
 
 #. [message]: speaker=Mortic
 #. to his fellow drakes, and any surviving orcs
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:771
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:770
 msgid ""
 "Dra-Nak is feeble,\n"
 "His armies weakened,\n"
@@ -7671,7 +7553,7 @@ msgstr ""
 
 #. [message]: speaker=Mortic
 #. to his fellow drakes, and any surviving orcs
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:780
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:779
 msgid ""
 "Long has our Honor been stained.\n"
 "No longer shall it be.\n"
@@ -7685,12 +7567,12 @@ msgstr ""
 
 #. [message]: speaker=$found_unit.id
 #. Speaker is an orc, and Mortic is flying towards them. "What? Hey!" *gets killed by Mortic*
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:806
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:805
 msgid "Wha— hey!"
 msgstr "啥—嘿！"
 
 #. [message]: speaker=Mortic
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:825
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:824
 msgid ""
 "The Hunt is called!\n"
 "The orcs our prey!\n"
@@ -7701,14 +7583,14 @@ msgstr ""
 "莫提克翼群，吾等战之！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:862
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:861
 msgid ""
 "Hurry! If we cannot secure a position on the west bank, the drakes will "
 "surely fly behind and cut off our retreat!"
 msgstr "快！如果我们不能在河西岸占领阵地，龙人肯定会在后面飞来切断我们的退路！"
 
 #. [message]: speaker=Mortic
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:869
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:868
 msgid ""
 "The sun arises.\n"
 "Second and third Wings,\n"
@@ -7720,30 +7602,30 @@ msgstr ""
 
 #. [message]
 #. spoken by the leader of either orc side. Lots of drakes appear immediately after this.
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:885
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:884
 msgid ""
 "We need help over here! Where are the rest of those lousy drakes? They "
 "should be in position by now!"
 msgstr "我们这里需要支援！那些讨厌的龙人在哪里？他们现在应该已经到位了！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:913
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:912
 msgid "Gel’ka"
 msgstr "杰尔卡"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:918
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:917
 msgid "We have not crossed the bridge in time. Now we will all be killed!"
 msgstr "我们没有及时过这座桥。现在我们都会被杀掉的！"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:929
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:928
 msgid ""
 "I can hardly believe it! We didn’t need to destroy the bridge after all."
 msgstr "我几乎不能相信！我们不用摧毁这座桥。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:933
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:932
 msgid ""
 "Huzzah, a glorious victory in the name of the Clans! Man will never flee "
 "from orc and drake; we have taught these northerners not to trifle with "
@@ -7753,7 +7635,7 @@ msgstr ""
 "北方人不要轻视韦诺！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:937
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:936
 msgid ""
 "(cough)(cough) Yes, yes, very well, well done. (cough) Now, it is finally "
 "time for us to see what has become of Wesnoth in our absence."
@@ -7762,18 +7644,18 @@ msgstr ""
 "时候韦诺发生什么了。"
 
 #. [message]: speaker=Varrak-Klar
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:964
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:963
 msgid "Graahh! Stupid humans..."
 msgstr "呱啦！愚蠢的人类……"
 
 #. [message]: speaker=Mortic
 #. Aspirant is a drake military rank
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:986
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:985
 msgid "I am Aspirant no more."
 msgstr "吾非竞位者矣。"
 
 #. [message]: speaker=Rakkha
-#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:999
+#: data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg:998
 msgid "I hate you! Hate... hate... hate you..."
 msgstr "我恨你！恨……恨……恨你……"
 
@@ -7783,12 +7665,12 @@ msgid "Spoils of War"
 msgstr "战利品"
 
 #. [part]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:26
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:27
 msgid "Part III: Wesnoth at War"
 msgstr "第三部：战争中的韦诺"
 
 #. [part]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:39
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:40
 msgid ""
 "As Gweddry, Owaec, and Dacyn fled across the Listra, a frenzy of shouts, "
 "screams, and roars broke out from behind. Neither the orcs nor the drakes "
@@ -7798,113 +7680,129 @@ msgstr ""
 "尖叫和咆哮。兽人和龙人都没有试图追击。"
 
 #. [part]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:44
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:45
 msgid ""
 "Leaving the tumultuous wildlands far behind, the soldiers of Wesnoth "
 "prepared to cross the Great River once more and return to their homeland..."
 msgstr "韦诺的士兵们远离喧嚣的荒野，准备再次渡过泰河，返回家园……"
 
-#. [side]: type=Death Knight, id=Ducatithil
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:253
-msgid "Ducatithil"
-msgstr "杜卡提希尔"
-
 #. [side]: type=Necromancer, id=Mal-Yrna, gender=female
 #. female necromancer, will be renamed to Mal-Mana if Mal-Mana wasn't killed in a previous scenario
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:279
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:275
 msgid "Mal-Yrna"
 msgstr "玛尔-尔娜"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:441
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:421
+msgid "Ducatithil"
+msgstr "杜卡提希尔"
+
+#. [event]
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:448
 msgid "Vaenyc"
 msgstr "瓦尼克"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:453
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:460
 msgid "Vovan"
 msgstr "沃凡"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:465
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:840
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:913
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:995
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1077
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1244
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:472
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:868
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:941
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1023
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1105
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1272
 msgid "Gaoler"
 msgstr "狱卒"
 
+#. [event]
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:482
+#: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:804
+msgid "150 gold"
+msgstr "150金币"
+
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:478
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:504
 msgid "Rescue as many prisoners as possible (6 groups arrive soon)"
 msgstr "营救尽可能多的战俘（6组就要到来）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:485
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:511
 msgid "Rescue as many prisoners as possible (5 groups arrive soon)"
 msgstr "营救尽可能多的战俘（5组就要到来）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:492
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:518
 msgid "Rescue as many prisoners as possible (4 groups arrive soon)"
 msgstr "营救尽可能多的战俘（4组就要到来）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:499
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:525
 msgid "Rescue as many prisoners as possible (3 groups arrive soon)"
 msgstr "营救尽可能多的战俘（3组就要到来）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:506
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:532
 msgid "Rescue as many prisoners as possible (2 groups arrive soon)"
 msgstr "营救尽可能多的战俘（2组就要到来）"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:513
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:539
 msgid "Rescue as many prisoners as possible (1 group arrives soon)"
 msgstr "营救尽可能多的战俘（1组就要到来）"
 
 #. [objective]: condition=win
 #. Mal-Yrna, a female necromancer
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:521
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:547
 msgid "Defeat the southern necromancer"
 msgstr "击败南面的死灵法师"
 
 #. [objective]: condition=lose
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:525
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:551
 msgid "Death of Owaec"
 msgstr "欧瓦埃克死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:534
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:560
 msgid "Death of Terraent"
 msgstr "特拉恩特死亡"
 
 #. [note]
 #. two prisoners and one jailer per gang
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:550
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:576
 msgid "Prisoner gangs will alternate arriving on north and south paths."
 msgstr "每群战俘将会轮流沿北边和南边的路线到达。"
 
 #. [note]
 #. "enemy" in this case meaning "player's unit"
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:554
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:580
 msgid "Bats prefer to fly towards the nearest enemy."
 msgstr "蝙蝠倾向于飞向最近的敌人。"
 
 #. [message]: id=Owaec,Terraent
-#. TODO for 1.19? There's a cut-scene running up to this, but it's unclear what's happened until I read the WML and found that player's full starting roster is exactly one *horseman* for this scenario.
-#. The fastest-moving of the player's units has been trying to catch up with a bat, but the bat has flow over the river to the Mal-Yrna / Mal-Mana.
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:595
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:619
 msgid ""
-"Alas, I have failed in my mission! The undead scout has already reported "
-"back to its mistress."
-msgstr "唉，我的任务失败了！亡灵侦察兵已经回去向女主人报告了。"
+"Alas, my long days of riding have been for naught. I could not catch the "
+"undead scout before it could report back to its mistress!"
+msgstr ""
+"唉，我连日策马奔驰都徒劳无功了。我没能赶在亡灵侦察兵向其女主人回报之前将它截"
+"下！"
+
+#. [message]: id=Owaec,Terraent
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:623
+msgid ""
+"Gweddry had hoped we might take this necromancer by surprise. But now that "
+"she is alerted, and with the rest of our army yet weeks away, she will have "
+"more than enough time to prepare for our arrival."
+msgstr ""
+"格威德利原本希望我们能出其不意地拿下这名死灵法师。但如今她已被惊动，而我军其"
+"余部队还要数周才能抵达，她将有充裕的时间为我们的到来做好准备。"
 
 #. [message]: speaker=Mal-Yrna
 #. speaking to a bat
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:605
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:633
 msgid ""
 "Minion, what’s this? Soldiers of Wesnoth approach from the north? That area "
 "should have been cleansed over a month ago."
@@ -7912,38 +7810,38 @@ msgstr ""
 "小兵，这是什么？韦诺士兵从北方逼近？那个区域应该在一个月前就被清理干净了。"
 
 #. [message]: speaker=Mal-Yrna
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:609
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:637
 msgid ""
 "No matter. Bring in the next batch of prisoners. I have need of them a "
 "little sooner than expected."
 msgstr "无论怎样，把下一批囚犯带来。我比预期的更早一些需要他们。"
 
 #. [message]: speaker=Vovan
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:617
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:645
 msgid "Wait a moment, can we talk about thi-"
 msgstr "等一下，我们可以谈谈这——"
 
 #. [message]
 #. Vovan has been turned into a ghoul, and the other prisoner has been too.
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:623
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:651
 msgid "I... Hunger..."
 msgstr "我……饿……"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:628
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:656
 msgid ""
 "By the Clans, she wields slaves as weapons! This injustice will not stand!"
 msgstr "以氏族之名，她以奴隶为武器！这种不公不容存在！"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:632
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:660
 msgid ""
 "By all that is holy, she wields slaves as weapons! This evil will not stand!"
 msgstr "凭所有神圣之物，她以奴隶为武器！这种邪恶不容存在！"
 
 #. [message]: id=Owaec,Terraent
 #. two dwarves, with a Deathblade as the jailer
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:646
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:674
 msgid ""
 "More prisoners approach from the northwest! I have not the time to depart "
 "and return with Gweddry, or those dwarves will surely be slain."
@@ -7952,14 +7850,14 @@ msgstr ""
 "会被杀死。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:650
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:678
 msgid ""
 "I may have failed my original mission, but in the name of the Clans, I will "
 "not fail these prisoners now!"
 msgstr "我可以在原来的任务下失败，但以氏族之名，我现在不会辜负这些战俘！"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:654
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:682
 msgid ""
 "I may have failed my original mission, but by the holy Light, I will not "
 "fail these prisoners now!"
@@ -7967,37 +7865,37 @@ msgstr "我可以在原来的任务下失败，但在圣光之下，我现在不
 
 #. [message]: speaker=Mal-Yrna
 #. the speaker was renamed to Mal-Mana at the start
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:671
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:699
 msgid ""
 "Wait — I remember you! You’re one of the ones who fled from me last autumn "
 "near Soradoc!"
 msgstr "等等——我记得你了！你是去年秋天在索拉多克附近逃走的那些人之一！"
 
 #. [message]: speaker=Mal-Yrna
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:675
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:703
 msgid ""
 "This time I’ve traded my bats for ghouls. There’s no way you’ll escape now!"
 msgstr "这次我把蝙蝠换成食尸鬼。你现在逃不掉了！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:806
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:834
 msgid "Nargaril"
 msgstr "纳加里尔"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:823
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:851
 msgid "Urmarol"
 msgstr "乌尔马若尔"
 
 #. [message]: speaker=Nargaril
 #. to a Deathblade
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:848
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:876
 msgid "Get yer filthy chains off my wrists, ye pile o’ bones!"
 msgstr "把你那臭气熏天的锁链从我的手腕上拿开，你这堆骨头！"
 
 #. [message]: speaker=Urmarol
 #. "Thank you kindly for freeing us! My runesmithing arts are not meant to be used outside of knalga, but I think now is an exception. I just hope the East Gate didn't fare too bad after I was captured..."
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:862
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:890
 msgid ""
 "Thank ye kindly fer freein’ us! Me runesmithin’ arts are not meant ta be "
 "used outside o’ Knalga, but methinks now is an exception. I just hope tha "
@@ -8007,30 +7905,30 @@ msgstr ""
 "我只希望我在被俘获之后，东门不要受太大的损害……"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:879
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:907
 msgid "Vinreddoc"
 msgstr "温雷多克"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:896
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:924
 msgid "Tunreoryr"
 msgstr "图内罗伊尔"
 
 #. [message]: speaker=Vinreddoc
 #. spoken between two prisoners, "them" being the undead forces
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:921
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:949
 msgid "How are there so many of them? Is this the end of all Wesnoth?"
 msgstr "他们怎么这么多？这是整个韦诺的终结了吗？"
 
 #. [message]: speaker=Tunreoryr
 #. spoken between two prisoners
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:926
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:954
 msgid "Don’t worry. I’m sure the Crown has a plan..."
 msgstr "别担心，我相信王国有计划……"
 
 #. [message]: speaker=Vinreddoc
 #. Vinreddoc is a mage, but with random gender
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:940
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:968
 msgid ""
 "Thank you! When the undead overran the academy I thought I was dead for "
 "sure. I just wonder what has happened to my friends..."
@@ -8039,45 +7937,45 @@ msgstr ""
 "事……"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:944
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:972
 msgid "Take heart! As long as there is Light, hope always remains."
 msgstr "鼓起勇气！只要有光明，希望就永远存在。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:961
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:989
 msgid "Ugzush"
 msgstr "乌兹什"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:978
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1006
 msgid "Hibro"
 msgstr "希布罗"
 
 #. [message]: speaker=Hibro
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1005
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1033
 msgid "I’ll take you all on! As soon as I get out of these chains..."
 msgstr "我会把你们全部干掉！只要我摆脱了这些锁链……"
 
 #. [message]: speaker=Gaoler_Orcs
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1009
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1037
 msgid "Silence. Orcs. March."
 msgstr "安静。兽人。前进。"
 
 #. [message]: speaker=Ugzush
 #. he's just been rescued
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1023
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1051
 msgid ""
 "Cruddy undead think they can chain me up! I’ll grind their bones into dust!"
 msgstr "脏兮兮的亡灵以为他们可以锁住我！我会把他们的骨头磨成尘土！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1040
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1068
 msgid "Syner"
 msgstr "西纳"
 
 #. [message]: speaker=Gaennell
 #. this Dark Adept is a prisoner too
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1088
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1116
 msgid ""
 "I swear, it was an accident! Please, if you’ll just let me talk to Mel "
 "Guthrak, I’m sure this can all be straightened out."
@@ -8085,7 +7983,7 @@ msgstr "我发誓，这是意外！请让我和梅尔·古斯拉克谈谈，我�
 
 #. [message]: speaker=Syner
 #. to Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1093
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1121
 msgid ""
 "Your time is done, necromancer. If I have one small comfort, it’s that I’ll "
 "get to watch you die alongside me."
@@ -8095,13 +7993,13 @@ msgstr ""
 
 #. [message]: speaker=Syner
 #. speaking of Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1107
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1135
 msgid "I’m free! Now I’ll have the pleasure of killing this dark adept myself."
 msgstr "我自由了！现在我可以亲自享受杀掉这个黑暗狂徒的乐趣了。"
 
 #. [message]: speaker=Terraent
 #. speaking to Syner about Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1120
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1148
 msgid ""
 "Stay your hand, man of Wesnoth! A killing in cold blood is no justice and "
 "revenge will bring you no peace."
@@ -8109,18 +8007,18 @@ msgstr "韦诺人，请手下留情！冷血杀人不算正义，复仇也不会
 
 #. [message]: speaker=Syner
 #. speaking of Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1125
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1153
 msgid "Are you mad? That woman is a necromancer!"
 msgstr "你疯了吗？那个女人是死灵法师！"
 
 #. [message]: speaker=Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1129
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1157
 msgid ""
 "...you might as well. They think I’m a traitor. I’m as good as dead already."
 msgstr "…你也可以。他们认为我是叛徒。 我已经死了 。"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1133
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1161
 msgid ""
 "Then the choice is yours. Flee and face the world alone, or forswear your "
 "dark arts and join me to protect all that yet remains holy in this good "
@@ -8130,40 +8028,40 @@ msgstr ""
 "美好世界上尚存的一切神圣之物。"
 
 #. [message]: speaker=Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1145
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1173
 msgid "Okay. No more necromancy. I’ll join you."
 msgstr "好吧。不再使用死灵术。我会加入你。"
 
 #. [message]: speaker=Owaec
 #. speaking to Syner, who has just killed Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1190
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1218
 msgid "And so justice has been served! Such is the fate of all evildoers."
 msgstr "于是正义得到了伸张！这就是所有作恶者的命运。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1210
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1238
 msgid "Scyla"
 msgstr "希拉"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1227
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1255
 msgid "Mame"
 msgstr "玛米"
 
 #. [message]: speaker=Gaoler_Merfolk
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1256
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1278
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1284
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1306
 msgid "March. Faster."
 msgstr "走。快点。"
 
 #. [message]: speaker=Mame
 #. a Mermaid Priestess as prisoner, the line ends with the jailer hitting her
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1261
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1289
 msgid "We’re going as fast as we can! Maybe if you’d let us swim-"
 msgstr "我们正在尽可能快地前进！也许你可以让我们游泳的—"
 
 #. [message]: speaker=Mame
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1291
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1319
 msgid ""
 "Thanks stranger! I do not recognize these lands, but I do recognize a kind "
 "heart when I meet one. Should I ever find my way home to the coast, I will "
@@ -8174,61 +8072,61 @@ msgstr ""
 
 #. [message]: id=Owaec,Terraent
 #. "we" being the speaker and the prisoners that they've rescued
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1302
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1330
 msgid "Now we come for you, necromancer!"
 msgstr "现在我们来找你了，死灵法师！"
 
 #. [message]: speaker=Mal-Yrna
 #. each bat-summoning event is triggered by the player rescuing prisoners
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1351
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1379
 msgid ""
 "Of course, just because I said I wouldn’t summon bats doesn’t mean I can’t..."
 msgstr "当然，我说我不召唤蝙蝠，并不代表我不能……"
 
 #. [message]: speaker=Mal-Yrna
 #. each bat-summoning event is triggered by the player rescuing prisoners
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1359
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1387
 msgid "My prisoners!! You’ll pay for that..."
 msgstr "我的俘虏！！你会为那件事付出代价……"
 
 #. [message]: speaker=Mal-Yrna
 #. this is a common misquote from the wizard of oz, she's talking to her bats
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1369
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1397
 msgid "Fly, my pretties, fly!"
 msgstr "飞吧，我的小可爱，飞吧！"
 
 #. [message]: speaker=Mal-Yrna
 #. to Terraent. She's summoning bats.
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1396
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1424
 msgid "Not again! Do not test me, paladin of Wesnoth..."
 msgstr "不要再来了！不要考验我，韦诺的圣骑士……"
 
 #. [message]: speaker=Mal-Yrna
 #. to Owaec. She's summoning bats.
 #. The text is an allusion to drowned plains, which the next scenario will reveal to be the current state of the Horse Clans' beloved plains.
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1405
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1433
 msgid "Not again! Do not test me, lord of the swamps..."
 msgstr "又来了！不要考验我，沼泽之主……"
 
 #. [message]: speaker=Mal-Yrna
 #. More prisoners rescued, more bats get summoned.
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1429
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1457
 msgid "You are starting to become rather irritating."
 msgstr "你开始变得有点让人生气了。"
 
 #. [message]: speaker=Mal-Yrna
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1451
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1479
 msgid "Enough! My bats will feast on your blood!"
 msgstr "够了！我的蝙蝠要享用你的血液！"
 
 #. [message]: speaker=Mal-Yrna
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1474
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1502
 msgid "Why won’t you just die?!"
 msgstr "你怎么不去死？！"
 
 #. [message]: speaker=Gweddry
 #. victory event, and the rest of the player's units catch up
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1558
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1586
 msgid ""
 "Hail, Terraent! We feared the worst when you did not return, yet here I find "
 "you alive and well!"
@@ -8238,7 +8136,7 @@ msgstr ""
 
 #. [message]: speaker=Gweddry
 #. victory event, and the rest of the player's units catch up
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1566
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1594
 msgid ""
 "Hail, Owaec! We feared the worst when you did not return, yet here I find "
 "you alive and well!"
@@ -8247,7 +8145,7 @@ msgstr ""
 "的！"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1579
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1607
 msgid ""
 "Indeed! The Light blessed me with an opportunity to save many souls and I "
 "could not decline! Now the crossing is clear, and we may return to see what "
@@ -8257,7 +8155,7 @@ msgstr ""
 "们可以返回去看看我们的故乡变成了什么样子。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1586
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1614
 msgid ""
 "Huzzah! Today has been a great victory! I have rescued a great many "
 "prisoners and defeated a foul necromancer! Now the crossing is clear, and we "
@@ -8267,12 +8165,12 @@ msgstr ""
 "在渡口已经畅通无阻，我们可以返回去看看我们的故乡变成了什么样子。"
 
 #. [message]: speaker=Mal-Yrna
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1593
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1621
 msgid "You’re too late! Wesnoth is... already..."
 msgstr "你来晚了！韦诺…已经……"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1644
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1672
 msgid ""
 "Hail, Terraent! We feared the worst when you did not return, yet here I find "
 "you alive and well! But who is this you are fighting?"
@@ -8281,7 +8179,7 @@ msgstr ""
 "的！但是现在和你战斗的是谁？"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1651
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1679
 msgid ""
 "Hail, Owaec! We feared the worst when you did not return, yet here I find "
 "you alive and well! But who is this you are fighting?"
@@ -8291,7 +8189,7 @@ msgstr ""
 
 #. [message]: speaker=Mal-Yrna
 #. she dispatches a messenger bat after this, leading to Dacyn saying all is lost
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1658
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1686
 msgid ""
 "Can it be? Dacyn the mage? We thought you perished in the wild northlands, "
 "but now I find you alive and isolated from Wesnoth! I must inform Mal-"
@@ -8301,7 +8199,7 @@ msgstr ""
 "隔绝！我必须告诉玛尔-拉瓦纳尔！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1684
+#: data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg:1712
 msgid ""
 "Even if we triumph at this crossing, Mal-Ravanal will surely find and "
 "destroy us before we can reunite with Wesnoth..."
@@ -8515,11 +8413,6 @@ msgstr "175金币"
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:803
 msgid "55 gold"
 msgstr "55金币"
-
-#. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:804
-msgid "150 gold"
-msgstr "150金币"
 
 #. [event]
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:807
@@ -8767,6 +8660,10 @@ msgid ""
 "the shambling hordes responsible for all this destruction, we must not find "
 "our armories wanting."
 msgstr ""
+"我同意，但一切安静得有些反常。或许剩余的亡灵正处于蛰伏状态？\n"
+"\n"
+"即便我们没有足够的力量真正夺回此地，也应趁机收集剩余的补给。当我们最终与造成"
+"这一切毁灭的蹒跚大军交战时，绝不能让军械库出现匮乏。"
 
 #. [objective]: condition=win
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:1291
@@ -9055,7 +8952,7 @@ msgid "... Necromancer... you are a blight..."
 msgstr "…死灵法师……你是一个祸害……"
 
 #. [message]: speaker=Gaennell
-#. to an undead horseman in an [event]name=attack
+#. to an undead horseman in an attack event
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:1999
 msgid ""
 "Not sure what you’d call me anymore, but definitely not more of a blight "
@@ -9153,13 +9050,15 @@ msgid ""
 "of Wesnoth. We must make the most of our time here; we cannot afford to "
 "tarry too long."
 msgstr ""
+"倘若马上氏族已经覆灭得如此彻底，我不禁为维尔帝和韦诺其他地区担忧。必须抓紧利"
+"用在此地的时间，我们耽搁不起太久。"
 
 #. [message]: speaker=Owaec
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:2155
 msgid ""
 "So much death. So many of my kinsmen left unavenged. If only we had more "
 "time..."
-msgstr ""
+msgstr "死了这么多人。这么多族人的血海深仇还未得报。要是我们有更多时间就好了……"
 
 #. [message]: speaker=Gweddry
 #: data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg:2159
@@ -9305,6 +9204,8 @@ msgid ""
 "Then we must reinforce the city at once. There is a relief tunnel nearby, "
 "its entrance still hidden from the dead. Come on men, follow me!"
 msgstr ""
+"那么我们必须立刻增援这座城市。附近有一条秘密通道，入口至今没被亡灵发现。来"
+"吧，伙计们，跟我来！"
 
 #. [time]: id=indoors
 #: data/campaigns/Eastern_Invasion/scenarios/15_Return_to_Wesnoth.cfg:721
@@ -9315,7 +9216,7 @@ msgstr "室内"
 
 #. [unit]: id=Aeraeka, type=Arch Mage, gender=female
 #: data/campaigns/Eastern_Invasion/scenarios/15_Return_to_Wesnoth.cfg:755
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:101
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:102
 msgid "Aeraeka"
 msgstr "艾瑞卡"
 
@@ -9654,19 +9555,19 @@ msgstr "保护将军哈拉德、哈尔里克和哈尔罗德"
 #. [objective]: condition=lose
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:1013
 #: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:134
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:632
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:631
 msgid "Death of Dacyn"
 msgstr "达辛死亡"
 
 #. [objective]: condition=lose
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:1017
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:636
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:635
 msgid "Death of Konrad II"
 msgstr "科纳德二世死亡"
 
 #. [note]
 #: data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg:1022
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:641
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:640
 msgid "Konrad II will not leave the center island."
 msgstr "科纳德二世不会离开中央的岛屿。"
 
@@ -10306,7 +10207,7 @@ msgstr ""
 
 #. [objective]: condition=win
 #: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:130
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:623
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:622
 msgid "Defeat Mal-Ravanal"
 msgstr "击败玛尔-拉瓦纳尔"
 
@@ -10345,14 +10246,14 @@ msgstr ""
 "他们来战斗。"
 
 #. [message]: speaker=$found_unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:294
+#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:297
 msgid ""
 "Wait — what just happened? More undead creatures just came out of the "
 "ground! That’s not allowed!"
 msgstr "等等——刚才发生什么了？更多亡灵生物从地底出来了！这是不允许的！"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:298
+#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:301
 msgid ""
 "The rules say nothing about bringing up warriors who were already here. Feel "
 "free to reanimate some too, if you can."
@@ -10360,12 +10261,12 @@ msgstr ""
 "规则里可没有说不能复活已经存在于此的战士。如果你行的话，也可以随便复活一些。"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:306
+#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:309
 msgid "Tsk, tsk, I begin to tire of this."
 msgstr "啧啧，我开始对此感到厌倦了。"
 
 #. [message]: speaker=$found_unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:311
+#: data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg:314
 msgid "More reinforcements come every time!"
 msgstr "每次都有更多的援军到来！"
 
@@ -10463,60 +10364,60 @@ msgid ""
 msgstr "整整一场战争过去了，那个家伙的魔法还是没有进步……"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:612
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:611
 msgid "Kill $liches_to_kill liches to reveal Mal-Ravanal"
 msgstr "击杀$liches_to_kill|名巫妖以暴露玛尔-拉瓦纳尔"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:719
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:718
 msgid "150 gold remains in my war-chest. I place it at your service, my Liege."
 msgstr "我的资金中还剩150金币。我将它供您使用，吾王。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:755
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:754
 msgid ""
 "My Liege, I’ve managed to conserve 150 gold from the previous battle. I "
 "place it at your disposal."
 msgstr "吾王，我从之前的战斗中留下了150金币，现将其置于您的支配之下。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:793
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:792
 msgid ""
 "For you, my Liege: my men have salvaged 150 gold from the ruins of the city "
 "outskirts."
 msgstr "为您效劳，吾王：我的部下从城市郊区的废墟中找回了150金币。"
 
 #. [message]: speaker=Halrad
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:843
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:842
 msgid "My forces are in position at the northern wall; awaiting your orders."
 msgstr "我的部队已经部署在北城墙；等待您的命令。"
 
 #. [message]: speaker=Halric
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:847
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:846
 msgid "Eastern flank reclaimed. I stand ready to launch the assault."
 msgstr "东部侧翼已收复。我准备发起进攻。"
 
 #. [message]: speaker=Halrod
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:851
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:850
 msgid "The western barricades are manned and ready — it’s payback time."
 msgstr "西部屏障已经布置完毕，准备迎战——是时候报仇了。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:861
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:860
 msgid ""
 "Now is the time to strike! In the name of the Clans, Mal-Ravanal will be "
 "ended this day!"
 msgstr "现在就是进攻的时刻！以氏族之名，玛尔-拉瓦纳尔将在今日终结！"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:868
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:867
 msgid ""
 "Now is the time to strike! By the might of all Wesnoth, Mal-Ravanal shall be "
 "ended this day!"
 msgstr "现在就是进攻的时刻！凭韦诺全体的力量，玛尔-拉瓦纳尔将在今日终结！"
 
 #. [message]: speaker=Dacyn
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:895
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:894
 msgid ""
 "These liches are channeling some dark magic to hide themselves. (cough)"
 "(cough) Even if Mal-Ravanal is here, I will not be able to (cough) reveal "
@@ -10527,7 +10428,7 @@ msgstr ""
 "也无法（咳）在杀死足够的巫妖以破除他们的魔咒之前将他们暴露出来。（咳）"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:906
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:905
 msgid ""
 "Then that’s what we’ll have to do. And we will have to do it quickly, before "
 "Mal-Ravanal’s reinforcing armies overwhelm us."
@@ -10536,88 +10437,88 @@ msgstr ""
 "之前。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:910
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:909
 msgid ""
 "Stride fearless upon the plain of battle, for today we reclaim our legacy! "
 "For Wesnoth!!"
 msgstr "勇踏战场，无畏前行，今日我们重拾荣光！为了韦诺！！"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:917
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:916
 msgid ""
 "Then kill them we shall. Stride fearless upon the plain of battle, for today "
 "we reclaim our legacy! For Wesnoth!!"
 msgstr "然后我们将消灭他们。勇踏战场，无畏前行，今日我们重拾荣光！为了韦诺！！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:926
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:925
 msgid "Mal-Hadanak"
 msgstr "玛尔-哈达纳克"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:927
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:926
 msgid "You dare to attack me?"
 msgstr "你胆敢攻击我？"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:930
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:929
 msgid "Mal-Katklagad"
 msgstr "玛尔-卡拉戈德"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:931
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:930
 msgid "I will enjoy watching you suffer!"
 msgstr "看着你受苦我会很享受的！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:934
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:933
 msgid "Mal-Xaskanat"
 msgstr "玛尔-夏斯卡纳特"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:935
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:934
 msgid "Death will only be the beginning of your torment!"
 msgstr "死亡只是你苦痛的开端而已！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:938
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:937
 msgid "Mal-Akranbral"
 msgstr "玛尔-阿克兰布劳尔"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:939
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:938
 msgid "You will serve me in death!"
 msgstr "死后你将臣服于我！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:942
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:941
 msgid "Mal-Larakan"
 msgstr "玛尔-拉莱坎"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:943
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:942
 msgid "Allow me to free you from your wretched existence!"
 msgstr "让我把你从这悲惨的存在之中解放出来吧！"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:946
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:945
 msgid "Mal-Drakanal"
 msgstr "玛尔-德拉卡纳尔"
 
 #. [value]
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:947
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:946
 msgid "I am merely toying with you!"
 msgstr "我只是和你们玩玩而已！"
 
 #. [message]: speaker=$found_unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:992
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:991
 msgid ""
 "The River Weldyn used to be so beautiful, before the undead dammed it and "
 "flooded the shores..."
 msgstr "在亡灵修建了水坝并淹没河岸之前，维尔帝河曾经那么美……"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1016
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1015
 msgid ""
 "My legacy will not be one of failure! With all the might of the throne of "
 "Wesnoth, I shall strike you down!"
@@ -10625,7 +10526,7 @@ msgstr "我的遗志不会是失败！凭韦诺王座所有的力量，我会把
 
 #. [message]: speaker=Konrad
 #. killed a lich
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1037
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1036
 msgid ""
 "That’s one down! The undead must still be in disarray after their failed "
 "attack during the long night."
@@ -10633,7 +10534,7 @@ msgstr "干掉了一个！在漫长的夜晚失败的攻击之后，亡灵一定
 
 #. [message]: speaker=$found_unit.id
 #. speaker is a random lich
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1051
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1050
 msgid ""
 "Night falls on Weldyn! Your counterattack may have caught us by surprise, "
 "but this hour is our domain."
@@ -10641,19 +10542,19 @@ msgstr "夜幕降临维尔帝！你们的反击或许让我们感到意外，但
 
 #. [message]: speaker=$found_unit.id
 #. speaker is a random lich, almost certainly a different one than the previous speaker
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1060
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1059
 msgid "Now you will pay for your arrogance!"
 msgstr "现在你将为你的心高气傲付出代价！"
 
 #. [message]: speaker=Konrad
 #. the player is trying to move him away
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1082
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1081
 msgid "A king belongs in his capital! I will not abandon my post!"
 msgstr "国王属于他的首都！我不会放弃我的岗位！"
 
 #. [floating_text]
 #. the parts to translate here are "gold refunded" and "per side"
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1214
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1213
 msgid ""
 "<span color='#FFD700' size='x-small'>gold refunded</span>\n"
 "<span color='#FFFFFF' size='xx-small'>  (1/$side_count per side)</span>"
@@ -10662,7 +10563,7 @@ msgstr ""
 "<span color='#FFFFFF' size='xx-small'>（每方1/$side_count）</span>"
 
 #. [message]: speaker=$found_unit.id
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1243
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1242
 msgid ""
 "Fools, you have already lost! For each minion you strike down, another shall "
 "rise to take its place."
@@ -10670,12 +10571,12 @@ msgstr ""
 "蠢货，你们已经输了！你每杀死我们的一个部下，就会有另一个站出来接替它的位置。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1385
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1384
 msgid "Their spell is broken!"
 msgstr "魔咒阻断了！"
 
 #. [message]: speaker=Mal-Ravanal
-#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1677
+#: data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg:1676
 msgid "Enough of this farce! I shall end this personally."
 msgstr "这场闹剧到此为止！我将亲自了结此事。"
 
@@ -10718,13 +10619,13 @@ msgstr ""
 "拦地照耀在维尔帝之上。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:113
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:114
 msgid "Renaerawan"
 msgstr "瑞纳尔拉文"
 
 #. [message]: speaker=Renaerawan
 #. the speaker is a white mage who first appears in this epilogue
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:198
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:199
 msgid ""
 "We are gathered here today in remembrance of our dear colleague and friend, "
 "Dacyn, who fell even as he vanquished the arch-lich Mal-Ravanal."
@@ -10733,7 +10634,7 @@ msgstr ""
 "时就倒下了。"
 
 #. [message]: speaker=Renaerawan
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:202
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:203
 msgid ""
 "I knew Dacyn as a complicated man: ambitious yet loyal, proud yet wise. But "
 "above all, Dacyn sought to act for the good of Wesnoth, and today we honor "
@@ -10743,23 +10644,23 @@ msgstr ""
 "为韦诺的利益而行动，今天我们为此向他致敬。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:208
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:209
 msgid "Today we have won a great victory, yet it comes at great cost."
 msgstr "今天我们赢得了伟大的胜利，然而同样付出了巨大的代价。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:212
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:213
 msgid "Grug sad! Magic man kind."
 msgstr "格拉格伤心！魔法人类。"
 
 #. [message]: speaker=Dolburras
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:216
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:217
 msgid ""
 "Ay. Too many ha’ died in this war, both my kinsmen at Knalga and yours here."
 msgstr "是的。在这场战争中死了太多人了，包括俺们纳尔迦的和你们的亲属。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:220
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:221
 msgid ""
 "So many months of fighting... I feel as though I am awakening from a long "
 "nightmare."
@@ -10767,13 +10668,13 @@ msgstr "这么多月的战斗……我觉得自己就像从漫长的噩梦之中
 
 #. [message]: speaker=Owaec
 #. he's alive, this isn't a plaque on a tomb
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:225
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:226
 msgid ""
 "My duty is done; the Clans have been avenged. At last, I can rest in peace."
 msgstr "我的职责已经完成；氏族的仇已经报了。我终于可以安心地休息了。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:231
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:232
 msgid ""
 "Alas, our work is not yet complete. Mal-Ravanal’s host has been broken, but "
 "in its wake, chaos and disorder prevail throughout the countryside. We will "
@@ -10783,7 +10684,7 @@ msgstr ""
 "诺的乡村陷入了混乱和无序之中。我们要花几年……几十年……从这里的恶劣环境恢复。"
 
 #. [message]: speaker=Aeraeka
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:235
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:236
 msgid ""
 "Even now we should be sending what’s left of our armies to restore order "
 "throughout the land."
@@ -10793,7 +10694,7 @@ msgstr "哪怕是现在我们也应该派我们剩下的部队到各地恢复秩
 #. TODO for 1.19? Make clear who this is addressing, and make variations depending on whether it's to one person or two.
 #. To Owaec, Gweddry or both; but I only know that because I can see the condition and the alternative line if they're both dead.
 #. The "we" could be the royal pronoun (first person singular), but "we" as in "everyone in the Kingdom" fits too.
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:249
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:250
 msgid ""
 "It shall be so. But first, know that you have served Us, and Our Kingdom, "
 "full well. We are minded to reward you."
@@ -10804,7 +10705,7 @@ msgstr ""
 #. [message]: speaker=Konrad
 #. All three heroes are dead.
 #. The "we" could be the royal pronoun (first person singular), but "we" as in "everyone in the Kingdom" fits too.
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:259
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:260
 msgid ""
 "I had a mind to share this victory with those who made it possible, yet so "
 "many of them now lie dead. Lieutenant Gweddry, Lord Owaec, Advisor Dacyn, we "
@@ -10815,7 +10716,7 @@ msgstr ""
 
 #. [message]: speaker=Konrad
 #. the player chose to give Grug the plague staff
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:284
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:285
 msgid ""
 "Grug, a necromancer ogre is something wholly new to Us, but know that "
 "Wesnoth will never tolerate your kind. You shall surrender that accursed "
@@ -10828,12 +10729,12 @@ msgstr ""
 "将被判处死刑，并且你因此被驱逐出韦诺。请感谢我们的慈悲。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:288
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:289
 msgid "Guh... Grug say no magic yes ok."
 msgstr "格…格拉格说没魔法是好。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:297
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:298
 msgid ""
 "Grug, Gweddry has told me of the help you and your tribe provided his men. "
 "We wish to offer you a new home in the Estmark Hills along with Our thanks."
@@ -10842,12 +10743,12 @@ msgstr ""
 "们在东界丘陵里安一个新家，以示感谢。"
 
 #. [message]: speaker=Grug
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:301
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:302
 msgid "(bowing clumsily) Grug say new home will make thanks with."
 msgstr "（笨拙地鞠躬）格拉格说新家要谢谢。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:321
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:322
 msgid ""
 "Dolburras, Owaec has told me of the help you provided his men; both your "
 "skill at arms and your tenacious spirit. We wish to offer you this finely "
@@ -10860,19 +10761,19 @@ msgstr ""
 
 #. [message]: speaker=Dolburras
 #. "Aye, I am honored. You have my sincerest thanks, your Majesty."
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:332
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:333
 msgid "Aye, I be honored. Ye have my sincerest thanks, yer Majesty."
 msgstr "是的，俺很荣幸。陛下，俺衷心感谢您。"
 
 #. [message]: speaker=Dolburras
 #. Owaec's dead
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:340
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:341
 msgid "Aye, I be honored. I only wish he were here to see the Clans avenged."
 msgstr "是的，俺很荣幸。俺只希望他能在这里看到有人为氏族复仇。"
 
 #. [message]: speaker=Konrad
 #. the player chose to give Addogin the plague staff
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:367
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:368
 msgid ""
 "Mercenary, <i>necromancer</i>, know that Wesnoth will never tolerate your "
 "kind. You shall surrender that accursed stave to be destroyed, you shall "
@@ -10884,7 +10785,7 @@ msgstr ""
 "逐出韦诺。请感谢我们的慈悲。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:371
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:372
 msgid ""
 "Yeah, figures. How did I let myself get caught up in all this anyways? "
 "Suppose I can always head north to those farmlands we passed by..."
@@ -10893,7 +10794,7 @@ msgstr ""
 "们路过的农田里……"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:380
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:381
 msgid ""
 "Addogin, mercenary captain from the Estmarks. I have heard the story of how "
 "you entered Gweddry’s service against your will, but I have also heard that "
@@ -10906,7 +10807,7 @@ msgstr ""
 "为你提供皇家卫队的位置。"
 
 #. [message]: speaker=Addogin
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:384
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:385
 msgid ""
 "Sir, uh, milord, uh, King sir, I’m honored, really am, but I just wanna go "
 "home. If it’s alright with you, this old geezer will be haulin’ himself back "
@@ -10916,14 +10817,14 @@ msgstr ""
 "这个老头子回到东部，去享受迟来的退休生活了。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:389
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:390
 msgid ""
 "As you wish. Then take this chest of silver, that you may never again need "
 "raise sword for coin."
 msgstr "如你所愿。那么拿走这箱银子，从此以后你再也不需要举剑换金钱。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:409
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:410
 msgid ""
 "Hahid al-Ali, We know of your far-off people, but great distance has caused "
 "little contact between us. May it be thus no longer. If you accept, We would "
@@ -10933,7 +10834,7 @@ msgstr ""
 "状不再延续。若阁下愿意接受，吾等愿任命您为你我两界之间的大使。"
 
 #. [message]: speaker=Hahid al-Ali
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:413
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:414
 msgid ""
 "Me, ambassador to the barbarian kingdoms, what a thought! I am honored, and "
 "would be even more honored to learn that the job comes with... excellent pay "
@@ -10943,7 +10844,7 @@ msgstr ""
 "优厚的话，我会更加荣幸？"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:431
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:432
 msgid ""
 "Sir Terraent, your service to the Crown and your unfailing optimism has been "
 "a beacon of light in these dark times. If you accept, we would appoint you "
@@ -10953,7 +10854,7 @@ msgstr ""
 "我将委派你指挥东界的河岸卫队。"
 
 #. [message]: speaker=Terraent
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:435
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:436
 msgid ""
 "It has been an honor to spread the holy Light in this kingdom, and I humbly "
 "accept your commission. May the Light shine ever-bright upon the pious."
@@ -10962,7 +10863,7 @@ msgstr "在王国散布圣光乃微臣之幸，受此大任，不胜惶恐。愿
 #. [message]: speaker=Konrad
 #. Gaennell’s previous crimes are held against her, regardless of whether or not she has the plague staff now.
 #. Terraent is alive, "speaks well of you" meaning he's asked the King to pardon Gaennell.
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:470
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:471
 msgid ""
 "As for you, <i>necromancer</i>. We are not as like as Terraent to show mercy "
 "unto evil, but he speaks well of you, and so mercy shall be shown. Go from "
@@ -10976,7 +10877,7 @@ msgstr ""
 #. [message]: speaker=Konrad
 #. Gaennell’s previous crimes are held against her, regardless of whether or not she has the plague staff now.
 #. Terraent is dead.
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:480
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:481
 msgid ""
 "As for you, <i>necromancer</i>. We are not as like as Terraent to show mercy "
 "unto evil, but in honor of his sacrifice We will show it now. Go from here a "
@@ -10988,12 +10889,12 @@ msgstr ""
 "道，你被禁止练习所有形式的魔法，否则将被判处死刑。"
 
 #. [message]: speaker=Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:486
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:487
 msgid "<i>Forbidden to-</i>"
 msgstr "<i>禁止—</i>"
 
 #. [message]: speaker=Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:490
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:491
 msgid ""
 "... as an adept I’d dreamt of one day standing in this palace, though "
 "under... different circumstances. Well, better that I get to keep my head, I "
@@ -11004,7 +10905,7 @@ msgstr ""
 
 #. [message]: speaker=Konrad
 #. a unit has the plague staff, but they're not one of the loyals. This version of the line is used if Gaennell is here.
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:515
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:516
 msgid ""
 "And the same goes for you, wielder of that accursed stave. You shall "
 "surrender it to be destroyed, and leave here forbidden to practice magic. Be "
@@ -11015,7 +10916,7 @@ msgstr ""
 
 #. [message]: speaker=Konrad
 #. a unit has the plague staff, but they're not one of the loyals, and the player doesn't have Gaennell
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:524
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:525
 msgid ""
 "As for you, <i>necromancer</i>. You shall surrender that accursed stave to "
 "be destroyed, and are hereby forbidden to practice magic in any form, at "
@@ -11025,32 +10926,32 @@ msgstr ""
 "习所有的魔法，否则将被判处死刑。请感谢我们的慈悲。"
 
 #. [message]: speaker=$plague_staff_wielder_id
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:530
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:531
 msgid "As you command, your Majesty."
 msgstr "遵命，陛下。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:551
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:552
 msgid ""
 "Owaec, last Prince of the Plains. You and your people have suffered much."
 msgstr "欧瓦埃克，平原的最后一位王子。你和你的人民遭受了很多苦难。"
 
 #. [message]: speaker=Owaec
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:555
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:556
 msgid ""
 "My Lord, the Clansmen gladly gave their lives for Wesnoth, and know that I "
 "would do the same without hesitation."
 msgstr "吾主，氏族勇士们甘愿为韦诺献出生命，并深知我会毫不犹豫地做同样的事。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:560
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:561
 msgid ""
 "The true test is not to die for one’s King, but to live for Him... Kneel, "
 "Owaec."
 msgstr "真正的考验不是为国王而死，而是为他而活……下跪，欧瓦埃克。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:565
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:566
 msgid ""
 "And arise, Sir Owaec, High Lord of the Horse Clans! Your people have been "
 "shattered, but We trust none more than you to make them whole again. Ride "
@@ -11061,7 +10962,7 @@ msgstr ""
 
 #. [message]: speaker=Konrad
 #. Owaec is dead too
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:574
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:575
 msgid ""
 "But alas, what of the Clansmen? Their horses have been scattered, their "
 "Lords were broken, and now the last prince has fallen defending the walls of "
@@ -11073,26 +10974,26 @@ msgstr ""
 "辉煌了。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:592
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:593
 msgid ""
 "And now what of the humble Gweddry; still but a lieutenant. It seems you are "
 "long-overdue for a promotion."
 msgstr "而现在，平凡的格威德利，仍然只是一个尉官；看来你已经很久没有晋升了。"
 
 #. [message]: speaker=Gweddry
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:596
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:597
 msgid "Sire, I but did my duty."
 msgstr "陛下，微臣只是尽职而已。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:601
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:602
 msgid ""
 "Quite. Now do not interrupt while I am doing mine... Kneel, Gweddry, "
 "lieutenant."
 msgstr "安静。现在不要打断我……单膝下跪，格威德利，尉官。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:606
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:607
 msgid ""
 "And arise, Gweddry, Earl of Estmark! The land for which you shed your blood "
 "shall be put under your hand to be made green again. May you ever prosper."
@@ -11101,7 +11002,7 @@ msgstr ""
 "繁荣昌盛。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:614
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:615
 msgid ""
 "And what of Gweddry... He had survived long, sacrificed much, only to meet "
 "his end here at the last. I wish he could have lived to see the peace he has "
@@ -11111,7 +11012,7 @@ msgstr ""
 "真希望他能活着看到他带来的和平。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:626
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:627
 msgid ""
 "Wesnoth is bowed, but thanks to the efforts of many heroes we stand yet "
 "unbroken. And now, at long last, the time has come to rebuild."
@@ -11120,7 +11021,7 @@ msgstr ""
 "到了。"
 
 #. [message]: speaker=Konrad
-#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:631
+#: data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg:632
 msgid ""
 "To each of you, take as Our first command to you your own wish! Go from "
 "here; secure our borders. Show all that the might of Wesnoth will endure!"
@@ -11134,7 +11035,7 @@ msgid "Empire"
 msgstr "帝国"
 
 #. [part]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:18
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:17
 msgid ""
 "Congratulations! By sparing Dra-Nak in S11, ‘Captured’, sparing Mortic in "
 "S12 ‘Evacuation’, and completing the difficult S17b ‘All-In’, you’ve "
@@ -11144,67 +11045,67 @@ msgstr ""
 "场景17b“全体上场”，你解锁了这个奖励场景！"
 
 #. [side]: type=Drake Arbiter, id=Goag
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:103
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:104
 msgid "Goag"
 msgstr "戈格"
 
 #. [side]: type=Drake Warrior, id=Gra'ritos
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:130
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:133
 msgid "Gra’ritos"
 msgstr "格拉里托斯"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:190
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:195
 msgid "Survivors"
 msgstr "幸存者"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:224
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:229
 msgid "Tribute"
 msgstr "贡品"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:232
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:237
 msgid "Prison Guards"
 msgstr "狱卒"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:234
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:239
 msgid "Tobo"
 msgstr "托博"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:235
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:240
 msgid "Unik"
 msgstr "尤尼克"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:236
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:241
 msgid "Shubru"
 msgstr "舒布鲁"
 
 #. [side]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:237
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:242
 msgid "Grugnuk"
 msgstr "格拉格纳克"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:539
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:544
 msgid "Filthy..."
 msgstr "污秽的…"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:544
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:549
 msgid "Stinking..."
 msgstr "臭气熏天的…"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:549
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:554
 msgid "TRAITORS!!!"
 msgstr "叛徒！！！"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:554
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:559
 msgid ""
 "Drakes, human, dwarves... vermin, all of them! I offered them a chance at "
 "peace, at purpose! A chance to be part of something greater than themselves "
@@ -11215,26 +11116,26 @@ msgstr ""
 "的报答？"
 
 #. [message]: type=Orcish Slayer
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:560
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:565
 msgid ""
 "Chief, more wyrms are attacking the east tunnels! There’s too many of them! "
 "What do we do?"
 msgstr "酋长，有更多的飞龙正在攻击东部隧道！它们的数量太多了！我们该怎么办？"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:564
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:569
 msgid ""
 "I’m not going to let everything I’ve worked for fall apart so easily! These "
 "vermin are WEAK! We are STRONG!"
 msgstr "我不会让一切努力付诸东流！这些鼠辈是弱小的！我们是强大的！"
 
 #. [message]: type=Orcish Slayer
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:568
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:573
 msgid "Okay, but that’s not really a battle pla-"
 msgstr "好了，但这真的不是一个战场—"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:572
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:577
 msgid ""
 "Capture their warriors and sell them for gold. Break their leaders and bend "
 "their followers to my will. I’ll slay anyone who resists and build a new "
@@ -11244,34 +11145,34 @@ msgstr ""
 "意志。我会斩杀任何反抗者，并在他们热气腾腾的尸体上建立一个新的帝国！"
 
 #. [objective]: condition=win
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:578
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:583
 msgid "Defeat all drake leaders"
 msgstr "击败所有龙人首领"
 
 #. [objective]: condition=lose
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:582
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:587
 msgid "Death of Chief Dra-Nak"
 msgstr "德拉-纳克酋长死亡"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:586
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:591
 msgid "You are fighting in your home and therefore pay no upkeep."
 msgstr "你在家作战，因此无需支付维护费用。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:589
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:594
 msgid ""
 "Reduce enemies to 0 hp to capture them and gain gold. The prisons have "
 "limited space."
 msgstr "将敌人的生命值降至0以俘获他们并获得金币。监狱的空间是有限的。"
 
 #. [note]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:592
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:597
 msgid "Surviving enemies will (mostly) join you when you defeat their leader."
 msgstr "击败敌方的首领后，他们剩余的敌人（大多数）会加入你的部队。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:621
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:626
 msgid ""
 "I’ve emptied the last of our treasury! Only 31 pieces, but better than "
 "nothing."
@@ -11279,29 +11180,29 @@ msgstr "我已经用完了我们金库里的最后一笔钱！只有31块，但�
 
 #. [then]
 #. said by Dra-Nak as an insult to Mortic in the latter's last-breath event
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:636
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:641
 msgid "Some ‘leader’."
 msgstr "某个“首领”。"
 
 #. [then]
 #. said by Dra-Nak as an insult to Goag in the latter's last-breath event
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:643
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:648
 msgid "That’ll teach him. Where was that loyalty when he used to obey me?"
 msgstr "那会教训他。他以前跟我的时候，那份忠诚哪儿去了？"
 
 #. [then]
 #. said by Dra-Nak as an insult to Gra’ritos in the latter's last-breath event
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:650
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:655
 msgid "What happened to dying slow? So much for him."
 msgstr "慢慢等死又怎么了？对他来说都结束了。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:656
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:661
 msgid "They really thought they could get away? Haw..."
 msgstr "他们真以为能逃得掉吗？呵…"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:680
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:685
 msgid ""
 "He called himself your leader, but now you see him for the weakling he "
 "really was. You can either join him or fight alongside me and pray I show "
@@ -11311,19 +11212,19 @@ msgstr ""
 "我身边与他作战，并祈求我会对你仁慈。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:686
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:691
 msgid ""
 "As for the rest of you — pledge yourselves to me, or die a slow painful "
 "death!"
 msgstr "至于你们其余的人——要么向我效忠，要么慢慢地痛苦地死掉！"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:692
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:697
 msgid "You might as well give it up! Resistance is pointless."
 msgstr "你还是放弃吧！抵抗是没有意义的。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:698
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:703
 msgid ""
 "Nobody escapes me. Join me and I’ll treat you fairly, resist me and you’ll "
 "die painfully."
@@ -11331,7 +11232,7 @@ msgstr ""
 "没有人能从我手中逃脱。加入我，我会公正地对待你；抵抗我，你会痛苦地死去。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:709
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:714
 msgid ""
 "Mortic was strong.\n"
 "Alone I am weak.\n"
@@ -11342,7 +11243,7 @@ msgstr ""
 "吾将侍奉汝。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:717
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:722
 msgid ""
 "I crave not death.\n"
 "I will myself to you."
@@ -11351,7 +11252,7 @@ msgstr ""
 "此身意志，尽归于尔。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:724
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:729
 msgid ""
 "These orcs enrage me,\n"
 "But I possess no strength to resist.\n"
@@ -11362,12 +11263,12 @@ msgstr ""
 "吾将效忠于汝。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:732
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:737
 msgid "Yes, yes, just please don’t hurt me!"
 msgstr "好的，好的，请不要伤害我！"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:772
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:777
 msgid ""
 "I shall never again obey orc.\n"
 "Mortic fought and died.\n"
@@ -11378,7 +11279,7 @@ msgstr ""
 "吾亦将战。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:780
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:785
 msgid ""
 "I am always loyal,\n"
 "but never to prey.\n"
@@ -11389,7 +11290,7 @@ msgstr ""
 "吾将奋战至死。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:788
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:793
 msgid ""
 "I grieve.\n"
 "May the end come swiftly."
@@ -11398,17 +11299,17 @@ msgstr ""
 "愿此终焉，速速降临。"
 
 #. [then]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:795
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:800
 msgid "You traitors, how could you! I’ll never betray Wesnoth!"
 msgstr "你们这些叛徒，怎么会这样！我绝不会背叛韦诺的！"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:823
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:828
 msgid "Surrender or die, your choice!"
 msgstr "投降或战死，由你选择！"
 
 #. [message]: speaker=Mortic
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:827
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:832
 msgid ""
 "Surrender brings certain death.\n"
 "Battle may yet bring victory.\n"
@@ -11419,13 +11320,13 @@ msgstr ""
 "别无他选。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:833
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:838
 msgid "Die it is then!"
 msgstr "那就死吧！"
 
 #. [message]: speaker=Mortic
 #. Mortic's last breath
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:850
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:855
 msgid ""
 "Surrender brings death.\n"
 "Battle brings death.\n"
@@ -11436,14 +11337,14 @@ msgstr ""
 "万物，皆归死寂…"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:873
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:878
 msgid ""
 "The reaper’s knocking at your door, wyrm! Give up now and maybe I’ll kill "
 "you quickly."
 msgstr "收割者已在你的门前等候，巨龙！现在投降或许我可以速战速决。"
 
 #. [message]: speaker=Goag
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:877
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:882
 msgid ""
 "Mortic commanded me to fight.\n"
 "So the Aspirant ordered, so I will fight,\n"
@@ -11455,7 +11356,7 @@ msgstr ""
 
 #. [message]: speaker=Gra'ritos
 #. to Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:913
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:918
 msgid ""
 "You are Prey.\n"
 "I am Hunter.\n"
@@ -11466,13 +11367,13 @@ msgstr ""
 "吾非轻易倒下之人。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:919
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:924
 msgid "Good, I’ll enjoy making it slow."
 msgstr "好的，我会享受慢慢来的。"
 
 #. [message]: speaker=Chief Dra-Nak
 #. as the west bridge is broken, the Wesnothians who were left behind are trying to get though the orc's caves and out the east side
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:953
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:958
 msgid ""
 "Haw, back so soon? Too bad your ‘friends’ abandoned you on MY side of the "
 "river. But it’s your lucky day, I’m a fair orc. Surrender now and I might be "
@@ -11482,30 +11383,30 @@ msgstr ""
 "好的一天，我是公平的兽人。现在投降我可能会对你仁慈。"
 
 #. [message]: role=leader
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:957
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:962
 msgid "We’ll never give in to you! For Wesnoth!!"
 msgstr "我们绝不会向你屈服！为了韦诺！！"
 
 #. [message]: role=leader
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:969
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:974
 msgid "This foolish plan was my idea... I’m so, so sorry everyone..."
 msgstr "这个愚蠢的计划是我提出的…我真的，真的，很抱歉…"
 
 #. [message]: role=leader
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:985
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:990
 msgid "Keep pushing forward! Stick to the south tunnels! We can do this!"
 msgstr "继续前进！坚持走南边的隧道！我们可以做到的！"
 
 #. [message]: speaker=Chief Dra-Nak
 #. the necromancers are apparently paying gold immediately when each prisoner is captured
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1010
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1015
 msgid ""
 "That’s right, bleed them down and lock them up! I need gold to win this "
 "fight!"
 msgstr "没错，给他们放血，把他们关起来！我需要金币来赢得这场战斗！"
 
 #. [message]: speaker=Unik
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1020
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1025
 msgid ""
 "Chief, I only have space for so many prisoners. As cells get crowded, "
 "prisoners will start to get sick and we won’t get paid as much."
@@ -11515,33 +11416,33 @@ msgstr ""
 
 #. [message]: speaker=Unik
 #. the hole where the escape in S11 started
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1028
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1033
 msgid ""
 "Things are starting to get really crowded over here Chief. Shame the fourth "
 "cell has a hole in the back..."
 msgstr "这里越来越拥挤了，酋长。可惜第四格的后面有个洞…"
 
 #. [message]: speaker=Unik
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1035
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1040
 msgid ""
 "That’s it boss, the prisoners are packed as tight as they’ll go! Hope you "
 "got enough gold to finish off the drakes."
 msgstr "好了老大，俘虏已经塞得满满的了！希望你有足够的金币来搞定那些龙人。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1205
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1210
 msgid "Get away from my jail cells! Filthy traitors, there goes my income..."
 msgstr "离我的牢房远点！肮脏的叛徒，我收入没了…"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1209
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1214
 msgid ""
 "Fine then, I’m done taking prisoners. From here on out, you either submit or "
 "die!"
 msgstr "好的，我现在不再抓俘虏了。从现在起，你只能屈服或死亡！"
 
 #. [message]: role=leader
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1336
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1341
 msgid ""
 "Come on, don’t give up! Owaec’s destroyed the bridge so we’ll have to fight "
 "our way back through the orcish tunnels."
@@ -11549,7 +11450,7 @@ msgstr ""
 "加油，不要放弃！欧瓦埃克炸毁了桥，所以我们必须战斗着穿过兽人的隧道回去。"
 
 #. [message]: role=leader
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1352
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1359
 msgid ""
 "I know this looks grim, but we have to try. It’s our only chance. If we can "
 "just get through to the eastern exit, we might be able to escape!"
@@ -11558,32 +11459,32 @@ msgstr ""
 "部出口，我们就有可能逃脱！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1414
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1421
 msgid "Thank the Light, I’ve made it! Please please please don’t chase me..."
 msgstr "感谢光明，我做到了！请，请，请不要追我…"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1417
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1424
 msgid "Yes, YES! Get me out of here."
 msgstr "是的，是的！带我离开这里。"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1420
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1427
 msgid "Ha ha, you’ll never catch me now!"
 msgstr "哈哈，你没法抓住我了！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1423
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1430
 msgid "Whew, that was a close one!"
 msgstr "哇，那真是近！"
 
 #. [event]
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1427
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1434
 msgid "I’ve escaped!"
 msgstr "我逃走了！"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1483
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1490
 msgid ""
 "Well done, grunts. No more revolts, no more rebellion, and lots of "
 "prisoners..."
@@ -11591,24 +11492,24 @@ msgstr "干得不错，咕噜兵。再无叛乱，再无反抗，还有很多俘
 
 #. [message]: speaker=Chief Dra-Nak
 #. all the prisoners
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1488
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1495
 msgid "Now kill them all."
 msgstr "现在杀光他们。"
 
 #. [message]: speaker=Unik
 #. already paid them for the prisoners
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1604
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1611
 msgid "But Chief, the necromancers already paid us! We can’t just-"
 msgstr "但酋长，死灵法师已经付给我们报酬了！我们不能就这样—"
 
 #. [message]: speaker=Chief Dra-Nak
 #. all the necromancers
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1609
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1616
 msgid "Then I’ll kill them all too! I’m done working with others!"
 msgstr "然后我把他们也全都杀掉！我再也不和别人合作了！"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1625
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1632
 msgid ""
 "I tried being merciful. I tried working toward peace. I tried building an "
 "empire where all races could be a part of something great, and all I asked "
@@ -11618,7 +11519,7 @@ msgstr ""
 "部分的帝国，而我所要求的不过是简单的贡品而已。"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1629
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1636
 msgid ""
 "Mercy no more. I’ll build a new empire on the smoking rubble of the old, an "
 "empire for orcs and orcs alone, an empire to unite all the scattered tribes "
@@ -11628,13 +11529,13 @@ msgstr ""
 "国，一个将所有分散的部落团结在一面旗帜之下的帝国！"
 
 #. [message]: speaker=Chief Dra-Nak
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1633
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1640
 msgid "And when I’m ready, we will march across the world and make it ours."
 msgstr "等到我准备好了，我们就横扫世界，让它成为我们的天下。"
 
 #. [message]: speaker=Chief Dra-Nak
 #. the chief's last breath
-#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1649
+#: data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg:1656
 msgid "FILTHY... Rotten... ...traitors... ..."
 msgstr "污秽的……腐烂的……叛徒……"
 
@@ -12141,7 +12042,7 @@ msgstr "此攻击极其迅速。当用于进攻时，对手将无法反击。"
 #. [attacks]: id=stagger
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:152
 msgid "stagger"
-msgstr ""
+msgstr "蹒跚"
 
 #. [attacks]: id=stagger
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:153
@@ -12266,7 +12167,7 @@ msgstr "在防守的时候，这个单位有50%的火焰和奥术抗性。"
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:524
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:536
 msgid "arcane blessing"
-msgstr ""
+msgstr "奥术祝福"
 
 #. [damage_type]: id=arcane_damage_blessing
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:525
@@ -12274,6 +12175,8 @@ msgid ""
 "All attacks combine the arcane type with the type of the weapon used, so "
 "that resistance to arcane does not penalize the user."
 msgstr ""
+"所有攻击均兼具奥术类型与所用武器的类型，因此奥术抗性不会给使用者带来不利影"
+"响。"
 
 #. [damage_type]: id=arcane_damage_blessing
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:526
@@ -12281,6 +12184,7 @@ msgid ""
 "This unit’s weapons are treated as arcane instead of the declared damage "
 "type if that would increase the damage."
 msgstr ""
+"若此举能增加伤害，此单位的武器的伤害类型将视为奥术，而非其声明的伤害类型。"
 
 #. [damage_type]: id=arcane_damage_ranged_blessing
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:537
@@ -12288,6 +12192,8 @@ msgid ""
 "All bow or crossbow attacks combine the arcane type with the type of the "
 "weapon used, so that resistance to arcane does not penalize the user."
 msgstr ""
+"所有弓或弩攻击均兼具奥术属性与所用武器的属性，因此奥术抗性不会给使用者带来不"
+"利影响。"
 
 #. [damage_type]: id=arcane_damage_ranged_blessing
 #: data/campaigns/Eastern_Invasion/utils/abilities.cfg:538
@@ -12295,6 +12201,7 @@ msgid ""
 "This unit’s bow or crossbow attacks are treated as arcane instead of the "
 "declared damage type if that would increase the damage."
 msgstr ""
+"若此举能增加伤害，此单位的弓或弩的攻击将视为奥术攻击，而非其声明的伤害类型。"
 
 #. [trait]: id=loyal_dummy
 #: data/campaigns/Eastern_Invasion/utils/character-definitions.cfg:16
@@ -12798,14 +12705,14 @@ msgstr "我—我在哪儿？我身上正在发生什么？"
 msgid ""
 "The mage called Dacyn is dying! It is time for you to be reborn under a new "
 "name: Mal-Dak‘an."
-msgstr "称为达辛的法师正在死去！是时候让你重生，以一个新的名字：玛尔-达克安。"
+msgstr "称为达辛的法师正在死去！是时候以一个新的名字让你重生了：玛尔-达克安。"
 
 #. [message]: speaker=Dacyn
 #: data/campaigns/Eastern_Invasion/utils/final_battle/final_battle.cfg:779
 msgid ""
 "—I... —I am no necromancer! Everything I have done is for the good of "
 "Wesnoth."
-msgstr ""
+msgstr "—我……我不是死灵法师！我所做的一切都是为了韦诺的福祉。"
 
 #. [message]: speaker=spirit
 #: data/campaigns/Eastern_Invasion/utils/final_battle/final_battle.cfg:783
@@ -12813,6 +12720,8 @@ msgid ""
 "Was it? Was it for the good of all Wesnoth when you took Iliah-Malal’s "
 "Amulet of the Veil, turning to the darkness and letting us into your soul?"
 msgstr ""
+"是吗？当你戴上伊利阿-玛拉尔的面纱护身符、投身黑暗，以及让我们进入你的灵魂时，"
+"那也是为了整个韦诺的福祉吗？"
 
 #. [message]: speaker=spirit
 #: data/campaigns/Eastern_Invasion/utils/final_battle/final_battle.cfg:787
@@ -12820,6 +12729,8 @@ msgid ""
 "Was it for the good of Wesnoth when you enslaved the seer Eryssa’s senile "
 "mind, so the King would choose you as his advisor over Ravan?"
 msgstr ""
+"当你奴役先知伊蕊莎昏聩的心智，好让国王选择你而非拉万作为他的顾问时，那也是为"
+"了韦诺的福祉吗？"
 
 #. [message]: speaker=Dacyn
 #: data/campaigns/Eastern_Invasion/utils/final_battle/final_battle.cfg:791
@@ -12908,20 +12819,20 @@ msgstr "<i>黑暗吞噬灵魂。</i>"
 #. [item_dialog]: description={ITEM_DESC}
 #. [item_dialog_musttake]
 #. Button label for 'take an item'
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:37
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1097
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1253
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:40
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1116
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1272
 msgid "Take"
 msgstr "拿走"
 
 #. [item_dialog]: description={ITEM_DESC}
 #. Button label for 'leave an item'
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:39
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1098
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:42
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1117
 msgid "Leave"
 msgstr "留下"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:120
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:128
 msgid ""
 "<span size='small'><i>  This item is reusable if its wielder dies, and can "
 "be dropped by right clicking.</i></span>\n"
@@ -12934,7 +12845,7 @@ msgstr ""
 "<span size='small'><i>捡起道具会消耗你的移动和攻击次数。</i></span>\n"
 "<b></b>"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:125
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:133
 msgid ""
 "<span size='small'><i>This item <b>CANNOT</b> be dropped, and <b>CANNOT</b> "
 "be reused if its user dies.</i></span>\n"
@@ -12947,15 +12858,15 @@ msgstr ""
 "<span size='small'><i>  捡起道具会消耗你的移动和攻击次数。</i></span>\n"
 "<b></b>"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:139
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:147
 msgid "quiver"
 msgstr "箭筒"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:140
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:148
 msgid "Crystal Quiver"
 msgstr "水晶箭筒"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:141
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:149
 msgid ""
 "Arrows from this crystalline quiver glimmer with a pale magical light, "
 "<i><b>illuminating</b></i> the surrounding area and making your bow or "
@@ -12964,19 +12875,19 @@ msgstr ""
 "这个水晶箭筒中的箭闪烁着淡淡的魔光，<i><b>照明</b></i>周围的区域，使你的弓或"
 "弩变成<i><b>奥术</b></i>攻击。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:161
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:169
 msgid "Drop Crystal Quiver"
 msgstr "放下水晶箭筒"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:181
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:189
 msgid "amulet"
 msgstr "护身符"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:182
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:190
 msgid "Holy Amulet"
 msgstr "神圣护身符"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:183
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:191
 msgid ""
 "Engraved with a consecrated symbol, this amulet will bless both your "
 "<i><b>melee</b></i> and <i><b>ranged</b></i> attacks with <i><b>arcane</b></"
@@ -12985,19 +12896,19 @@ msgstr ""
 "雕刻着神圣的符号，这个护身符将祝福你的<i><b>近战</b></i>和<i><b>远程</b></i>"
 "攻击形成<i><b>奥术</b></i>伤害。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:202
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:210
 msgid "Drop Holy Amulet"
 msgstr "放下神圣护身符"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:216
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:224
 msgid "sentinel"
 msgstr "哨兵"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:217
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:225
 msgid "Shield of the Sentinel"
 msgstr "哨兵之盾"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:218
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:226
 msgid ""
 "Deep within this shield’s towering bulk, enchanted machinery whirrs faintly. "
 "Whenever an adjacent ally is hit by an attack, <i><b>this shield’s bearer is "
@@ -13006,19 +12917,19 @@ msgstr ""
 "在这面盾牌厚重的内部，被施过魔法的机械发出轻微的嗡鸣声。每当相邻盟友受到攻击"
 "时，<i><b>这面盾牌的持有者会代为承受攻击</b></i>。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:240
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:248
 msgid "Drop Shield of the Sentinel"
 msgstr "放下哨兵之盾"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:568
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:578
 msgid "yetiburger"
 msgstr "雪人堡"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:569
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:579
 msgid "Yetiburger"
 msgstr "雪人堡"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:570
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:580
 msgid ""
 "Eating this funny tasting meat <i><b>doubles your hitpoints</b></i> and "
 "grants <i><b>immunity to cold</b></i>."
@@ -13026,15 +12937,15 @@ msgstr ""
 "食用这种味道有趣的肉<i><b>使你的生命值翻倍</b></i>，并赋予你<i><b>对寒冷的免"
 "疫</b></i>。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:596
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:606
 msgid "ant ambrosia"
 msgstr "蚁蜜"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:597
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:607
 msgid "Ant Ambrosia"
 msgstr "蚁蜜"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:598
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:608
 msgid ""
 "This goopy honey-like substance makes you feel very sleepy... perhaps eating "
 "too much would be unwise.\n"
@@ -13048,16 +12959,16 @@ msgstr ""
 "移动，<span color='#00FF00'>+10</span> 生命值</b></i>。"
 
 #. [effect]: type=arcane
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:630
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:645
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:640
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:655
 msgid "baneblade"
 msgstr "毒刃"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:631
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:641
 msgid "Baneblade"
 msgstr "毒刃"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:632
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:642
 msgid ""
 "This incorporeal sword resembles those wielded by undead wraiths. Any mortal "
 "brave enough to wield it becomes <i><b>chaotic</b></i> and lashes out at "
@@ -13070,19 +12981,19 @@ msgstr ""
 "<i><b>6x4 奥术</b></i> 伤害，<i><b>吸血</b></i>，<i><b>狂暴</b></i>。在防守时"
 "总是会使用。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:682
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:692
 msgid "Drop Baneblade"
 msgstr "放下毒刃"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:696
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:706
 msgid "barkskin"
 msgstr "树皮"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:697
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:707
 msgid "Potion of Barkskin"
 msgstr "树皮药水"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:698
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:708
 msgid ""
 "This potion bubbles as though over an open flame, yet is cool to the touch. "
 "Its drinker gains the <i><b>steadfast</b></i> ability and can <i><b>heal 2 "
@@ -13091,15 +13002,15 @@ msgstr ""
 "这种药水在明火上冒泡，但摸起来很凉。喝它的人获得<i><b>坚定</b></i>能力，"
 "<i><b>每回合恢复2点生命</b></i>，就像具有“康健”特质的矮人一样。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:728
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:738
 msgid "ring"
 msgstr "指环"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:729
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:739
 msgid "Ring of Invisibility"
 msgstr "隐身之环"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:730
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:740
 msgid ""
 "This plain gold ring looks unremarkable, but its wearer gains "
 "<i><b>skirmisher</b></i> and <i><b>nightstalk</b></i>, becoming invisible in "
@@ -13108,19 +13019,19 @@ msgstr ""
 "这枚纯金戒指看起来毫不起眼，但佩戴者会获得<i><b>散兵</b></i>和<i><b>夜遁</"
 "b></i>技能，在黑暗中变得不可见。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:754
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:764
 msgid "Drop Ring of Invisibility"
 msgstr "放下隐身之环"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:768
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:778
 msgid "staff"
 msgstr "法杖"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:784
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:794
 msgid "Plague Staff"
 msgstr "瘟疫法杖"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:785
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:795
 msgid ""
 "Looted from a dead necromancer, the wielder of this dark staff becomes "
 "<i><b>chaotic</b></i>, and can <i><b>recruit and recall</b></i> Walking "
@@ -13131,73 +13042,89 @@ msgstr ""
 "<i><b>征募和召回</b></i>陆行僵尸和无魂怪。\n"
 "<i><b>6x3 冲击</b></i>伤害，<i>瘟疫</i>。"
 
-#. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:795
+#. [message]: speaker=Owaec
+#. said by Owaec, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:806
 msgid "Do not insult me! No clansman will ever stoop to such black magic."
-msgstr ""
+msgstr "休得侮辱我！没有一个氏族人会堕落到使用这等黑魔法。"
 
-#. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:802
+#. [message]: speaker=Gweddry
+#. said by Gweddry, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:814
 msgid ""
 "I already have an army of human soldiers — living soldiers. Let someone else "
 "use this staff."
-msgstr ""
+msgstr "我已经有一支人类士兵组成的军队了——活生生的士兵。这根法杖让别人去用吧。"
 
-#. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:809
+#. [message]: speaker=Dacyn
+#. said by Dacyn, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:822
 msgid ""
 "Tempting! Most tempting... but I fear it would be unwise for me to wield "
 "such a thing. That privilege passes onto another."
 msgstr ""
+"诱人！太诱人了……但我担心由我使用此物恐怕并非明智之举。这份特权就交给别人吧。"
 
-#. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:816
+#. [message]: speaker=Hahid al-Ali
+#. said by Hahid al-Ali, a Dune Herbalist, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:830
 msgid ""
 "Ha! Good joke! I’m not about to mess around with any of your foul northerner "
 "magic; necromancy was the cause of all this trouble in the first place."
 msgstr ""
+"哈！好个玩笑！我才不会去碰你们那套肮脏的北方魔法；死灵术从一开始就是这一切麻"
+"烦的罪魁祸首。"
 
-#. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:823
+#. [message]: speaker=Terraent
+#. said by Terraent, a Paladin, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:838
 msgid ""
 "I serve the light, not this staff of foul darkness! We should cast away this "
 "thing and be done with it."
 msgstr ""
+"我侍奉的是光明，不是这根污秽黑暗的法杖！我们应当把这东西扔掉，一了百了。"
 
-#. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:830
+#. [message]: speaker=Konrad
+#. said by King Konrad, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:846
 msgid ""
 "...what foul thing is this? Remove it from my presence; necromancy shall not "
 "take root in Wesnoth, not under my watch."
 msgstr ""
+"……这是何等污秽之物？把它从我眼前拿走。只要有我坐镇，死灵术休想在韦诺扎根。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:840
+#. said by a White Mage, Mage of Light, or Paladin, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:857
 msgid ""
 "No. I serve that which is good and light, and will not wield such a dark "
 "magical artifact."
-msgstr ""
+msgstr "不。我侍奉良善与光明，绝不会使用如此黑暗的魔法器物。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:850
+#. said by a dunefolk, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:868
 msgid ""
 "Fighting your northerners’ foul magic is bad enough. Don’t expect me to "
 "wield that — civilized cultures don’t mess around with magic."
 msgstr ""
+"跟你们北方人的肮脏魔法作战已经够糟了。别指望我会用那东西——有文化的文明，可不"
+"会胡乱摆弄魔法。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:856
+#. said by one of the player's units, when the player tries to give them a necromancer's staff
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:875
 msgid ""
 "I will not wield such a dark magical artifact, though I shall not begrudge "
 "its use by my companions."
 msgstr "我不会使用这样的黑暗魔法造物，尽管我不会介意我的同伴们使用它。"
 
 #. [effect]: type=impact
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:869
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:888
 msgid "plague staff"
 msgstr "瘟疫法杖"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:948
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:967
 msgid "Drop Plague Staff"
 msgstr "放下瘟疫法杖"
 
@@ -13206,7 +13133,7 @@ msgstr "放下瘟疫法杖"
 #. randomly getting a falcon, spider, wolf or sand scorpion corpse. Here “crown” means “top of head”, or “top of cephalothorax”.
 #. Dacyn says this the first time a corpse is recruited, and this event could happen in almost any scenario from S07b onwards.
 #. Even before picking up the amulet, he’s showing a level of interest that might get a student expelled from the Academy on Alduin
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:993
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1012
 msgid ""
 "Fascinating. The necromantic magic concentrates in the subject’s crown, "
 "replacing its bestial soul. Unnatural, yet effective."
@@ -13215,19 +13142,19 @@ msgstr ""
 
 #. [message]: speaker=Owaec
 #. First time a corpse is recruited by the wielder of the plague staff.
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:998
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1017
 msgid "A disgusting abomination! I lament living in such times..."
 msgstr "令人作呕的怪物！我哀叹生活在这个时代……"
 
 #. [object]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1056
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1075
 msgid "Gwza-Alswdan"
 msgstr "瓜扎-奥苏丹"
 
 #. [item_dialog]: description={ITEM_DESC}
 #. [item_dialog_musttake]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1094
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1250
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1113
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1269
 msgid ""
 "<span size='small'><i>  (Elixirs only last for 1 scenario.)</i></span>\n"
 "<span size='small'><i>  Picking up an item consumes your moves and attack.</"
@@ -13238,66 +13165,66 @@ msgstr ""
 "<span size='small'><i>拾取物品会消耗你的移动和攻击机会。</i></span>\n"
 "<b></b>"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1123
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1142
 msgid "Elixir of Water Breathing"
 msgstr "水下呼吸药水"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1124
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1143
 msgid ""
 "This shimmering blue vial grants its drinker normal movement and defense in "
 "swamp and shallow water."
 msgstr "这个闪烁着蓝色光芒的药瓶能让饮使用者在沼泽和浅水中正常移动和防御。"
 
 #. [floating_text]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1144
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1163
 msgid "<span color='#00FFFF' size='x-small'>water breathing</span>"
 msgstr "<span color='#00FFFF' size='x-small'>水下呼吸</span>"
 
 #. [trait]: id=TRAIT_waterbreathing
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1156
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1175
 msgid "waterbreathing"
 msgstr "水下呼吸"
 
 #. [trait]: id=TRAIT_waterbreathing
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1157
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1176
 msgid ""
 "An elixir of waterbreathing has given this unit normal movement and defense "
 "in swamp and shallow water."
 msgstr "水下呼吸药水让该单位在沼泽和浅水中拥有正常的移动和防御能力。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1190
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1209
 msgid "Elixir of Elements"
 msgstr "元素药水"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1191
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1210
 msgid ""
 "This bubbling yellow vial grants immunity to both fire and cold. It also "
 "makes you sweat profusely."
 msgstr "这个沸腾的黄色药瓶能让你免疫火焰和冰寒。也会让你大汗淋漓。"
 
 #. [floating_text]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1211
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1230
 msgid "<span color='#E8B923' size='x-small'>elemental resist</span>"
 msgstr "<span color='#E8B923' size='x-small'>元素抗性</span>"
 
 #. [trait]: id=TRAIT_elements
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1223
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1242
 msgid "elements"
 msgstr "元素"
 
 #. [trait]: id=TRAIT_elements
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1224
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1243
 msgid ""
 "An elixir of elements has given this unit immunity to both fire and cold."
 msgstr "元素药水赋予了这个单位对火焰和冰寒的免疫。"
 
 #. [item_dialog_musttake]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1247
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1266
 msgid "Elixir of Haste"
 msgstr "疾行药水"
 
 #. [item_dialog_musttake]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1249
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1268
 msgid ""
 "This saccharine green liquid grants +1 movement and +10% defense on all "
 "terrain. You may have difficulty standing still."
@@ -13306,27 +13233,27 @@ msgstr ""
 "站稳。"
 
 #. [floating_text]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1272
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1291
 msgid "<span color='#0BDA51' size='x-small'>haste</span>"
 msgstr "<span color='#0BDA51' size='x-small'>疾行</span>"
 
 #. [trait]: id=TRAIT_haste
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1284
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1303
 msgid "haste"
 msgstr "疾行"
 
 #. [trait]: id=TRAIT_haste
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1285
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1304
 msgid ""
 "An elixir of haste has given this unit +1 movement and +10% defense on all "
 "terrain."
 msgstr "疾行药水使该单位在所有地形上移动+1且防御力提升10%。"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1323
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1342
 msgid "Elixir of Fury"
 msgstr "狂怒药水"
 
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1324
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1343
 msgid ""
 "The red liquid in this vial sloshes violently, as though trying to escape. "
 "Drinking it grants <b><i>unlimited melee attacks</i></b> and the "
@@ -13336,17 +13263,17 @@ msgstr ""
 "攻击次数</i></b>以及<b><i>狂暴</i></b>近战特攻。"
 
 #. [floating_text]
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1344
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1363
 msgid "<span color='#FF0000' size='x-small'>berserker fury</span>"
 msgstr "<span color='#FF0000' size='x-small'>狂战士之怒</span>"
 
 #. [trait]: id=TRAIT_fury
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1356
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1375
 msgid "fury"
 msgstr "狂怒"
 
 #. [trait]: id=TRAIT_fury
-#: data/campaigns/Eastern_Invasion/utils/items.cfg:1357
+#: data/campaigns/Eastern_Invasion/utils/items.cfg:1376
 msgid ""
 "An elixir of fury has given this unit <b><i>unlimited melee attacks</i></b> "
 "and the <b><i>berserk</i></b> melee special."
@@ -13489,226 +13416,3 @@ msgstr ""
 "克服了重重困难，这个单位经受了玛尔-拉瓦纳尔的监狱的恐怖和折磨，并活着讲述了这"
 "个故事。幸存者承受着被囚禁的沉重负担，但也了解了以前囚禁他们的人的强项和弱"
 "点。"
-
-#~ msgid ""
-#~ "<span font_family='WesScript' size='90000'>\n"
-#~ "\n"
-#~ "\n"
-#~ "<i>Part III: Wesnoth at War </i></span>"
-#~ msgstr ""
-#~ "<span font_family='WesScript' size='90000'>\n"
-#~ "\n"
-#~ "\n"
-#~ "<i>第三部：战争中的韦诺</i></span>"
-
-#~ msgid ""
-#~ "I suppose you have a right to know of the adversary we face. I will tell "
-#~ "you about Mal-Ravanal."
-#~ msgstr "我想你们有权知道我们面临的敌人。我将告诉你关于玛尔-拉瓦纳尔的事情。"
-
-#~ msgid ""
-#~ "One drink from this shimmering blue vial and you’ll move at full speed* "
-#~ "through swamps and shallow water! <span color='#BCB088' size='x-"
-#~ "small'><i>*less effective on cavalry</i></span>"
-#~ msgstr ""
-#~ "从这闪亮的蓝色药瓶喝一口，你就可以在沼泽地和浅水中全速*移动！<span "
-#~ "color='#BCB088' size='x-small'><i>*对骑兵效果较差</i></span>"
-
-#~ msgid ""
-#~ "Supplies are limited so <span strikethrough='true'>call</span> buy now! "
-#~ "<i>(elixirs only last for 1 scenario)</i>"
-#~ msgstr ""
-#~ "补给有限，所以<span strikethrough='true'>安排</span>现在购买！<i>（药水只"
-#~ "在1个场景有效）</i>"
-
-#~ msgid "<b><span color='#00cc99'>Part II: The Wildlands</span></b>"
-#~ msgstr "<b><span color='#00cc99'>第二部：荒地</span></b>"
-
-#~ msgid "<span color='#00FF00' size='small'>resist</span>"
-#~ msgstr "<span color='#00FF00' size='small'>抵抗</span>"
-
-#~ msgid "Hissssss..."
-#~ msgstr "他的嘶嘶……"
-
-#~ msgid "<span size='small' font-style='italic'>AAAAHHHH!</span>"
-#~ msgstr "<span size='small' font-style='italic'>啊啊啊啊！</span>"
-
-#~ msgid "<span color='#00FF00' size='x-small'>weapons restored</span>"
-#~ msgstr "<span color='#00FF00' size='x-small'>武器被恢复</span>"
-
-#~ msgid ""
-#~ "<span size='small' font-style='italic'>And most importantly...</span>"
-#~ msgstr "<span size='small' font-style='italic'>而且最重要的是……</span>"
-
-#~ msgid ""
-#~ "I agree, yet all is strangely quiet. Perhaps the remaining undead lie "
-#~ "dormant? If we take time to capture villages and rebuild our forces, we "
-#~ "may yet be able to reclaim this place."
-#~ msgstr ""
-#~ "我同意，但一切出奇地安静。也许剩下的亡灵处于休眠状态？如果我们花时间占领村"
-#~ "庄并重建我们的力量，或许我们还能夺回这个地方。"
-
-#~ msgid ""
-#~ "It may be wise to capture villages and build up an army before attacking."
-#~ msgstr "在进攻之前占领村庄并建立军队可能是明智的。"
-
-#~ msgid ""
-#~ "We must finish here and hurry on from this dead place! If the Horse Clans "
-#~ "have fallen so completely, I fear for Weldyn and the rest of Wesnoth."
-#~ msgstr ""
-#~ "我们必须在这里结束，赶紧离开这个死寂的地方！如果马背氏族已经失败得这么彻"
-#~ "底，我担心维尔帝和韦诺的其他地方也会陷入危险。"
-
-#~ msgid ""
-#~ "Why are we here at all? We should be advancing towards Weldyn, not "
-#~ "humoring Owaec’s lust for vengeance. The Plains are already drowned."
-#~ msgstr ""
-#~ "我们究竟为什么要在这里？我们应该朝着维尔帝进发，而不是迎合欧瓦埃克那复仇的"
-#~ "欲望。平原已经淹没了。"
-
-#~ msgid ""
-#~ "Enough of this. We have wasted too much time here already; give up your "
-#~ "foolish quest of vengeance and travel on."
-#~ msgstr ""
-#~ "够了。我们已经浪费了太多时间在这里；放弃你那愚蠢的复仇计划，继续上路吧。"
-
-#~ msgid ""
-#~ "Your search for foul magic has caused enough harm already, and now you "
-#~ "would leave my countrymen’s bodies defiled by undeath? I will slay "
-#~ "everything that moves in this swamp, and once I am done, perhaps my "
-#~ "hammer will find you next!"
-#~ msgstr ""
-#~ "你对邪术的追求已经造成了足够的危害，现在你还想让我的同胞们变成被诅咒的亡灵"
-#~ "吗？我会杀死一切在这个沼泽中移动的东西，而当我完成这一切后，或许接下来我的"
-#~ "锤子就会找到你！"
-
-#~ msgid ""
-#~ "You fools are welcome to linger here clearing this swamp, but I intend to "
-#~ "travel on alone and defeat Mal-Ravanal. Go as you wish on your own. I "
-#~ "have a task to complete."
-#~ msgstr ""
-#~ "你们这些傻瓜可以留下来清理这个沼泽，但我打算独自上路去击败玛尔-拉瓦纳尔。"
-#~ "随你们怎么选。我有自己的任务要完成。"
-
-#~ msgid ""
-#~ "Then we must break through to the city at once! Come on men, follow me!"
-#~ msgstr "那我们必须立刻突围到城里！上吧，兄弟们，跟我来！"
-
-#~ msgid ""
-#~ "Dwarf, <i>necromancer</i>, know that Wesnoth will never tolerate your "
-#~ "kind. You shall surrender that accursed stave to be destroyed, you shall "
-#~ "foreswear the practice of all magic on penalty of death, and you are "
-#~ "hereby exiled from Wesnoth. Be grateful for Our mercy."
-#~ msgstr ""
-#~ "矮人，<i>死灵法师</i>，你知道韦诺绝不会容忍你这种人。你应该交出那根被诅咒"
-#~ "的棍子，让它被摧毁，你应该放弃练习所有的魔法，否则将被判处死刑，并且你因此"
-#~ "被驱逐出韦诺。请感谢我们的慈悲。"
-
-#~ msgid ""
-#~ "Aye, fair enough. I dinnae think my kinsmen will look kindly upon "
-#~ "necromancies either."
-#~ msgstr "是的，很公平。俺寻思俺的族人也不会对死灵术抱有善意。"
-
-#~ msgid ""
-#~ "Southerner, <i>necromancer</i>, know that Wesnoth will never tolerate "
-#~ "your kind. You shall surrender that accursed stave to be destroyed, you "
-#~ "shall foreswear the practice of all magic on penalty of death, and you "
-#~ "are hereby exiled back to the desert wastes. Be grateful for Our mercy."
-#~ msgstr ""
-#~ "南方人，<i>死灵法师</i>，你知道韦诺绝不会容忍你这种人。你应该交出那根被诅"
-#~ "咒的棍子，让它被摧毁，你应该放弃练习所有的魔法，否则将被判处死刑，并且你因"
-#~ "此被驱逐回沙漠。请感谢我们的慈悲。"
-
-#~ msgid ""
-#~ "Bah, I save you barbarians from an invasion, and this is the thanks I "
-#~ "get! What happened to being paid thrice what I’m owed? So much for "
-#~ "northerner generosity!"
-#~ msgstr ""
-#~ "呵呵，我把你们这些野蛮人从入侵中解救出来，这就是我得到的感谢吗！当初说好付"
-#~ "给我三倍的酬劳呢？北方人的慷慨也就这样了！"
-
-#~ msgid "Urban"
-#~ msgstr "城市丛林"
-
-#~ msgid ""
-#~ "Densely packed structures are less suitable for garrison than traditional "
-#~ "villages, providing no income or healing. They are difficult to navigate "
-#~ "quickly, but offer significant protection."
-#~ msgstr ""
-#~ "和传统的村庄相比，密集的建筑群不适合作为驻防地点，不会提供收入或治疗。它们"
-#~ "难以快速通行，但提供了显著的保护。"
-
-#~ msgid "female^Shadow Lord"
-#~ msgstr "暗影领主"
-
-#~ msgid ""
-#~ "Few humans fathom the secrets of light and dark magic and retain their "
-#~ "sanity. Those that can master that balance become Shadow Lords, fully "
-#~ "existing neither in the world of light nor the world of darkness. No "
-#~ "longer needing physical weapons, they are fearsome to both their enemies "
-#~ "and those they fight alongside."
-#~ msgstr ""
-#~ "很少人类能参透光明与黑暗魔法的奥秘而不失理智。那些可以掌握那种平衡的成为暗"
-#~ "影领主，既不完全属于光明世界，亦不完全属于黑暗世界。她们不再需要实体武器，"
-#~ "令敌人和并肩作战的人都恐惧。"
-
-#~ msgid "astral blade"
-#~ msgstr "星刃"
-
-#~ msgid "blast wave"
-#~ msgstr "冲击波"
-
-#~ msgid "female^Shadow Mage"
-#~ msgstr "暗影法师"
-
-#~ msgid ""
-#~ "Obsessive study over the forces of light and dark have turned the shadow "
-#~ "mages into feared fighters. Cloaked in mist, they have been known to "
-#~ "vanish into the night swifter than any ghost. While their zealous study "
-#~ "has left their bodies exhausted and enfeebled, they instead channel their "
-#~ "energies into devastatingly accurate melee attacks."
-#~ msgstr ""
-#~ "沉迷于光明与黑暗力量的研究，暗影法师们变成了令人畏惧的战士。他们身披迷雾，"
-#~ "在夜色中消失得比任何鬼魂都要迅速。尽管他们的狂热研究使身体疲惫虚弱，但他们"
-#~ "却将能量倾注于精准致命的近战攻击之中。"
-
-#~ msgid "shock"
-#~ msgstr "震击"
-
-#~ msgid ""
-#~ "In this campaign, whenever a max-level unit advances, they can select one "
-#~ "of several minor bonuses!"
-#~ msgstr ""
-#~ "在这个战役中，每当最高等级的单位升级时，他们可以选择几个次要奖励之一！"
-
-#~ msgid "Gain +8 hitpoints."
-#~ msgstr "获得 +8 生命值。"
-
-#~ msgid "Gain +4 melee damage."
-#~ msgstr "获得 +4 近战伤害。"
-
-#~ msgid "Gain +2 melee damage."
-#~ msgstr "获得 +2 近战伤害。"
-
-#~ msgid "Gain +1 melee damage."
-#~ msgstr "获得 +1 近战伤害。"
-
-#~ msgid "Gain +3 ranged damage."
-#~ msgstr "获得 +3 远程伤害。"
-
-#~ msgid "Gain +2 ranged damage."
-#~ msgstr "获得 +2 远程伤害。"
-
-#~ msgid "Gain +1 ranged damage."
-#~ msgstr "获得 +1 远程伤害。"
-
-#~ msgid "-I... -I am no lich! I am no harbinger of darkness, unlike Ravan!"
-#~ msgstr "—我…—我不是巫妖！我不是黑暗的先驱，不像莱文！"
-
-#~ msgid ""
-#~ "The wielder of the red stone shall become intertwined with the darkness "
-#~ "between worlds, whether they will it or not. You sought this Amulet of "
-#~ "your own will, O Magnificent Dacyn!"
-#~ msgstr ""
-#~ "执掌红石者将不可避免地与世界之间的黑暗交织在一起，无论其意愿如何。您是出于"
-#~ "自己的意志寻求这枚护身符的，啊，伟大的达辛！"

--- a/translations/wesnoth/po/wesnoth-l/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-l/zh_CN.po
@@ -1,25 +1,26 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
 # CloudiDust <cloudidust@gmail.com>, 2011.
 # wind <everywherewind@gmail.com>, 2012.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.18\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2025-10-21 01:10 UTC\n"
-"PO-Revision-Date: 2025-12-14 14:30+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-08-18 15:19 UTC\n"
+"PO-Revision-Date: 2026-08-29 15:16+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.8\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=Liberty
 #. [achievement_group]
@@ -60,7 +61,7 @@ msgstr "困难"
 
 #. [campaign]: id=Liberty
 #. "marchlander" is archaic English for an inhabitant of a border region, not to be confused with "marshlander"
-#: data/campaigns/Liberty/_main.cfg:26
+#: data/campaigns/Liberty/_main.cfg:25
 msgid ""
 "As the shadow of civil war deepens across Wesnoth, a band of hardy "
 "marchlanders revolts against the governance of the new queen. To win their "
@@ -73,36 +74,37 @@ msgstr ""
 "\n"
 
 #. [campaign]: id=Liberty
-#: data/campaigns/Liberty/_main.cfg:28
+#: data/campaigns/Liberty/_main.cfg:27
 msgid "(Novice level, 7 scenarios.)"
 msgstr "（新手级别，7幕场景。）"
 
 #. [campaign]: id=Liberty
-#: data/campaigns/Liberty/_main.cfg:30
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Liberty/_main.cfg:31
 msgid ""
-"Story continued in:\n"
-"Heir to the Throne"
+"The saga continues in\n"
+"<i>Heir to the Throne</i>"
 msgstr ""
 "故事续于：\n"
-"王座继承人"
+"<b>王座继承人</b>"
 
 #. [about]
-#: data/campaigns/Liberty/_main.cfg:34
+#: data/campaigns/Liberty/_main.cfg:35
 msgid "Original Campaign Design"
 msgstr "原战役设计"
 
 #. [about]
-#: data/campaigns/Liberty/_main.cfg:40
+#: data/campaigns/Liberty/_main.cfg:41
 msgid "Latest Rewrite"
 msgstr "最新改写"
 
 #. [about]
-#: data/campaigns/Liberty/_main.cfg:46
+#: data/campaigns/Liberty/_main.cfg:47
 msgid "Campaign Maintenance"
 msgstr "战役维护"
 
 #. [about]
-#: data/campaigns/Liberty/_main.cfg:56
+#: data/campaigns/Liberty/_main.cfg:57
 msgid "Artwork and Graphics Design"
 msgstr "插图与图形设计"
 
@@ -114,7 +116,7 @@ msgstr "给我自由或者给我死亡！"
 #. [achievement]: id=liberty_or_death
 #: data/campaigns/Liberty/achievements.cfg:8
 msgid "Complete <i>Civil Disobedience</i> with at least 3 peasants remaining."
-msgstr "完成<i>温和反抗</i>时至少有3个农民存活。"
+msgstr "完成 <b>温和反抗</b> 时，至少有3个农民存活。"
 
 #. [achievement]: id=liberty_nameless
 #: data/campaigns/Liberty/achievements.cfg:14
@@ -124,7 +126,7 @@ msgstr "无名卫兵"
 #. [achievement]: id=liberty_nameless
 #: data/campaigns/Liberty/achievements.cfg:15
 msgid "Discover the name of the royal guard in <i>Unlawful Orders</i>."
-msgstr "在<i>不法命令</i>中找出侍卫的名字。"
+msgstr "在 <b>不法命令</b> 中，找出侍卫的名字。"
 
 #. [achievement]: id=liberty_iron
 #: data/campaigns/Liberty/achievements.cfg:21
@@ -134,7 +136,7 @@ msgstr "哈珀大战歌利亚"
 #. [achievement]: id=liberty_iron
 #: data/campaigns/Liberty/achievements.cfg:22
 msgid "Defeat an Iron Mauler with Harper in <i>Hide and Seek</i>."
-msgstr "在<i>捉迷藏</i>一幕用哈珀击败一名铁锤兵。"
+msgstr "在 <b>捉迷藏</b> 中，用哈珀击败一名铁锤兵。"
 
 #. [achievement]: id=liberty_hunter
 #. this is the achievement for the scenario The Hunters
@@ -145,7 +147,7 @@ msgstr "完美猎人"
 #. [achievement]: id=liberty_hunter
 #: data/campaigns/Liberty/achievements.cfg:30
 msgid "Complete <i>The Hunters</i> with no losses."
-msgstr "无损失完成<i>猎手</i>。"
+msgstr "无损失完成 <b>猎手</b>。"
 
 #. [achievement]: id=liberty_army
 #: data/campaigns/Liberty/achievements.cfg:36
@@ -155,7 +157,7 @@ msgstr "没有战略的武装毫无意义"
 #. [achievement]: id=liberty_army
 #: data/campaigns/Liberty/achievements.cfg:37
 msgid "On Challenging difficulty, defeat Dommel in <i>Glory</i>."
-msgstr "在挑战者难度，在<i>荣耀</i>击败多梅尔。"
+msgstr "在挑战者难度的 <b>荣耀</b> 中，击败多梅尔。"
 
 #. [scenario]: id=01_The_Raid
 #: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:4
@@ -238,7 +240,7 @@ msgstr "法尔·卡格"
 #: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:85
 #: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:66
 #: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:101
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:120
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:119
 msgid "Orcs"
 msgstr "兽人"
 
@@ -255,26 +257,26 @@ msgstr "地精到达达尔本村"
 #. [objective]: condition=lose
 #: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:116
 #: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:101
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:175
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:181
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:176
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:198
 #: data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg:157
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:189
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:158
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:232
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:430
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:190
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:157
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:231
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:428
 msgid "Death of Baldras"
 msgstr "巴尔德拉斯死亡"
 
 #. [objective]: condition=lose
 #: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:120
 #: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:105
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:179
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:185
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:180
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:202
 #: data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg:161
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:193
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:162
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:236
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:434
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:194
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:161
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:235
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:432
 msgid "Death of Harper"
 msgstr "哈珀死亡"
 
@@ -359,20 +361,20 @@ msgid "Treagh"
 msgstr "特雷加"
 
 #. [unit]: type=Footpad_Peasant, id=Harper, gender=female
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:232
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:230
 msgid "Harper"
 msgstr "哈珀"
 
 #. [message]: speaker=Red
 #. Other country folk also have accents
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:259
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:257
 msgid ""
 "Look, goblin riders approach! You was right, they was going to raid Dallben "
 "while we was gone."
 msgstr "看，地精骑手来了！你说对了，他们想在俺们离开的时候偷袭达尔本。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:263
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:261
 msgid ""
 "We gots to stop them or they’ll burn down the whole village. Damn these "
 "goblins and damn the Crown. We always be havin’ to fight for ourselves."
@@ -384,7 +386,7 @@ msgstr ""
 #. Harper has a bit of an accent, but not as much as Baldras. She's a bit reckless as Baldras alludes to, but is more polite.
 #. Harper is quite the tomboy and her personality should reflect that, she should use words that are exciting and high spirited
 #. She's also pretty young (teenagerish) so her dialogue should reflect some lack of experience or immaturity
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:270
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:268
 msgid ""
 "Uncle, we got no time to talk! Them riders are heading full speed straight "
 "for Dallben. We’ll need to chase them down through those woods, and fast, or "
@@ -394,13 +396,13 @@ msgstr ""
 "上了。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:274
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:272
 msgid ""
 "Do it. Hold them beasts back till us old-timers get there to finish ‘em off."
 msgstr "干吧。挡着那帮子野兽，等俺们这些老骨头上来把丫们都做了。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:278
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:276
 msgid ""
 "And Harper... don’t be getting reckless on me today. Your old man died like "
 "that, charging into a pack of goblins by ‘imself. I won’t lose ya the same "
@@ -410,19 +412,19 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:282
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:280
 msgid "I know, I know, no need to worry so much. All right, let’s go!"
 msgstr "知道了知道了，别这么担心。行了，走着！"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:296
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:294
 msgid ""
 "These orc raids keep getting harder and harder to hold off. Feels like every "
 "new day’s just another chance for us to lose everything..."
 msgstr "兽人这袭击越来越难搞了。俺觉着俺们每天都可能会输得啥都不剩……"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:300
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:298
 msgid ""
 "That Garard II stopped sendin’ patrols out here a while back. Stinker "
 "probably sent his troops on some new war against them orcs. Don’t really "
@@ -434,7 +436,7 @@ msgstr ""
 "忙。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:304
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:302
 msgid ""
 "Then why do we got to pay taxes to the King? Maybe Elensefar doesn’t help "
 "us, but at least they don’t take our gold."
@@ -442,7 +444,7 @@ msgstr ""
 "那俺们为啥交税给国王？也许埃仁撒伐是没帮俺们，但他们至少没拿俺们的钱啊。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:308
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:306
 msgid ""
 "We don’t got no choice, lass. If I don’t gives them what they want, they’ll "
 "make trouble for everyone in Dallben."
@@ -450,7 +452,7 @@ msgstr ""
 "俺们没得选，姑娘。要是不把他们想要的钱给了，他们会让达尔本所有人都倒霉。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:312
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:310
 msgid ""
 "But we can’t keep doing this forever, Uncle. If we stay like this, those "
 "orcs will eventually overrun us. What should we do?"
@@ -459,7 +461,7 @@ msgstr ""
 "怎么办？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:316
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:314
 msgid ""
 "I don’t know, Harper. I just don’t know. Alls I can say is we’re on our own "
 "out here."
@@ -467,97 +469,97 @@ msgstr "俺不晓得，哈珀。俺真是不晓得。只能讲，俺们在这儿
 
 #. [message]: speaker=Harper
 #. Harper has a scar from a fire burn on the right side of her face
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:338
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:336
 msgid "My face kinda itches... I gotta be careful around these big ones."
 msgstr "俺的脸有点痒…我必须小心这些大家伙。"
 
 #. [message]: speaker=Fal Khag
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:355
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:353
 msgid "Time to feast on these puny pinkskins."
 msgstr "是时候大快朵颐一下这些弱小的粉皮佬了。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:360
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:358
 msgid "Hey! Who ya calling puny?"
 msgstr "喂！你丫说谁弱小啊？"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:375
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:373
 msgid "Ahh! I <i>really</i> don’t like fire..."
 msgstr "啊！我 <i>真的</i>不喜欢火..."
 
 #. [message]: speaker=Fal Khag
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:387
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:385
 msgid "I was... too weak..?"
 msgstr "我……太弱了……？"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:392
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:390
 msgid "Silly goblin."
 msgstr "地精蠢货。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:408
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:406
 msgid ""
 "Hey, someone left their pack here. I could use it to carry some heavier "
 "rocks."
 msgstr "嘿，有人的背包丢这儿了。俺能拿来装些更重的石头。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:435
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:433
 msgid "Your footpad has gained +1 ranged damage!"
 msgstr "你的走卒获得了 +1 远程伤害输出！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:447
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:445
 msgid "Spooky."
 msgstr "怪了。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:487
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:485
 msgid "They’re getting close to Dallben! What should we do?"
 msgstr "他们接近达尔本了！怎么办？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:491
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:489
 msgid ""
 "There be a couple guards in the village. Might be able to slow them wolves "
 "down if they gets closer."
 msgstr "村里有几个卫兵。要是他们能过来，搞不好能拖住那些狼。"
 
 #. [event]
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:504
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:502
 msgid "Remald"
 msgstr "雷马尔德"
 
 #. [event]
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:505
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:503
 msgid "Wolmas"
 msgstr "沃尔马斯"
 
 #. [message]: speaker=Wolmas
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:513
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:509
 msgid "What’s happening here? Why be you running like mad, $unit.name|?"
 msgstr "这儿咋了？你干嘛跑这么疯，$unit.name|？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:517
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:513
 msgid ""
 "Goblin riders be on the hunt, headed right for Dallben. We gots to stop them!"
 msgstr "地精骑手狩猎来了，他们冲着达尔本来了！得阻止他们！"
 
 #. [message]: speaker=Wolmas
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:524
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:520
 msgid "Look! Goblin riders be on the hunt, headed right for Dallben!"
 msgstr "看！地精骑手狩猎来了，他们冲着达尔本来了！"
 
 #. [message]: speaker=Remald
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:528
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:524
 msgid "We gots to stop them!"
 msgstr "得阻止他们！"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:548
+#: data/campaigns/Liberty/scenarios/01_The_Raid.cfg:544
 msgid ""
 "The goblins reached the village! Now there’ll be nothing left after they "
 "raid our homes..."
@@ -614,8 +616,8 @@ msgstr ""
 #: data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg:130
 #: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:82
 #: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:106
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:46
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:132
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:45
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:131
 msgid "Rebels"
 msgstr "义军"
 
@@ -637,7 +639,7 @@ msgstr "塔文"
 #: data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg:102
 #: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:124
 #: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:143
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:87
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:86
 msgid "Weldyn"
 msgstr "维尔帝"
 
@@ -787,21 +789,21 @@ msgstr ""
 "啥。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:425
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:424
 msgid ""
 "We’ve got to tell the people of Delwyn about this. Ol’ magistrate Relana "
 "will have some ideas."
 msgstr "得把这事告诉德尔文的人。老治安官蕾拉娜应该知道些啥。"
 
 #. [message]: role=Advisor
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:430
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:429
 msgid ""
 "That’s true. Whenever there’s been troubles, we’ve always looked to her for "
 "help."
 msgstr "这倒是。有麻烦的时候，俺们老找她帮忙的。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:435
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:434
 msgid ""
 "Fine. We’ll go to Delwyn, see what Relana gots to say. With them riders so "
 "eagerly attackin’ us today, I’m thinking Delwyn will be under threat too."
@@ -810,44 +812,44 @@ msgstr ""
 "文也危险了。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:440
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:439
 msgid "So we’ll have to fight them Wesnothians again?"
 msgstr "那俺们又要和韦诺人打了？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:445
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:444
 msgid ""
 "Alls I can say for certain is we’ve made ourselves enemies of the Crown. "
 "They’ll be hunting us now."
 msgstr "俺只能说，现在俺们成了王室的敌人。他们现在会追杀俺们。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:450
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:449
 msgid "Then we’re outlaws."
 msgstr "那俺们就是亡命徒了。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:455
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:454
 msgid "Aye, outlaws."
 msgstr "对，亡命徒。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:521
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:527
 msgid "Your units — formerly <i>neutral</i> — are now <i>chaotic</i>!"
 msgstr "你的单位 —— 之前是<i>中立</i> —— 现在变为<i>混沌</i>！"
 
 #. [message]: speaker=Reinforcement Knight
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:555
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:561
 msgid "At your order, Captain."
 msgstr "听从您的命令，队长。"
 
 #. [message]: speaker=Tarwen
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:559
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:565
 msgid "Slay them all."
 msgstr "把他们都杀光。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:563
+#: data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg:569
 msgid ""
 "Curses! Their reinforcements has arrived. We gots no chance to fight ‘em off "
 "now..."
@@ -930,22 +932,22 @@ msgid "Relana"
 msgstr "蕾拉娜"
 
 #. [objective]: condition=win
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:171
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:172
 msgid "Defeat both enemy leaders"
 msgstr "击败两名敌方首领"
 
 #. [objective]: condition=lose
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:183
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:184
 msgid "Death of Relana"
 msgstr "蕾拉娜死亡"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:217
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:218
 msgid "Baldras! Ya made it! Lil Harper here told me all about what happened."
 msgstr "巴尔德拉斯！你来啦！小哈珀已经把事儿都和俺说了。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:221
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:222
 msgid ""
 "Aye, Relana. It were one o’ the Queen’s patrol, strange as it do sound. "
 "Turns out they was itchin’ to attack us soon as I wasn’t willing to leave "
@@ -955,12 +957,12 @@ msgstr ""
 "们走，他们马上就打上来了。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:225
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:226
 msgid "But we fought those ugly scoundrels off!"
 msgstr "不过俺们把那些丑八怪恶棍打跑了！"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:229
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:230
 msgid ""
 "Queen’s patrol, ya say? They sent them a messenger our way a couple days "
 "ago, demanding our allegiance to some ‘Asheviere’. Weren’t that Garard’s "
@@ -970,7 +972,7 @@ msgstr ""
 "伽拉德的年轻新娘么？为什么现在是她在发号施令？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:233
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:234
 msgid ""
 "I don’t know, but some of them riders escaped us. Bet they’ll report back to "
 "their local garrison, tell them we’re a bunch o’ traitors."
@@ -978,24 +980,24 @@ msgstr ""
 "俺不知道，但有些他们的骑手逃跑了。俺打赌他们会报告驻军，说俺们是一群叛徒。"
 
 #. [message]: role=Advisor
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:237
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:238
 msgid "Then they’ll be comin’ back in force."
 msgstr "而后他们的大军就会回来了。"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:241
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:242
 msgid ""
 "We needs more information. We should consult ourselves with Elensefar. Lord "
 "Maddock surely gots to know more than us."
 msgstr "俺们需要更多情报，应该去问问埃仁撒伐。马多克领主知道的肯定比俺们多。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:245
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:246
 msgid "Elensefar? Why him?"
 msgstr "埃仁撒伐？为啥找他？"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:249
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:250
 msgid ""
 "Well all Annuvin be ruled by Elensefar, right? We don’t gots to heed "
 "anything Wesnoth says. Lord Maddock’s technically the one we answer to."
@@ -1004,14 +1006,14 @@ msgstr ""
 "领主的。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:253
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:254
 msgid ""
 "It don’t matter. Weldyn be doing whatever it likes while Maddock says "
 "nothing. He knows, but he don’t care."
 msgstr "有区别么。维尔帝想干啥就干啥，马多克啥意见都没有。他都知道，但他不管。"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:257
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:258
 msgid ""
 "But we still need that knowledge, Baldras. We can’t be coming up with any "
 "great plan without no information. We both knows that if Weldyn brings one "
@@ -1021,23 +1023,23 @@ msgstr ""
 "都知道，要是维尔帝派军队过来，俺们没法打跑他们的。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:261
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:262
 msgid ""
 "Perhaps, but — hold there. Did ya hear that? Sounded like some wolf howl."
 msgstr "大概吧，不过——等等。听到了没？听起来像狼嚎。"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:265
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:266
 msgid "Somethin’ smells like lizard too. We’re not alone here."
 msgstr "还有闻着像蜥蜴的东西，我们有伴儿了。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:269
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:270
 msgid "Finally, some action!"
 msgstr "终于可以动动手了！"
 
 #. [message]: speaker=Urk Delek
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:277
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:278
 msgid ""
 "Blasted humans and blasted Fal Khag! Stupid goblin was only supposed to "
 "scout that puny village, not fight it by himself. Then those damned humans "
@@ -1047,7 +1049,7 @@ msgstr ""
 "上去了。接着那些他妈的人类不让我们帮忙，那结果呢。"
 
 #. [message]: speaker=Urk Delek
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:281
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:282
 msgid ""
 "“Don’t know why the Queen hired some stinkin’ orcs, we don’t need you here.” "
 "Yeah, well now they’re dead like a bunch of beasts."
@@ -1095,46 +1097,46 @@ msgid "I don’t likes me the look of that water."
 msgstr "俺不喜欢那样子的水。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:409
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:411
 msgid "Ahh! Help, it’s a tentacle monster!"
 msgstr "啊，救命！有触手怪物！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:422
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:424
 msgid "That’s some fresh tasty water. Mmm!"
 msgstr "新鲜可口的水。嗯！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:443
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:445
 msgid "Your unit has gained +1 maximum hitpoints!"
 msgstr "你的单位获得了 +1 最大生命值！"
 
 #. [message]: speaker=Urk Delek
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:459
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:461
 msgid "Blasted pinkskins..."
 msgstr "该死的粉皮佬……"
 
 #. [message]: speaker=Thhsthss
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:472
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:473
 msgid "Thissss was not part of the deal..."
 msgstr "交易里可没有这个嘶嘶……"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:481
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:482
 msgid ""
 "Something be very wrong here. These orcs has weapons with army forge-"
 "markings."
 msgstr "老不对劲了。兽人的武器有军队的铸造标记。"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:485
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:486
 msgid ""
 "Aye, and the gold in their pouches looks new from mint. Could just be "
 "plunder, but..."
 msgstr "对。而且他们袋里的金币看来是最近造的。可能就是抢来的，但是……"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:489
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:490
 msgid ""
 "Don’t seem like it. I be thinking these orcs were hired to scout us. But for "
 "what? Of all the alliances to be making, why would Weldyn be hiring orcs?"
@@ -1143,7 +1145,7 @@ msgstr ""
 "为啥要雇兽人？"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:493
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:494
 msgid ""
 "I thinks your mission to Lord Maddock just became even more urgent. We needs "
 "to know the Queen’s motives."
@@ -1151,7 +1153,7 @@ msgstr ""
 "我觉着到马多克领主那儿去的任务现在更紧急了。我们得搞清楚女王为啥这么干。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:497
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:498
 msgid ""
 "I don’t like leaving our people here alone, but I sees your point. If we "
 "wait, more will be coming."
@@ -1159,7 +1161,7 @@ msgstr ""
 "俺不想把人一个人留在这儿，不过俺懂你的意思。要是等下去，更多敌人会来的。"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:501
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:502
 msgid ""
 "For now, I can stay here and perhaps talk them Wesnothians out of attacking "
 "us directly, but I don’t thinks it will work forever. To survive this, we "
@@ -1169,12 +1171,12 @@ msgstr ""
 "这能一直有用。要想活下来，俺们得快点儿，巴尔德拉斯。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:505
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:506
 msgid "Then we’ll go to Elensefar as fast as we can. Luck be with ya, Relana."
 msgstr "那俺们得尽快到埃仁撒伐去。祝你好运，蕾拉娜。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:523
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:524
 msgid ""
 "We gots no more time to be spending here nor to be traveling to Elensefar... "
 "them Wesnothians probably already be mobilizing against us. We’ve got to "
@@ -1184,7 +1186,7 @@ msgstr ""
 "俺们了。俺们得回达尔本去！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:529
+#: data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg:530
 msgid ""
 "Baldras and Relana returned to their villages to find them destroyed, with "
 "any survivors borne away to unknown fates. It was a bitter doom, and as "
@@ -1200,44 +1202,45 @@ msgid "Unlawful Orders"
 msgstr "不法命令"
 
 #. [side]: type=Lord of Elensefar, id=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:89
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:106
 msgid "Lord Maddock"
 msgstr "马多克领主"
 
 #. [side]: type=Lord of Elensefar, id=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:98
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:115
 msgid "Elensefar"
 msgstr "埃仁撒伐"
 
 #. [objective]: condition=win
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:177
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:194
 msgid "Defeat the enemy leader"
 msgstr "击败敌方首领"
 
 #. [objective]: condition=lose
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:189
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:206
 msgid "Death of Maddock"
 msgstr "马多克死亡"
 
 #. [event]
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:236
+#. "Daneth" is the name of Lord Maddock's late son. This ship also appears in HttT's S10, with the same name.
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:255
 msgid "The Daneth"
 msgstr "达内斯"
 
 #. [event]
 #. [unit]: type=Skiff, id=Skiff
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:237
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:256
 #: data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg:330
 msgid "Mary’s Minnow"
-msgstr ""
+msgstr "玛丽的小鲫鱼"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:296
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:315
 msgid "Maddock, I be coming to report—"
 msgstr "马多克，俺是来报告——"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:300
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:319
 msgid ""
 "I am already aware of your altercation in Dallben, Baldras. Your dissent was "
 "not wise."
@@ -1245,7 +1248,7 @@ msgstr "我已经知道你们在达尔本的争端了，巴尔德拉斯。你的
 
 #. [message]: speaker=Baldras
 #. pigdirt is slang for bullshit or hogwash
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:305
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:324
 msgid ""
 "Dissent? Maddock, I’m not trusting no strange riders who show up out of "
 "nowhere claimin’ to be from the Queen. Seems like a bunch of pigdirt to me."
@@ -1254,7 +1257,7 @@ msgstr ""
 "来他们说的话就和猪粪似的。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:309
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:328
 msgid ""
 "That was partially my fault, since I was not able to send a messenger to you "
 "in time. I shall have to inform you now. Five weeks ago, at the Ford of "
@@ -1264,16 +1267,19 @@ msgstr ""
 "诺的伽拉德二世国王被谋杀了。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:313
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:332
 msgid ""
 "Officially, one of his captains committed the crime. Unofficially, it is "
 "rumored that Queen Asheviere and her son Eldred were involved. Either way, "
 "Prince Eldred fell in battle not long after, upon which Asheviere claimed "
 "the throne."
 msgstr ""
+"官方说法是，他的一名队长犯下了这起罪行。非官方的说法则是，有传言称艾什维尔女"
+"王和她的儿子埃德雷德也卷入了此事。无论如何，埃德雷德王子不久后就在战斗中阵"
+"亡，随后艾什维尔女王登上了王位。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:317
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:336
 msgid ""
 "The Queen is not popular. She is at war with supporters of the old king, and "
 "searches far and wide for new conscripts. Part of that has been taking "
@@ -1285,12 +1291,12 @@ msgstr ""
 "目的。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:321
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:340
 msgid "Annuvin province be ruled by Elensefar! We has no duty to Weldyn."
 msgstr "安努文省是埃仁撒伐管的！俺们不对维尔帝尽忠。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:325
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:344
 msgid ""
 "You do now. I do not really need to tell you what will happen should you "
 "refuse Her Majesty’s offer."
@@ -1298,7 +1304,7 @@ msgstr ""
 "你现在得尽忠了。我真不必告诉你，如果你拒绝女王陛下的提议，那会发生什么。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:329
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:348
 msgid ""
 "Grow a spine, Maddock. If they come to ya and make you swear fealty to this "
 "Asheviere, would ya really give up that easy?"
@@ -1307,16 +1313,19 @@ msgstr ""
 "单就放弃吗？"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:333
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:352
 msgid ""
 "They will not come. I do not intend to pick a side in Wesnoth’s conflict, "
 "and the Queen knows better than to try to force my hand. It is true that she "
 "maintains a large garrison south at the great fortress of Halstead, but even "
 "should they mobilize all their troops, I doubt they could take Elensefar."
 msgstr ""
+"他们不会来的。我不打算在韦诺的冲突中选边站，女王也明白不该试图强迫我表态。诚"
+"然，她在南面的哈尔斯特德大要塞驻守着一支庞大的军队，但即便他们动员全部兵力，"
+"我也怀疑他们能否攻下埃仁撒伐。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:337
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:356
 msgid ""
 "But we can’t do nothing! The Queen even be sending them beast orcs against "
 "us, that’s how evil she is! Surely you can’t stand for this..."
@@ -1325,7 +1334,7 @@ msgstr ""
 "了吧……"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:341
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:360
 msgid ""
 "Yes, I am aware of Queen Asheviere’s propensity for hiring orcs to "
 "supplement her forces. I have begun expanding my army as well, although I "
@@ -1333,9 +1342,12 @@ msgid ""
 "and we are not in the habit of maintaining a large standing army. It will "
 "take time to assemble mercenaries of the right caliber."
 msgstr ""
+"是的，我知道艾什薇尔女王向来有雇佣兽人补充兵力的倾向。我也已经开始扩充军队"
+"了，尽管我认为战事爆发的可能性不大。但埃仁撒伐的人口不多，我们也没有维持大规"
+"模常备军的习惯。要召集到素质合格的雇佣兵还需要时间。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:345
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:364
 msgid ""
 "The treaty between Elensefar and Wesnoth is ancient, and I do not think Her "
 "Majesty means to break it. But I cannot afford to make enemies of Weldyn, as "
@@ -1343,41 +1355,46 @@ msgid ""
 "wizard and his rebels have suffered several defeats. I have some concessions "
 "that I shall have to make..."
 msgstr ""
+"埃仁撒伐与韦诺之间的条约由来已久，我不认为女王陛下有意撕毁它。但我不能冒与维"
+"尔帝为敌的风险，想必你也能理解。艾什薇尔看来正在赢得这场内战。那位巫师和他的"
+"叛军已遭受数次挫败。我将不得不做出一些让步……"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:349
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:368
 msgid "And what abouts us? Throw us like dogs to those Wesnothians?"
 msgstr "那俺们呢？你要把俺们像狗一样扔给那些韦诺人？"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:353
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:372
 msgid ""
 "Do not put words in my mouth. I am more than willing to act should the need "
 "arise. I am already in covert communication with— ...listen, there is a "
 "bigger picture here, Baldras."
 msgstr ""
+"别曲解我的意思。一旦有必要，我非常愿意采取行动。我已经在暗中与——……听着，鲍德"
+"拉斯，这里头有更大的考量。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:357
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:376
 msgid ""
 "The bigger picture of you idly sittin’ here waiting till them Wesnothians "
 "come to take the city right from your hands."
 msgstr "大局就是你在这儿啥都不干傻坐着，等着韦诺人来抢走这城市。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:361
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:380
 msgid "I very much doubt they would be bold enough to attack us outright—"
 msgstr "我觉得他们不会胆敢直接攻击我们——"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:365
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:384
 msgid ""
 "Head out of your behind, Maddock. Open your eyes! Look south and tell me "
 "that again!"
 msgstr "别把头塞屁眼里了，马多克。睁开眼睛！看看南边，再和俺说一次！"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:378
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:397
 msgid ""
 "An invading army? No, something is not right with those soldiers... but I "
 "presume we have no time to ponder that. To arms!"
@@ -1385,25 +1402,25 @@ msgstr ""
 "一支入侵军队？不，这些士兵有些不对劲……但我想没时间琢磨这个了。武装起来！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:393
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:412
 msgid "Hey, look! Some buried treasure!"
 msgstr "嘿，看啊！这里埋着些宝藏！"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:421
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:440
 msgid ""
 "It says, “Here lies Daneth, child of the Light, loyal defender of Lord and "
 "Land.”"
 msgstr "上面写着：“这里安眠着达内斯，圣光之子，主与土地的忠诚卫士。”"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:425
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:435
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:444
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:454
 msgid "Maddock’s firstborn son."
 msgstr "马多克的长子。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:431
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:450
 msgid ""
 "It says, “Here lies Daneth, child of the Light, loyal defender of Lord and "
 "Land.” Whoever that was."
@@ -1412,62 +1429,62 @@ msgstr ""
 
 # 一般中文中对上文的反应是“啊”而不是“哦”。
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:439
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:458
 msgid "Oh."
 msgstr "啊。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:460
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:481
 msgid "Hold there, soldier! Can we not come to terms without bloodshed?"
 msgstr "别动，士兵！我们就不能不流血地达成协议吗？"
 
 #. [message]: speaker=Kestrel
 #. [message]: speaker=Lord Maddock
 #. [message]: type=Heavy Infantryman
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:464
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:912
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:856
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:485
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:933
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:857
 msgid "..."
 msgstr "……"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:468
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:489
 msgid "Hmm. Something is quite wrong indeed..."
 msgstr "呃。确实很不对劲……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:481
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:502
 msgid "<i>The sun sets...</i>"
 msgstr "<b>夕阳西下……</b>"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:486
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:507
 msgid ""
 "Baldras and Harper watch, petrified, as the skin and flesh of their "
 "adversaries begin to rot away."
 msgstr "巴尔德拉斯和哈珀呆立在原地，看着对手们的皮肤和肉体开始腐烂。"
 
 #. [wml_message]
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:571
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:592
 msgid "Could not convert a $stored_changers[$i].type, please report!"
 msgstr "无法转换$stored_changers[$i].type，请发送错误报告！"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:828
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:849
 msgid ""
 "Them things look like evil spirits! Are they those undead you told me about, "
 "Uncle?"
 msgstr "这些东西看着像恶灵！它们就是你告诉俺的“亡灵”吗，舅舅？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:832
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:853
 msgid ""
 "They bears some likeness, but these men almost seem half alive. This be some "
 "kind of truly dreadful sorcery."
 msgstr "他们和亡灵看起来有点像，但这些人似乎还半死不活。这还真是可怕的巫术啊。"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:843
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:864
 msgid ""
 "So, their human aspect returns. Whatever these creatures are, we shall crush "
 "them all under the light of the sun."
@@ -1476,17 +1493,17 @@ msgstr ""
 "它们全部粉碎。"
 
 #. [modify_unit]
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:865
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:886
 msgid "Kestrel"
 msgstr "茶隼"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:872
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:893
 msgid "Who are you? What are you?"
 msgstr "你们是谁？你们怎么了？"
 
 #. [message]: speaker=Kestrel
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:876
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:897
 msgid ""
 "We... are accursed. We were the soldiers of Prince Eldred, the King’s son "
 "and betrayer... when the Prince stooped to black magic, we were damned... "
@@ -1496,24 +1513,25 @@ msgstr ""
 "于黑魔法时，我们被诅咒了…我们这些见证者扭曲成了这些奇形怪状的东西。"
 
 #. [message]: speaker=Kestrel
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:880
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:901
 msgid ""
 "The Queen sent us away... sent us west. Now, our mortal bodies pass... into "
 "another plane of hellish existence..."
 msgstr ""
+"女王将我们遣走……派往西方。如今，我们的凡躯正在消逝……进入另一个地狱般的位面……"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:903
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:924
 msgid "Such is the price for treachery."
 msgstr "这就是背叛的代价。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:907
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:928
 msgid "Maddock, we helped you defend your city. Will you help us now?"
 msgstr "马多克，我们帮你保卫了城市。你现在会帮俺们不？"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:917
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:938
 msgid ""
 "<i>Listen carefully. I shall not openly speak against Asheviere seeing as "
 "some of her spies are in the city... however, rest assured, I certainly do "
@@ -1523,12 +1541,12 @@ msgstr ""
 "不相信女王和她那些有问题的战术。</i>"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:921
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:942
 msgid "<i>What can ya offer us then?</i>"
 msgstr "<i>那你能给俺们啥呢？</i>"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:925
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:946
 msgid ""
 "<i>Well, I do not normally make my relationship with them known, but I can "
 "make an exception. Southeast of here, in Carcyn, you may find assistance "
@@ -1543,7 +1561,7 @@ msgstr ""
 "巡逻队。我最多就能做到这样了。</i>"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:929
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:950
 msgid ""
 "<i>Hmph. Clear that you won’t help us fight, but I gots no more time to be "
 "stayin’ here. If we is going to resist the Crown a second time, we needs "
@@ -1554,14 +1572,14 @@ msgstr ""
 "有个好计划。但愿你这不是让俺们去送死，马多克。</i>"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:949
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:970
 msgid ""
 "More troops be coming from the south! With all them reinforcements, we gots "
 "no chance to defend Elensefar!"
 msgstr "更多的部队从南边过来了！这些援军一到，俺们就没可能守住埃仁撒伐了！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:962
+#: data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg:983
 msgid ""
 "Asheviere’s armies assembled and struck before the nascent rebellion could "
 "even be planned. Without the necessary forces, Annuvin soon fell under "
@@ -1909,32 +1927,32 @@ msgid "Archarel"
 msgstr "艾查雷尔"
 
 #. [objective]: condition=win
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:185
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:186
 msgid "Kill all enemy patrols before they reach the outpost"
 msgstr "在敌方巡逻队到达前哨站之前杀光他们"
 
 #. [objective]: condition=lose
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:197
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:198
 msgid "Death of Helicrom"
 msgstr "赫里克罗姆死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:201
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:202
 msgid "Any patrol units survive when turns run out"
 msgstr "回合耗尽时仍有巡逻队单位存活"
 
 #. [objective]: condition=lose
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:205
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:206
 msgid "Any allied unit is sighted by the outpost guards"
 msgstr "友方单位被前哨站守卫看到"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:262
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:263
 msgid "The leader, I presumes."
 msgstr "俺猜你就是头儿。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:266
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:267
 msgid ""
 "Indeed, I am Lord Helicrom, the Crow of the Grey Woods. We are acquaintances "
 "of Lord Maddock, who sent word to us of your predicament. I believe we can "
@@ -1944,12 +1962,12 @@ msgstr ""
 "你们的困境。我想我们可以帮忙解决些问题。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:270
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:271
 msgid "What be your pursuits?"
 msgstr "你们追求什么？"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:274
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:275
 msgid ""
 "The former king’s magic ministry kept a tight control on the training and "
 "employment of mages in Wesnoth. Those of us who dared to... depart from the "
@@ -1962,24 +1980,24 @@ msgstr ""
 "们的安全和隐秘，可不便宜。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:278
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:279
 msgid "Then you be fellow outlaws. But why do you wants to help us?"
 msgstr "那么你们也是流寇了。但你们为什么想帮俺们呢？"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:282
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:283
 msgid ""
 "<i>Quid pro quo.</i> Our aid is never given freely. You have something that "
 "may be useful to us."
 msgstr "<b>一物换一物。</b>我们的援助从不是免费的。你有或许对我们有用的东西。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:286
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:287
 msgid "Manpower. Mages be no good at fighting, I knows. But what for?"
 msgstr "人力。法师不擅长战斗，俺知道。但为啥呢？"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:290
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:291
 msgid ""
 "Understand this. Any weakening of the Throne of Wesnoth, whether it be "
 "occupied by king or queen, aids us. To accomplish that, we must destabilize "
@@ -1989,12 +2007,12 @@ msgstr ""
 "了达到这一目的，我们必须破坏他们在这一地区的势力的稳定。其关键是哈尔斯提德。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:294
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:295
 msgid "That big ol’ fort between Aldril and Elensefar?"
 msgstr "矗立在艾尔德里尔和埃仁撒伐之间的大要塞？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:298
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:299
 msgid ""
 "Aye, Harper. What the mage says be no surprise. It be a bastion of central "
 "importance, rivalin’ Elensefar even. Maddock said the Queen’s troops were "
@@ -2006,7 +2024,7 @@ msgstr ""
 "去战斗。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:302
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:303
 msgid ""
 "Know this, Baldras. During the past week, several patrols have again "
 "ventured across the Great River into Annuvin. A woman named Relana opposed "
@@ -2022,19 +2040,19 @@ msgstr ""
 "小村庄没一个能抵抗的。你们唯一的选择就是逃往更北方，到兽人领地去。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:306
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:307
 msgid ""
 "We’d never survive there. But would it be so bad if we just swore fealty to "
 "the Queen?"
 msgstr "俺们没法在那边活下去。但如果俺们只是向女王宣誓效忠，真有那么糟糕吗？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:310
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:311
 msgid "Only if we gots no other choice. Let’s hear the mage’s plan first."
 msgstr "只有没得选的时候才行。我们先听听法师的计划。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:314
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:315
 msgid ""
 "I’m not asking you to fight a war. A direct fight against Weldyn’s armies "
 "would be undoubtedly foolish. However, we have other means within our grasp. "
@@ -2049,27 +2067,27 @@ msgstr ""
 "前就严重削弱他们的力量。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:318
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:319
 msgid "Then what?"
 msgstr "然后呢？"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:322
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:323
 msgid "I am sure you can guess, magistrate."
 msgstr "我确信你能猜得到，治安官。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:326
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:327
 msgid "You means to sack Halstead itself."
 msgstr "你的意思是要摧毁哈尔斯提德本身。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:330
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:331
 msgid "There’s no way we can fight them all... can we?"
 msgstr "俺们没可能和他们全体对抗……对吧？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:334
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:335
 msgid ""
 "I don’t know. But, for now, ambushing them patrols be easy enough. That’ll "
 "slow them Wesnothians down enough for us to figure out the next step."
@@ -2078,7 +2096,7 @@ msgstr ""
 "直到俺们想出下一步的办法。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:338
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:339
 msgid ""
 "In the last day, my scouts have counted five platoons of troops marching "
 "towards the garrison. We must eliminate them all before they reach the "
@@ -2090,12 +2108,12 @@ msgstr ""
 "大部队就会来打我们。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:349
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:350
 msgid "The first platoon approaches..."
 msgstr "第一排接近了……"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:384
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:385
 msgid ""
 "We shall pincer them from the other side of this path. When we are done, no "
 "one shall fear the open roads and night sky more than the armies of Weldyn. "
@@ -2105,108 +2123,108 @@ msgstr ""
 "道和夜空了。迅速地打，悄悄地打……别让任何人活下来。"
 
 #. [message]: speaker=Linneus
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:506
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:507
 msgid "It’s an ambush! Run!"
 msgstr "是埋伏！快跑！"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:521
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:522
 msgid ""
 "Ah, here it is. I was wondering where I had misplaced my favorite blade."
 msgstr "啊，找到了。我还在想我把最喜欢的刀放哪儿了呢。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:555
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:556
 msgid "Hey, I found some old coins in this shack."
 msgstr "嘿，我在这棚屋里发现了些旧硬币。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:591
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:592
 msgid "Bleagh, a slimy tentacle. Why’s it so big?"
 msgstr "呕，一只粘稠的触手。为什么它这么大？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:604
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:605
 msgid "There’s a rusty key here. I wonder if it could be useful?"
 msgstr "这里有把锈钥匙。我好奇它有没有用？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:631
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:632
 msgid "There is a waterlogged coffin here."
 msgstr "这里有具进满水的棺材。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:644
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:645
 msgid "Hey, that key fits in this coffin. Should I open it?"
 msgstr "嘿，那把钥匙能配上这棺材。我该打开它吗？"
 
 #. [option]
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:649
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:650
 msgid "No, that be a terrible idea."
 msgstr "不，这主意很糟糕。"
 
 #. [option]
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:656
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:657
 msgid "Fine, do it."
 msgstr "行，打开吧。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:671
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:672
 msgid "What is this disgusting monster?"
 msgstr "这恶心的怪物是什么？"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:676
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:677
 msgid ""
 "A ghoul, a creature of disease and pestilence. Kill the putrid thing. Its "
 "stench is making me sick."
 msgstr "食尸鬼，充满疾病和瘟疫之物。杀掉这腐烂的东西。它的臭味让我恶心。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:701
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:702
 msgid ""
 "Disgusting though it may be, perhaps that creature’s corpse could be useful."
 msgstr "虽然可能很恶心，但或许那个生物的尸体还有用。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:716
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:717
 msgid "Should I use this potion?"
 msgstr "我应该使用这药剂吗？"
 
 #. [option]
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:718
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:719
 msgid "Yes, I’ll use it."
 msgstr "是的，我会用的。"
 
 #. [object]: id=poison_weapon
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:726
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:727
 msgid "Vile Concoction"
 msgstr "邪恶混合物"
 
 #. [object]: id=poison_weapon
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:728
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:729
 msgid ""
 "This unit’s melee weapons gain the poison special and this unit gains a "
 "small number of hitpoints."
 msgstr "此单位的近战武器获得下毒特攻，同时，此单位获得少量生命值。"
 
 #. [option]
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:762
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:763
 msgid "No, I’ll leave it for someone else."
 msgstr "不，我会把它留给别人。"
 
 #. [message]: type=Heavy Infantryman
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:848
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:849
 msgid "Doesn’t something about these woods feel weird to you, sir?"
 msgstr "您不觉得这树林有些奇怪吗，长官？"
 
 #. [message]: type=Spearman,Pikeman
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:852
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:853
 msgid "Afraid of ghosts, soldier?"
 msgstr "怕鬼吗，士兵？"
 
 #. [message]: role=master_at_arms
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:943
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:944
 msgid ""
 "Woods, woods, woods and more woods! Bah, that general had better have a good "
 "reason for dragging me out to Halstead with all these oafs."
@@ -2215,37 +2233,37 @@ msgstr ""
 "好有个不错的理由。"
 
 #. [message]
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:950
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:951
 msgid "But cap’n, we’re your loyal troops..."
 msgstr "但队长，我们是你忠诚的部队……"
 
 #. [message]: role=master_at_arms
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:954
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:955
 msgid "Shut it and keep moving."
 msgstr "闭嘴，继续前进。"
 
 #. [message]: speaker=Archarel
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:975
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:976
 msgid ""
 "Several platoons of troops were supposed to arrive today. I wonder if "
 "something happened to them."
 msgstr "有几个排的部队本应在今天抵达。我想知道他们是不是出事了。"
 
 #. [message]: speaker=Archarel
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:992
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:993
 msgid ""
 "Something about these woods seems quite unnatural. Perhaps we should stop "
 "sending our soldiers this way."
 msgstr "这树林的某些地方似乎很不自然。也许我们不该继续派士兵过来。"
 
 #. [message]: speaker=Archarel
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1008
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1009
 msgid ""
 "Troops, to arms! Show these fugitive scum the meaning of the Queen’s law!"
 msgstr "士兵们，拿起武器！让这些逃亡的人渣知道女王法律的意义！"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1012
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1013
 msgid ""
 "With the outpost aware of our presence, we can no longer harry their "
 "reinforcements. Their forces will soon grow too powerful for us to resist."
@@ -2254,7 +2272,7 @@ msgstr ""
 "变强到我们无法抵挡。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1028
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1029
 msgid ""
 "The next morning, the local night patrol returned to the nearby outpost. "
 "They were surprised to see their fellow soldiers engaged in combat with the "
@@ -2264,12 +2282,12 @@ msgstr ""
 "惊讶，这匪帮正是近来闻名的那个。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1088
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1089
 msgid "It be done. Their patrols be shattered and broken."
 msgstr "我会做到的。他们的巡逻队会被打烂打垮。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1093
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1094
 msgid ""
 "Well done, but the fight is far from over. We will not be able to employ "
 "these tactics when more platoons arrive. You must make your choice. Will you "
@@ -2279,7 +2297,7 @@ msgstr ""
 "须做出选择。你们会战斗吗？还是会回到村里，乞求特赦？"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1098
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1099
 msgid ""
 "Amnesty? Knowing these Wesnothians, they’ll have my head. Then again, if I "
 "could gives my life to save my whole village, I would."
@@ -2288,12 +2306,12 @@ msgstr ""
 "个村，俺会用的。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1103
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1104
 msgid "We need you! Uncle..."
 msgstr "我们需要你！舅舅……"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1108
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1109
 msgid ""
 "I know what you is going to say, Harper. That we should be fighting for our "
 "homes, just like we do against them orcs. But we be risking everything on "
@@ -2303,7 +2321,7 @@ msgstr ""
 "俺们得赌上全部，姑娘。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1113
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1114
 msgid ""
 "If we go back like this, that means we’ll surrender to them Wesnothians and "
 "live our whole lives in oppression. You saw how they were sending so many "
@@ -2313,7 +2331,7 @@ msgstr ""
 "了，他们是怎么派那么多士兵甚至兽人来对付俺们的。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1118
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1119
 msgid ""
 "The girl is naive, but her spirit is in the right place. You risk your homes "
 "and the lives of your people, yes, but what good will they be if you live in "
@@ -2323,7 +2341,7 @@ msgstr ""
 "果生活在暴政之下，留下这些又如何呢？相信我，我曾经见过。我宁愿死也不愿回去。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1123
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1124
 msgid ""
 "Yes... Erwen would’ve said the same. If we march on Halstead, we gots to "
 "burn it to the ground before the Queen’s forces rally. If we does that, "
@@ -2333,7 +2351,7 @@ msgstr ""
 "把它烧成灰。要是俺们成功了，维尔帝在安努文就再也没有据点了。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1128
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1129
 msgid ""
 "It would be months before they could reassemble their forces here. Enough "
 "time for you to secure your homes, or relocate."
@@ -2342,12 +2360,12 @@ msgstr ""
 "安置到其他地方。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1133
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1134
 msgid "Then it be decided. We’ll attack the fort together. Luck be with us."
 msgstr "那就决定了。俺们一块儿进攻要塞。但愿运气与俺们同在。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1174
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1175
 msgid ""
 "Lieutenant, we were assaulted by a band of outlaws en route to the outpost. "
 "We were barely able to evade them and make it here!"
@@ -2356,12 +2374,12 @@ msgstr ""
 "里！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1194
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1195
 msgid "Look there! Outlaws and bandits roam these woods, harrying our patrols!"
 msgstr "看那儿！流寇和强盗在这丛林里游荡，骚扰我们的巡逻队！"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1211
+#: data/campaigns/Liberty/scenarios/06_The_Hunters.cfg:1212
 msgid "This is the end for me..."
 msgstr "这就是我的结局了……"
 
@@ -2371,7 +2389,7 @@ msgid "Glory"
 msgstr "荣耀"
 
 #. [part]
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:20
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:19
 msgid ""
 "From the Annals of Alduin, 98 YW\n"
 "\n"
@@ -2393,7 +2411,7 @@ msgstr ""
 "埃仁撒伐之间的道路。有了这条路，才能认为联盟真正成为了人类的联合体。"
 
 #. [part]
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:26
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:25
 msgid ""
 "To commemorate the concordat, six years ago, the Lords of Weldyn and "
 "Elensefar decreed that a monument be erected in the heart of these once "
@@ -2408,7 +2426,7 @@ msgstr ""
 "座巨大的要塞。"
 
 #. [part]
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:30
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:29
 msgid ""
 "Completed, as it is on this day, this sentinel of the west now towers "
 "hundreds of paces tall, a great monolith looming sheer above the plains. The "
@@ -2426,36 +2444,36 @@ msgstr ""
 "这些潮水般的石头。"
 
 #. [side]: type=General, id=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:54
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:53
 msgid "Dommel"
 msgstr "多梅尔"
 
 #. [side]: type=Orcish Warlord, id=Vashna
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:100
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:99
 msgid "Vashna"
 msgstr "瓦什纳"
 
 #. [objective]: condition=win
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:154
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:228
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:426
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:153
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:227
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:424
 msgid "Destroy the stronghold of Halstead"
 msgstr "摧毁哈尔斯提德要塞"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:259
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:258
 msgid "There be it. The stronghold of Halstead."
 msgstr "就是这儿了。哈尔斯提德要塞。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:272
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:271
 msgid ""
 "Look at how tall it is! Those towers be so sheer and smooth, it almost looks "
 "like magic called them up out of the earth!"
 msgstr "看它有多高啊！这些高塔又直又光滑，好似用魔法从地里唤出来的！"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:277
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:276
 msgid ""
 "Aye, there may be some truths in that. Old stories tells us that in times "
 "past, Elensefar and Weldyn had some real strong mages, much more adept than "
@@ -2468,17 +2486,17 @@ msgstr ""
 "造了哈尔斯提德的城墙，用来纪念联盟。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:282
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:281
 msgid "I don’t see how we can bring it down. They seem invincible in there!"
 msgstr "我看不出怎样才能攻陷这里。他们看起来无可匹敌！"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:286
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:285
 msgid "Indeed..."
 msgstr "确实……"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:290
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:289
 msgid ""
 "Worry not, Halstead has a weakness. What Baldras spoke was partly true. "
 "Previous orders of magi did help erect the fortress. What is not made known "
@@ -2488,7 +2506,7 @@ msgstr ""
 "确实帮忙建立了这座堡垒。但不为大多数人所知的是，城堡最初的建造时是有缺陷的。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:294
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:293
 msgid ""
 "These walls were raised over a system of catacombs, which connect the four "
 "towers to the central keep. Though they appear impressive, the tunnels were "
@@ -2503,14 +2521,14 @@ msgstr ""
 "秘密，他们不想让别人知道自己的失误。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:298
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:297
 msgid ""
 "So... we can knock out the supports and bring down the main keep. Would it "
 "really work?"
 msgstr "所以……俺们可以破坏支撑，这样就能击垮主楼。真能行吗？"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:302
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:301
 msgid ""
 "I believe it will. Each tower has a passage down to the catacombs. We must "
 "enter the tunnels and demolish all four supports, then the fortress should "
@@ -2520,12 +2538,12 @@ msgstr ""
 "而后堡垒便会倒塌。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:306
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:305
 msgid "Let’s hope you be right. Everything be hinging on this battle."
 msgstr "但愿你说得对。全靠这一仗了。"
 
 #. [message]: speaker=Vashna
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:315
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:314
 msgid ""
 "Dommel! The Queen has sent me and my warriors to support your forces. We "
 "come to squash the puny peasant rebellion."
@@ -2533,17 +2551,17 @@ msgstr ""
 "多梅尔！女王派我和战士们来支援你的部队。我们是来镇压那微不足道的农民叛乱的。"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:319
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:318
 msgid "I received no word from Her Majesty of your arrival, orc."
 msgstr "我没从女王陛下那里收到你将到来的消息，兽人。"
 
 #. [message]: speaker=Vashna
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:323
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:322
 msgid "I have the orders right here."
 msgstr "我这里就有命令。"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:327
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:326
 msgid ""
 "As if those could possibly be real. I would be a fool and an oaf to let a "
 "band of stinky raider orcs into Halstead without a fight."
@@ -2552,7 +2570,7 @@ msgstr ""
 "德，那我就是个白痴蠢货。"
 
 #. [message]: speaker=Vashna
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:331
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:330
 msgid ""
 "What? Now look here, you coddled pinkskin. Your helpless ‘soldiers’ have "
 "been getting bested by a filthy bunch of vagrant bandits. Your army is as "
@@ -2564,7 +2582,7 @@ msgstr ""
 "们太蠢了，没办法自己收拾。"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:335
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:334
 msgid ""
 "A fine story. Most likely, this is a pitiful excuse for you to enter our "
 "fortress to plunder our armory. Even if Her Majesty did order you here, we "
@@ -2576,7 +2594,7 @@ msgstr ""
 "助。没有你们，我们一直都处理得很好。"
 
 #. [message]: speaker=Vashna
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:339
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:338
 msgid ""
 "Yeah? Well, we will see how fine you manage <i>against</i> us. I’ll show you "
 "just how weak you pinkskins are."
@@ -2585,49 +2603,48 @@ msgstr ""
 "小。"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:343
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:342
 msgid "Come try it, cretin."
 msgstr "来试试啊，白痴。"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:347
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:346
 msgid ""
 "Infighting among the forces of Weldyn does not bode well for the new queen, "
 "but is awfully convenient for us..."
 msgstr "维尔帝势力的内讧对新女王来说不是好兆头，但对我们而言却非常方便……"
 
 #. [message]: role=farseer
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:365
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:364
 msgid "Look in the distance... riders approach!"
 msgstr "看远处……骑兵来了！"
 
 #. [unit]: type=Paladin, id=Sir Gwydion
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:372
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:371
 msgid "Sir Gwydion"
 msgstr "格威迪恩爵士"
 
 #. [message]: type=Lancer
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:387
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:386
 msgid "Sound the advance!"
 msgstr "发令前进！"
 
 #. [message]: type=Lancer
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:391
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:390
 msgid "At your order, my liege."
 msgstr "谨遵命令，阁下。"
 
 #. [message]: speaker=Sir Gwydion
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:395
-#, fuzzy
-#| msgid ""
-#| "Ready thy lances! Let us trample the armies of Weldyn beneath our steeds!"
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:394
 msgid ""
 "Lo, Knights of Elensefar, the battle hath begun ere our arrival. Ready thy "
 "lances! Let us trample the armies of Weldyn beneath our steeds!"
-msgstr "准备长枪！把维尔帝的军队踩在马下！"
+msgstr ""
+"看哪，埃仁撒伐的骑士们，不待我等抵达，战斗已然打响。备好尔等长矛！让我等将维"
+"尔帝的大军踏碎于铁蹄之下！"
 
 #. [message]: role=farseer
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:408
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:407
 msgid ""
 "A horde of knights, bearing the emblem of Elensefar! Amazing. I’ve never "
 "seen me so many riders in one place."
@@ -2635,7 +2652,7 @@ msgstr ""
 "一群骑士，戴着埃仁撒伐的纹章！真惊人。我从没在同一个地方见过这么多骑兵。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:413
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:411
 msgid ""
 "Gwydion be Lord Maddock’s son... more be hinging on victory than I thought. "
 "This battle don’t just be about our little villages no more."
@@ -2644,61 +2661,61 @@ msgstr ""
 "们的小村子有关了。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:457
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:455
 msgid ""
 "Not even a full day had passed before the first advance elements of "
 "Wesnoth’s main army began to arrive..."
 msgstr "甚至还没过一整天的时间，韦诺主力部队的第一批先头部队就开始抵达了……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:464
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:462
 msgid ""
 "That morning, another advance element of the main Wesnoth army arrived..."
 msgstr "那个上午，韦诺主力部队的另一支先头部队抵达了……"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:508
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:506
 msgid ""
 "I think... I think they’re trying to storm Halstead itself... the fools!"
 msgstr "我想……我想他们要强攻哈尔斯提德本身……这群傻瓜！"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:527
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:525
 msgid "They have breached the fortress gate! Repulse them!"
 msgstr "他们破坏了堡垒大门！击退他们！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:549
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:547
 msgid "I’m inside! I’m heading down to the catacombs."
 msgstr "我进塔了！我正往地下墓穴走。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:567
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:565
 msgid "After some time..."
 msgstr "一段时间后……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:587
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:585
 msgid "It’s done."
 msgstr "搞定了。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:614
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:612
 msgid "The stronghold of Halstead began to shake..."
 msgstr "哈尔斯提德要塞开始震动……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:620
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:618
 msgid "We can’t stay here. The fortress is starting to collapse!"
 msgstr "我们不能呆在这儿。堡垒开始倒塌了！"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:655
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:653
 msgid "I think it be working! Everybody get clear!"
 msgstr "俺觉得起作用了！大伙儿躲开！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:696
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:694
 msgid ""
 "With a thunderous roar and a vast billowing of dust, thousands of tons of "
 "stone and wood crashed in on itself. Some of the wreckage tumbled down the "
@@ -2709,12 +2726,12 @@ msgstr ""
 "而剩下的则沉入了几百尺地下的空心山内部。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:704
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:702
 msgid "No one inside the fortress would make it out alive."
 msgstr "堡垒里的人都不会活着出来了。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:789
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:787
 msgid ""
 "After several days of fierce fighting, the main body of Weldyn’s host "
 "arrived. The battle was soon finished. Every last man from the rebellion was "
@@ -2724,24 +2741,24 @@ msgstr ""
 "有人皆被处死。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:818
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:816
 msgid "The fort be done with... but I be crushed... under this rubble..."
 msgstr "堡垒完蛋了……但俺却被压在……瓦砾下面……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:822
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:820
 msgid ""
 "No one was able to get to Baldras in time. He and many of his companions "
 "died that day beneath the stronghold of Halstead."
 msgstr "没人能及时救出巴尔德拉斯。他和许多同伴那天都死在哈尔斯特德要塞之下。"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:829
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:827
 msgid "I knew... this wouldn’t work..."
 msgstr "我就知道……这行不通……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:834
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:832
 msgid ""
 "The rebellion had staked its all on victory at Halstead, but win or lose, "
 "there would be no help for the doomed villagers."
@@ -2750,29 +2767,29 @@ msgstr ""
 "助。"
 
 #. [message]: speaker=Harper
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:853
-#: data/campaigns/Liberty/utils/utils.cfg:34
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:850
+#: data/campaigns/Liberty/utils/utils.cfg:33
 msgid "Unngh..."
 msgstr "呃……"
 
 #. [message]: speaker=Baldras
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:857
-#: data/campaigns/Liberty/utils/utils.cfg:38
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:854
+#: data/campaigns/Liberty/utils/utils.cfg:37
 msgid "Harper, no!"
 msgstr "哈珀，不！"
 
 #. [message]: speaker=Helicrom
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:873
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:870
 msgid "Ended... like this? Fight on without me..."
 msgstr "就这样……结束了？没有我，也要继续战斗……"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:920
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:917
 msgid "Your time is over, General."
 msgstr "你的死期到了，将军。"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:925
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:922
 msgid ""
 "I may be done... but my death shall only bring the full wrath of the Crown "
 "upon you... relish your small victory, peasants, while you still can..."
@@ -2781,12 +2798,12 @@ msgstr ""
 "趁你们还能享受……"
 
 #. [message]: speaker=Vashna
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:945
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:942
 msgid "Grrarrghh... you... fools..."
 msgstr "咯啊啊啊啊啊……你们……蠢货……"
 
 #. [message]: speaker=Dommel
-#: data/campaigns/Liberty/scenarios/07_Glory.cfg:950
+#: data/campaigns/Liberty/scenarios/07_Glory.cfg:947
 msgid "Idiot orc. Know your place."
 msgstr "白痴兽人。知道自己的斤两了吧。"
 
@@ -2824,13 +2841,6 @@ msgstr ""
 
 #. [part]
 #: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:22
-#, fuzzy
-#| msgid ""
-#| "I’m sure them Wesnothians will come back in time and with Maddock holed "
-#| "up in his stupid tower, they’ll eventually siege Elensefar and take the "
-#| "city... but that don’t be my problem anymore. I has me a village to worry "
-#| "about. I need to get back, consult myself with Relana and figure out what "
-#| "to do next. We gots some more time now, but we can’t wait forever."
 msgid ""
 "I’m sure them Wesnothians will come back in time. Maddock sounded like he "
 "had a plan... we’ll see. But that don’t be my problem anymore. I has me a "
@@ -2838,9 +2848,9 @@ msgid ""
 "figure out what to do next. We gots some more time now, but we can’t wait "
 "forever."
 msgstr ""
-"我相信韦诺人到时候会回来的。马多克躲在他那座愚蠢的塔里，而他们最终会围攻埃仁"
-"撒伐，并占领那座城市……但那和俺没关系了。俺还有个村子要担心。俺得回去，跟蕾拉"
-"娜商量一下，想出下一步该咋办。俺们现在是多了点儿时间，但不可能一直等下去。"
+"俺相信韦诺人到时候会回来的。马多克听上去有个计划……走着瞧吧。但那和俺没关系"
+"了。俺还有个村子要担心。俺得回去，跟蕾拉娜商量一下，想出下一步该咋办。俺们现"
+"在是多了点儿时间，但不可能一直等下去。"
 
 #. [part]
 #: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:25
@@ -2913,7 +2923,7 @@ msgstr ""
 "来看看上面写了啥。"
 
 #. [part]
-#: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:47
+#: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:46
 msgid ""
 "<i>“Baldras, you would’ve been proud. We fought them soldiers off twice, "
 "gave them a good ol’ thrashing they won’t ever forget. But in the end, it "
@@ -2923,7 +2933,7 @@ msgstr ""
 "击。但最后，这还不够。在他们把我们都杀了之前，俺们只得像罪犯一样逃跑。”</b>"
 
 #. [part]
-#: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:51
+#: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:50
 msgid ""
 "<i>“I don’t know if you and Harper will see this note, but if you do, I’m "
 "expecting ya to come find us. Remember them ol’ pirate islands we used to "
@@ -2936,7 +2946,7 @@ msgstr ""
 "南边，陆地尽头之外。在三姐妹群岛见，老友。——蕾拉娜”</b>"
 
 #. [part]
-#: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:55
+#: data/campaigns/Liberty/scenarios/08_Epilogue.cfg:54
 msgid ""
 "So they survived! Them islands be a bit far, but I suppose this sack of old "
 "bones has one more adventure left in it..."
@@ -2944,10 +2954,8 @@ msgstr "这么说他们还活着！那些岛有点远，但俺觉着这把老骨
 
 #. [unit_type]: id=Lord of Elensefar, race=human
 #: data/campaigns/Liberty/units/Maddock.cfg:4
-#, fuzzy
-#| msgid "Port of Elensefar"
 msgid "Lord of Elensefar"
-msgstr "埃仁撒伐港"
+msgstr "埃仁撒伐领主"
 
 #. [unit_type]: id=Lord of Elensefar, race=human
 #: data/campaigns/Liberty/units/Maddock.cfg:7
@@ -2960,6 +2968,10 @@ msgid ""
 "lies a fierce independence, a trait that sometimes puts them at odds with "
 "the aristocrats of other regions."
 msgstr ""
+"埃仁撒伐大城邦是泰陆上最富裕的人类聚居地，其声望与实力远超其相对稀少的人口所"
+"应有的程度。与那些尚武的内陆贵族不同，埃仁撒伐的执政者们精通商贸与航海之术，"
+"且以性情随和著称。然而，在那商人般的魅力背后，是一种强烈的独立精神，这种特质"
+"有时会使他们与其他地区的贵族产生摩擦。"
 
 #. [unit_type]: id=Thug_Peasant
 #: data/campaigns/Liberty/units/Villagers.cfg:20
@@ -3052,7 +3064,7 @@ msgid "Borderer"
 msgstr "巡界人"
 
 #. [unit_type]: id=Fugitive_Peasant
-#: data/campaigns/Liberty/units/Villagers.cfg:142
+#: data/campaigns/Liberty/units/Villagers.cfg:141
 msgid ""
 "Border villages maintain militias dedicated to fending off hostiles. While "
 "these borderers are not trained and armed to up to military standards, their "
@@ -3063,17 +3075,17 @@ msgstr ""
 "是他们天生的韧性和对本地情况的了解使得他们在自己的土地上异常强大。"
 
 #. [female]
-#: data/campaigns/Liberty/units/Villagers.cfg:144
+#: data/campaigns/Liberty/units/Villagers.cfg:143
 msgid "female^Borderer"
 msgstr "巡界人"
 
 #. [unit_type]: id=Poacher_Peasant
-#: data/campaigns/Liberty/units/Villagers.cfg:163
+#: data/campaigns/Liberty/units/Villagers.cfg:162
 msgid "Peasant Hunter"
 msgstr "乡下猎人"
 
 #. [unit_type]: id=Poacher_Peasant
-#: data/campaigns/Liberty/units/Villagers.cfg:166
+#: data/campaigns/Liberty/units/Villagers.cfg:165
 msgid ""
 "Villages, especially in wilder areas near frontiers, rely on hunters to "
 "bring in much of their food supply. Their stealth and intimate knowledge of "
@@ -3083,12 +3095,12 @@ msgstr ""
 "形的秘密知识在战斗中是有价值的财产。"
 
 #. [unit_type]: id=Trapper_Peasant
-#: data/campaigns/Liberty/units/Villagers.cfg:179
+#: data/campaigns/Liberty/units/Villagers.cfg:178
 msgid "Peasant Trapper"
 msgstr "乡下陷阱猎人"
 
 #. [unit_type]: id=Trapper_Peasant
-#: data/campaigns/Liberty/units/Villagers.cfg:183
+#: data/campaigns/Liberty/units/Villagers.cfg:182
 msgid ""
 "Trappers are skilled hunters who supply food and furs for several villages. "
 "Their hunting experience makes them most valuable at night and in forests "
@@ -3098,12 +3110,12 @@ msgstr ""
 "林沼泽里最有价值。"
 
 #. [unit_type]: id=Huntsman_Peasant
-#: data/campaigns/Liberty/units/Villagers.cfg:196
+#: data/campaigns/Liberty/units/Villagers.cfg:195
 msgid "Peasant Huntsman"
 msgstr "乡下狩猎高手"
 
 #. [unit_type]: id=Huntsman_Peasant
-#: data/campaigns/Liberty/units/Villagers.cfg:201
+#: data/campaigns/Liberty/units/Villagers.cfg:199
 msgid ""
 "Huntsmen have spent their lives in the backwoods and swamps of their "
 "wilderness homes. They can bullseye ferocious swamp rats and track anything "
@@ -3118,194 +3130,11 @@ msgid "I’m coming... Erwen..."
 msgstr "俺来了……艾尔文……"
 
 #. [message]: speaker=Relana
-#: data/campaigns/Liberty/utils/utils.cfg:52
+#: data/campaigns/Liberty/utils/utils.cfg:51
 msgid "I’m finished..."
 msgstr "俺完了……"
 
 #. [message]: speaker=Lord Maddock
-#: data/campaigns/Liberty/utils/utils.cfg:66
+#: data/campaigns/Liberty/utils/utils.cfg:65
 msgid "How can this be?"
 msgstr "怎么会这样？"
-
-#~ msgid "Peasant"
-#~ msgstr "农民"
-
-#~ msgid "Outlaw"
-#~ msgstr "游寇"
-
-#~ msgid "Challenging"
-#~ msgstr "挑战"
-
-#~ msgid "Fugitive"
-#~ msgstr "亡命徒"
-
-#~ msgid "Jasken"
-#~ msgstr "贾斯肯"
-
-#~ msgid "Port of Elensefar"
-#~ msgstr "埃仁撒伐港"
-
-#~ msgid "Defeat the enemy general"
-#~ msgstr "击败敌方将军"
-
-#~ msgid ""
-#~ "Well, they do not come within the walls of my city. There is a large "
-#~ "garrison south at the great fortress of Halstead, but even should they "
-#~ "mobilize all their troops, I doubt they could take Elensefar. It is true "
-#~ "that for now, the majority of my forces are still returning from the "
-#~ "battle of Abez, but unless we are attacked within the next few days, I "
-#~ "shall be able to hold the city."
-#~ msgstr ""
-#~ "嗯，他们还没有进入我的城墙之内。南面的哈尔斯提德大堡垒里有一支庞大的驻军，"
-#~ "但即使他们动员了所有部队，我也很怀疑他们能不能拿下埃仁撒伐。目前，我的大部"
-#~ "分部队确实还在从雅碧滩战场上返回途中，但只要不是在未来几天内就遭到攻击，那"
-#~ "我应该能守住这座城市。"
-
-#~ msgid ""
-#~ "We have an uneasy peace to maintain. The treaty between Elensefar and "
-#~ "Wesnoth is ancient, and I do not think Her Majesty means to break it. At "
-#~ "the same time, I have some concessions that I shall have to make. I "
-#~ "cannot afford a war with Weldyn, as you can surely understand."
-#~ msgstr ""
-#~ "我们得维持这不稳定的和平。埃仁撒伐和韦诺之间的条约很古老，我不认为女王陛下"
-#~ "有意破坏它。同时，我也不得不做出一些让步。我无法承受与维尔帝的战争，你肯定"
-#~ "能理解的。"
-
-#~ msgid ""
-#~ "Yes, I am aware of Queen Asheviere’s propensity for hiring orcs to "
-#~ "supplement her forces. That does not mean I could do anything about it, "
-#~ "even if I were so inclined. The best advice I can give you is to just "
-#~ "apologize. Even if they may want your head, Baldras, you still have the "
-#~ "chance to preserve your village. Think of the bigger picture."
-#~ msgstr ""
-#~ "是的，我知道艾什薇尔女王倾向于雇用兽人来补充她的军队。即使我想做些什么，这"
-#~ "也不意味着我能做。我能给你的最好建议是直接道歉。即使他们可能想要你的脑袋，"
-#~ "巴尔德拉斯，你还是有机会保住村庄。想想大局。"
-
-#~ msgid "Looks like someone left some supplies here."
-#~ msgstr "看来有人在这里留下了些物资。"
-
-#~ msgid ""
-#~ "That’s a deep well! Wonder how far down it goes. Guess I’ll chuck a rock "
-#~ "down and find out."
-#~ msgstr "是口深井！不知能下多深。俺来扔块石头下去看看。"
-
-#~ msgid ""
-#~ "...\n"
-#~ "...\n"
-#~ "..."
-#~ msgstr ""
-#~ "……\n"
-#~ "……\n"
-#~ "……"
-
-#~ msgid "Plunk!"
-#~ msgstr "噗通！"
-
-#~ msgid ""
-#~ "Lo, Knights of Elensefar, the battle hath begun ere our arrival. Though I "
-#~ "disobey my father in this endeavor, our presence surely is much needed."
-#~ msgstr ""
-#~ "注意了，埃仁撒伐的骑士们，战斗在吾等到达之前已然开始。此次行动之中，吾虽违"
-#~ "背父亲的意愿，但吾等的登场无疑是必要的。"
-
-#~ msgid "Rogue Mage"
-#~ msgstr "流浪法师"
-
-#~ msgid ""
-#~ "Some mages are thrown out of the mages’ guild for attempting to practice "
-#~ "forbidden arts. Now completely outside the law, these rogue mages do "
-#~ "whatever is necessary to support their study of black magic. Although not "
-#~ "as skilled as mages with more formal training, their magic can be quite "
-#~ "lethal, while their banditry has resulted in moderate skill with the "
-#~ "short sword."
-#~ msgstr ""
-#~ "一些法师由于尝试练习禁止的法术被法师行会驱逐。这些叛出的法师现在完全处于法"
-#~ "律之外，他们为了支撑对黑魔法的研习，无所不为。虽然不如那些接受更正式训练的"
-#~ "法师那么熟练，但他们的魔法也可以相当致命。而他们的盗匪行为的结果是，他们使"
-#~ "用短剑的技能还算可以。"
-
-#~ msgid "ice blast"
-#~ msgstr "冷冻波"
-
-#~ msgid "Shadow Lord"
-#~ msgstr "暗影领主"
-
-#~ msgid ""
-#~ "Few humans fathom the secrets of light and dark magic and retain their "
-#~ "sanity. Those that can master that balance become Shadow Lords, fully "
-#~ "existing neither in the world of light nor the world of darkness. No "
-#~ "longer needing physical weapons, they are fearsome to both their enemies "
-#~ "and those they lord over."
-#~ msgstr ""
-#~ "很少人类能彻底理解光明和黑暗的魔法并保持他们的人性。那些能精通这个平衡的就"
-#~ "成为暗影领主，完全存在但既不属于光明界也不属于黑暗界。不再需要实体的武器，"
-#~ "他们被他们的敌人和麾下之人所畏惧。"
-
-#~ msgid "astral blade"
-#~ msgstr "星刃"
-
-#~ msgid "shadow bolt"
-#~ msgstr "暗影箭"
-
-#~ msgid "shadow blast"
-#~ msgstr "暗影波"
-
-#~ msgid "Shadow Mage"
-#~ msgstr "暗影法师"
-
-#~ msgid ""
-#~ "Years of violence and brutality to support the study of forbidden magical "
-#~ "arts have turned the shadow mages into feared fighters. Now completely "
-#~ "enthralled with power, they have been known to command small followings "
-#~ "of henchmen. They are outmatched in direct magical combat with their "
-#~ "magic-using peers, instead channeling their energies into devastating "
-#~ "melee attacks. Despite their offensive power, the corruption in their "
-#~ "souls has begun to adversely affect their health."
-#~ msgstr ""
-#~ "多年的暴力和残忍支持的禁忌魔法研究让暗影法师变成恐怖的战士。现在完全被力量"
-#~ "迷惑，他们以能指挥小部分下属的党羽被人熟知。他们超越了直接施展魔法的同等对"
-#~ "手，因为他们引导自己的能量摄入破坏性的近战攻击。尽管他们力量富有攻击性，但"
-#~ "他们灵魂的堕落开始对他们的健康产生了不利的影响。"
-
-#~ msgid "Rothel"
-#~ msgstr "罗瑟尔"
-
-#~ msgid "Bone Knight"
-#~ msgstr "枯骨骑士"
-
-#~ msgid ""
-#~ "Once great warriors across the plains, these mounted riders atop their "
-#~ "skeletal horses were raised from the ground by unholy magic to spread "
-#~ "fear and destruction."
-#~ msgstr ""
-#~ "这些骷髅马背上的骑手曾经是来自平原四方的伟大武士，如今他们被邪恶魔法从地下"
-#~ "召唤出来传播恐惧和毁灭。"
-
-#~ msgid "trample"
-#~ msgstr "践踏"
-
-#~ msgid "Death Squire"
-#~ msgstr "死亡扈从"
-
-#~ msgid ""
-#~ "Sometimes the mightiest warriors and generals, cursed with hate and "
-#~ "angst, came back to this world as Death Knights. Death Squires serve them "
-#~ "whilst accruing enough unholy power to become Death Knights. In the "
-#~ "process they pick up a good deal of the Knight’s power, including the "
-#~ "ability to command underlings."
-#~ msgstr ""
-#~ "某些时候最强大的将军和战士，受仇恨和恐怖的诅咒，作为死亡骑士重新来到这个世"
-#~ "界。死亡扈从服务他们以获得足够的邪恶力量从而变成死亡骑士。在此过程他们很好"
-#~ "的学会运用骑士的力量，包括指挥属下的能力。"
-
-#~ msgid "Skeleton Rider"
-#~ msgstr "骷髅骑手"
-
-#~ msgid ""
-#~ "Once great warriors thundering across the plains, these mounted riders "
-#~ "atop their skeletal horses were raised from the grave by unholy magic to "
-#~ "spread fear and destruction."
-#~ msgstr ""
-#~ "这些骷髅马背上的骑手曾经是雷鸣般驰骋于平原之上的伟大武士，如今他们被邪恶魔"
-#~ "法从坟墓里召唤出来传播恐惧和毁灭。"

--- a/translations/wesnoth/po/wesnoth-thot/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-thot/zh_CN.po
@@ -1,5 +1,5 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
@@ -8,74 +8,77 @@
 # wind <everywherewind@gmail.com>, 2011.
 # Yifan <yyf1992@mail.ustc.edu.cn>, 2015.
 # CloudiDust <cloudidust@gmail.com>, 2017.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.16\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2025-08-19 15:14 UTC\n"
-"PO-Revision-Date: 2024-06-28 11:59+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-08-18 15:19 UTC\n"
+"PO-Revision-Date: 2026-08-29 14:41+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
 #. [achievement_group]
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:10
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:32
 #: data/campaigns/The_Hammer_of_Thursagan/achievements.cfg:4
 msgid "The Hammer of Thursagan"
 msgstr "瑟萨冈之锤"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:12
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:34
 msgid "THoT"
 msgstr "THoT"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:19
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:42
+msgid "1x enemies"
+msgstr "1倍敌人"
+
+#. [campaign]: id=The_Hammer_of_Thursagan
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:42
 msgid "Easy"
 msgstr "容易"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:19
-msgid "Fighter"
-msgstr "战士"
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:43
+msgid "2x enemies"
+msgstr "2倍敌人"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:20
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:43
 msgid "Normal"
 msgstr "普通"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:20
-msgid "Steelclad"
-msgstr "钢甲兵"
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:44
+msgid "3x enemies"
+msgstr "3倍敌人"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:21
-msgid "Challenging"
-msgstr "挑战"
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:44
+msgid "Hard"
+msgstr "困难"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:21
-msgid "Lord"
-msgstr "领主"
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:45
+msgid "4x enemies"
+msgstr "4倍敌人"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:24
-#, fuzzy
-#| msgid ""
-#| "In the first years of the Northern Alliance, an expedition from Knalga "
-#| "seeks out their kin at Kal Kartha and to learn the fate of the legendary "
-#| "Hammer of Thursagan. The perils of their journey through the wild "
-#| "Northern Lands, though great, pale beside the evil they will face at its "
-#| "end.\n"
-#| "\n"
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:45
+msgid "Deadly"
+msgstr "致命"
+
+#. [campaign]: id=The_Hammer_of_Thursagan
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:47
 msgid ""
 "In the first years of the Northern Alliance, an expedition from Knalga seeks "
 "out their kin at Kal Kartha and to learn the fate of the legendary Hammer of "
@@ -89,66 +92,77 @@ msgstr ""
 "\n"
 
 #. [campaign]: id=The_Hammer_of_Thursagan
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:26
-msgid "(Intermediate level, 8 scenarios.)"
-msgstr "（中等级别，8幕场景。）"
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:49
+msgid "(Intermediate level, 9 scenarios.)"
+msgstr "（中等级别，9幕场景。）"
 
 #. [about]
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:29
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:52
 msgid "Author"
 msgstr "作者"
 
 #. [about]
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:35
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:58
 msgid "Special Guest Designer"
 msgstr "特邀设计师"
 
 #. [about]
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:41
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:64
 msgid "Art"
 msgstr "美工"
 
 #. [about]
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:54
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:77
 msgid "Brainstorming, playtesting, and spousal support"
 msgstr "头脑风暴，试玩和爱人支持"
 
 #. [about]
-#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:60
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:83
 msgid "Campaign Maintenance"
 msgstr "战役维护"
+
+#. [event]
+#. [unit]: type={TYPE}
+#. [side]: type=Dwarvish Masked Lord, id=Dufon
+#. [side]: type=Dwarvish Masked Lord, id=Aragoth
+#. [side]: type=Dwarvish Masked Lord, id=Dranath
+#: data/campaigns/The_Hammer_of_Thursagan/_main.cfg:103
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:33
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:92
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:127
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:150
+msgid "Masked Dwarf"
+msgstr "面具矮人"
 
 #. [achievement]: id=gryphon_hunter
 #: data/campaigns/The_Hammer_of_Thursagan/achievements.cfg:8
 msgid "Gryphon Hunter"
-msgstr ""
+msgstr "狮鹫猎人"
 
 #. [achievement]: id=gryphon_hunter
 #: data/campaigns/The_Hammer_of_Thursagan/achievements.cfg:9
-msgid "Kill the Gryphon leader in <i>High Pass</i>."
-msgstr ""
+msgid "Capture every gryphon in <i>High Pass</i>."
+msgstr "在 <b>高原山口</b> 中，抓住全部狮鹫。"
 
 #. [achievement]: id=conqueror_of_the_forest
 #: data/campaigns/The_Hammer_of_Thursagan/achievements.cfg:16
 msgid "Conqueror of the Forest"
-msgstr ""
+msgstr "森林征服者"
 
 #. [achievement]: id=conqueror_of_the_forest
 #: data/campaigns/The_Hammer_of_Thursagan/achievements.cfg:17
 msgid "Defeat an enemy leader in <i>Forbidden Forest</i>."
-msgstr ""
+msgstr "在 <b>禁忌森林</b> 中，击败一名敌方首领。"
 
 #. [achievement]: id=new_thursagan
 #: data/campaigns/The_Hammer_of_Thursagan/achievements.cfg:23
-#, fuzzy
-#| msgid "The Hammer of Thursagan"
 msgid "New Thursagan"
-msgstr "瑟萨冈之锤"
+msgstr "新瑟萨冈"
 
 #. [achievement]: id=new_thursagan
 #: data/campaigns/The_Hammer_of_Thursagan/achievements.cfg:24
-msgid "Complete <i>The Underlevels</i> on challenging difficulty."
-msgstr ""
+msgid "Complete <i>The Underlevels</i> on the hardest difficulty."
+msgstr "在 <b>下层世界</b>中，以最高难度通关。"
 
 #. [scenario]: id=01_At_the_East_Gate
 #: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:5
@@ -156,7 +170,7 @@ msgid "At the East Gate"
 msgstr "在东之门"
 
 #. [part]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:26
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:24
 msgid ""
 "In the first few years after the founding of the Northern Alliance, the "
 "dwarves of Knalga and the human population of Dwarven Doors were fully "
@@ -171,7 +185,7 @@ msgstr ""
 "亲族重新建立联系。"
 
 #. [part]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:30
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:28
 msgid ""
 "But the threat from hostile orcs, wild men, and remnant undead was not yet "
 "ended. The dwarves kept strong guards on the approaches to Knalga. In the "
@@ -182,172 +196,77 @@ msgstr ""
 "迦的道路上维持着强大的守备力量。在韦诺建立后第550年，东之门的守备队长收到警告"
 "说，发现了一小群流窜而来的兽人。"
 
-#. [side]
-#. [side]: type=Dwarvish Lord, id=Hamel
-#. [side]: type=Orcish Warrior, id=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:43
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:34
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:46
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:36
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:52
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:34
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:32
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:27
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:32
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:47
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:36
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:22
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:20
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:70
-msgid "Alliance"
-msgstr "联盟"
-
-#. [unit]: type=Gryphon Rider, id=Pelmathidrol
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:54
-msgid "Pelmathidrol"
-msgstr "佩尔马希德罗"
+#. [side]: type=Orcish Warrior, id=Bashnark
+#. [side]: id=leader{SIDE}, type={TYPE}
+#. this is the same clan name as the orcs who show up in S08, helping to explain how the cloak-pin made it all the way to Knalga. "Withervein" refers to poison.
+#. this is the same clan name as the orcs who you fought in S01, helping to explain how the cloak-pin made it all the way to Knalga. "Withervein" refers to poison.
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:52
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:41
+msgid "Clan Withervein"
+msgstr "枯脉氏族"
 
 #. [side]: type=Orcish Warrior, id=Bashnark
-#. [side]: type=Orcish Warlord, id=Tan-Morgh
-#. [side]: type=Orcish Warlord, id=Tan-Garukh
-#. [side]: type=Orcish Warlord, id=Tan-Wagran
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:70
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:82
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:127
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:169
-msgid "Orcs"
-msgstr "兽人"
-
-#. [side]: type=Orcish Warrior, id=Bashnark
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:75
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:57
 msgid "Bashnark"
 msgstr "巴什纳克"
 
-#. [label]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:87
+#. [event]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:77
 msgid "East Gate"
 msgstr "东之门"
 
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:96
-msgid "Defeat Bashnark"
-msgstr "击败巴什纳克"
-
-#. [objective]: condition=lose
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:100
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:149
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:106
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:121
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:364
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:136
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:221
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:135
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:215
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:762
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:928
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1096
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1149
-msgid "Death of Aiglondur"
-msgstr "艾格隆达死亡"
-
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:118
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:102
 msgid ""
 "<i>Up axes!</i> We will be the Northern Alliance’s arm today, and kill or "
 "scatter these invaders."
 msgstr "<b>举起斧来！</b>我们今天是北方联盟的守备队，杀散这帮侵略者。"
 
 #. [message]: speaker=Bashnark
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:123
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:106
 msgid ""
 "We are the true orcs, not the weaklings who ally with human-worms and stinky-"
-"midgets like you. You will be meat for our wolves."
+"midgets like you. Come out of your hole and fight us or we will burn your "
+"fields to ash!"
 msgstr ""
-"我们是真正的兽人，可不是那些会和你们这种人虫和臭矮子结盟的懦夫。你们等着变我"
-"们的狼粮吧。"
+"我们是真正的兽人，可不是那些会和你们这种人虫和臭矮子结盟的懦夫。滚出你们的洞"
+"穴来战，否则我们就把你们的田地烧成灰！"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:115
+msgid "Defeat Bashnark"
+msgstr "击败巴什纳克"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:119
+msgid "Death of Aiglondur"
+msgstr "艾格隆达死亡"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:143
+msgid "Rarrrggh..."
+msgstr "吼啊啊——！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:135
-msgid ""
-"What is this? Their vanquished leader wears a cloak-pin of dwarvish make. "
-"And it bears a loremaster’s emblem. Why would an orc be carrying metalwork "
-"of dwarvish make?"
-msgstr ""
-"这是什么？他们被击败的头目戴着矮人制作的斗篷别针。那上面还有博学士的纹章。为"
-"什么兽人会带着矮人制作的金属制品？"
-
-#. [message]: speaker=Movrur
 #: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:150
 msgid ""
-"Hail, kinsmen of Knalga. I have been tracking that orc for several days. He "
-"be part of a band of raiders that attacked us a few weeks ago and stole many "
-"arms from our forges."
+"What is this? Their vanquished leader wears a cloak-pin of dwarvish make. "
+"And it bears a loremaster’s emblem."
 msgstr ""
-"致敬，纳尔迦的同胞们。我已经追踪那个兽人好几天了。他是几周前袭击我们的掠袭者"
-"的一员，从我们的锻炉偷走了许多武器。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:160
-msgid "Yes, this cloak-pin be of our work."
-msgstr "是的，这个斗篷别针是我们制作的。"
+"这是什么？他们被击败的头目戴着矮人制作的斗篷别针。那上面还有博学士的纹章。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:165
-msgid "Hold... kinsman. Who are you and from where do you hail?"
-msgstr "等等......同胞。你是谁，来自哪里？"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:170
-msgid "I be Movrur, of the ancient stronghold of Kal Kartha."
-msgstr "我是摩夫鲁尔，来自古老的卡尔-卡萨要塞。"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:175
-msgid ""
-"Kal Kartha, the hold of the forges and the olden birthplace of our kind? "
-"That Kal Kartha? We have not heard from you in years! It was thought that "
-"your hold was lost to the orcs long ago."
-msgstr ""
-"卡尔-卡萨，锻炉之要塞，我们一族古老的发源地？那个卡尔-卡萨？我们已经多年没有"
-"你们的消息了！大家都以为你们的要塞早就被兽人占领了。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:180
-msgid ""
-"Aye, our hold was once overrun by orcs, but in recent times, we have begun "
-"to clear them out and reclaim the lands that were once ours. However, as you "
-"saw here, our troubles with the orcs are far from over."
-msgstr ""
-"是的，我们的要塞曾经被兽人占领过，但在最近，我们已开始清除他们，夺回曾经属于"
-"我们的土地。然而，正如你在这里看到的，我们面临的兽人麻烦还远远没有结束。"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:185
-msgid ""
-"In that case, we had best consult Lord Hamel. We may yet be able to send you "
-"some aid against these orcish marauders."
-msgstr ""
-"既然如此，那我们最好咨询哈梅尔领主。我们也许还能派人帮助你们对付这些兽人掠夺"
-"者。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:190
-msgid "If you wish it. Let us see what you can offer."
-msgstr "如果你们愿意那自然好。让我们看看你们能提供什么。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg:154
+msgid "The maker’s mark is strange to me. We had best consult the lord Hamel."
+msgstr "这工匠印记我从未见过。我们最好去请教哈梅尔领主。"
 
 #. [scenario]: id=02_Reclaiming_the_Past
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:5
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:9
 msgid "Reclaiming the Past"
 msgstr "追溯往昔"
 
 #. [part]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:23
-#, fuzzy
-#| msgid ""
-#| "Following the victory against the orcs, Aiglondur was summoned to the "
-#| "audience hall of Hamel, lord of Knalga and Lord Companion of the Northern "
-#| "Alliance. Beside the dais stood a stranger in the robes of the Order of "
-#| "Loremasters..."
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:27
 msgid ""
 "Following the victory against the orcs, Aiglondur was summoned to the "
 "audience hall of Hamel, Lord of Knalga and Lord Companion of the Northern "
@@ -355,92 +274,93 @@ msgid ""
 "Loremasters..."
 msgstr ""
 "在取得对兽人作战的胜利后，艾格隆达被传召到哈梅尔的会客大厅。哈梅尔是纳尔迦领"
-"主，同时也是北方联盟的共事王。台边站着一位穿着博学士修会长袍的陌生人……"
+"主，同时也是北方联盟的共同领主。台边站着一位穿着博学士修会长袍的陌生人……"
 
 #. [side]: type=Dwarvish Lord, id=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:51
+#. [side]: type=Orcish Warrior, id=Marth-Tak
+#. [side]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:40
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:76
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:58
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:24
+msgid "Alliance"
+msgstr "联盟"
+
+#. [side]: type=Dwarvish Lord, id=Hamel
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:45
 msgid "Hamel"
 msgstr "哈梅尔"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:98
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:96
 msgid ""
-"Aiglondur, the news ye bring is disturbing, for all it seems a small thing. "
-"I make known to ye Angarthing, loremaster in training."
+"Aiglondur, what ye ha’ found is disturbing, for all it seems a small thing. "
+"I make known to ye Angarthing, loremaster in training, who recognized the "
+"mark on it."
 msgstr ""
-"艾格隆达，你带来的消息虽小，却很让人不安。我要引见安伽辛给你，他是修行中的博"
-"学士。"
+"艾格隆达，你带来的消息看来虽小，却很让人不安。我要引见安伽辛给你，他是修行中"
+"的博学士，还认出了这上面的徽记。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:103
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:101
 msgid ""
-"As you know, the mark on this cloak-pin is that of our ancient kin at Kal "
-"Kartha in the high mountains. That an orc should come to possess this is "
-"troubling, for no orc should know even that loremasters exist, let alone "
-"come near enough to one to get this."
+"The mark on this cloak-pin is that of our kin at Kal Kartha in the eastern "
+"hills, from whom we’ve heard nothing since before Tallin broke the orcish "
+"occupation of Knalga. It troubles us that an orc should have come to possess "
+"it; no outsider should know even that loremasters exist, let alone come near "
+"enough one to get this."
 msgstr ""
-"如你所知，这枚斗篷别针上的印记是我们在高山之中的卡尔·卡萨的古老同胞的。这东西"
-"在兽人手上，让人很不安。兽人甚至不应该知道博学士的存在，更不要说能接近一位博"
-"学士并拿到这个了。"
+"这枚斗篷别针上的印记是我们在东部丘陵之中的卡尔·卡萨的同胞的。在塔林打破兽人对"
+"纳尔迦的占领之前，我们就已经没有他们的消息了。这东西在兽人手上，让我们深感不"
+"安。兽人甚至不应该知道博学士的存在，更不要说能接近一位博学士并拿到这个了。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:108
-msgid "Has some grave ill become of Kal Kartha?"
-msgstr "卡尔·卡萨是否已遭大难？"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:106
+msgid "I fear some grave ill may have become Kal Kartha."
+msgstr "我担心卡尔·卡萨已遭大难。"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:113
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:111
 msgid ""
-"Nay, it was merely... bad luck. We had just uncovered a magma bed for a new "
-"forge, one hot enough to reforge the ruined Hammer of Thursagan. We brought "
-"a loremaster to survey the site, but orcs ambushed us not long after he "
-"arrived."
+"And I fear for the Hammer of Thursagan. Our kin at Kal Kartha have been its "
+"keepers since a hero of their line recovered it from the Caverns of Flame, "
+"centuries ago."
 msgstr ""
-"不，这只是……运气不好而已。我们刚刚发现了一座岩浆床，可以建设新的锻炉。它的温"
-"度足以重新锻造被毁的瑟萨冈之锤。我们带了一位博学士来勘察现场，但在他到达后不"
-"久，兽人就伏击了我们。"
+"我为瑟萨冈之锤感到担忧。几个世纪以来，我们在卡尔·卡萨的族人一直守护着它，自从"
+"他们家族的一位英雄从烈焰洞穴中将其寻回后便是如此。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:118
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:116
 msgid "The Hammer of Thursagan?"
 msgstr "瑟萨冈之锤？"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:123
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:121
 msgid ""
 "Aye. The very tool with which our greatest runesmith made the Sceptre of "
 "Fire. But it is ancient, far older than Thursagan; he was but the last to "
 "wield it, and our oldest histories hint that this very hammer was used to "
-"forge the dwarves themselves in the heart of the deepest forges beneath Kal "
-"Kartha."
+"forge the dwarves themselves in the heart of the earth."
 msgstr ""
 "是的。我们最伟大的符文工匠打造圣火权杖时，使用的正是这一工具。但它很古老，比"
-"瑟萨冈还古老得多。而他只不过是最后一位使用者而已。我们最古老的历史记载暗示"
-"说，这正是用来在卡尔-卡萨最深处的锻炉核心之中，打造我们矮人的那把锤子。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:128
-msgid ""
-"We recovered the pieces from the Caverns of Flame long ago, but were unable "
-"to repair the artifact. The consequences of the Hammer’s ruination have thus "
-"been irreparable."
-msgstr ""
-"我们很久以前就从火焰岩洞中找到了瑟萨冈之锤的碎片，但却无法修复这件神器。因"
-"此，锤子毁坏的后果是无法弥补的。"
+"瑟萨冈还老得多。而他只不过是最后一位使用者而已。我们最古老的历史记载暗示说，"
+"这正是用来在地核之中，打造我们矮人的那把锤子。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:133
-msgid "What consequences?"
-msgstr "什么后果？"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:126
+msgid ""
+"But if the dwarves of Kal Kartha have held it all this time, why has none "
+"wielded it since Thursagan?"
+msgstr "但如果卡尔·卡萨的矮人一直保管着它，为何自瑟萨冈以来就无人挥舞过它？"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:138
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:131
 msgid ""
-"When Thursagan burned to death with his hand on the Hammer, all the "
+"Because when Thursagan burned to death with his hand on the Hammer, all the "
 "runemasters and arcanisters then living — all those who had sworn to the "
 "craft and bound themselves to the power o’ the Hammer — dropped dead without "
 "a mark on them, all struck down at the same moment. Their craft secrets died "
-"with them. That is why there are nae runesmiths among the dwarves today, and "
+"with them. That is why there are nae runesmiths among the Dwarves today, and "
 "sorely we miss them."
 msgstr ""
 "当瑟萨冈手上持锤，浑身着火而亡时，当时活着的符文大师和奥术师——他们全都对这一"
@@ -449,7 +369,7 @@ msgstr ""
 "文工匠的原因，我们深切地怀念他们。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:143
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:136
 msgid ""
 "That is what is said, my lord Hamel, and it is true. Except this; the Order "
 "of Loremasters has given me leave to reveal that the craft secrets were not, "
@@ -459,12 +379,12 @@ msgstr ""
 "上，技艺的秘密并没有像我们认为的那样彻底失传。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:148
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:141
 msgid "What is this ye say? Nae lost?"
 msgstr "你是什么意思？并无失传？"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:153
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:146
 msgid ""
 "Aye. Ye’ll recall that in repairing the western galleries we cleared a small "
 "cave-in hard by where Thursagan himself once had a workshop here, before he "
@@ -474,12 +394,12 @@ msgstr ""
 "冈自己曾拥有过的工坊，那是他独自去更北面的地方求学之前使用的。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:158
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:151
 msgid "And ye found something?"
 msgstr "而你是不是找到了些啥？"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:163
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:156
 msgid ""
 "A book. Thursagan’s book, in a secret and locked compartment he must have "
 "dug from the living rock himself by unaided runecraft. The cave-in breached "
@@ -493,12 +413,12 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:168
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:161
 msgid "And for what cause ha’ I heard naught o’ this?"
 msgstr "那为何我从未听说这个？"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:173
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:166
 msgid ""
 "My lord, the find was very recent. We are still deciphering the book. And "
 "there is this: with the Hammer at Kal Kartha and the book here, the question "
@@ -510,14 +430,14 @@ msgstr ""
 "就……很微妙了。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:178
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:171
 msgid ""
 "We feared stirring up a controversy before the book was even properly "
 "understood."
 msgstr "我们担心在这本书还没被正确解读之前，就会引发争议。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:183
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:176
 msgid ""
 "I’ll grant that was well thought, even if I am nae entirely pleased to have "
 "been kept in the dark. But ye came to me with a request, and I think I ken "
@@ -527,68 +447,51 @@ msgstr ""
 "你的请求是什么。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:188
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:181
 msgid ""
 "That is obvious; the Order of Loremasters wants to send an expedition to Kal "
-"Kartha to examine the possibility of restoring the order of Runemasters."
+"Kartha to find what has become of our kindred and the Hammer."
 msgstr ""
-"那很明显。博学士修会想派遣一个探险队去卡尔·卡萨，去看看有没有可能恢复符文大师"
-"修会。"
+"那很明显。博学士修会想派遣一个探险队去卡尔·卡萨，去看看我们的族人还有圣锤出了"
+"什么事。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:193
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:186
 msgid "Indeed, Lord Hamel, that is what we came to ask."
 msgstr "确实，哈梅尔领主，那就是我们此行的请求。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:198
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:191
 msgid "And you spoke my guess, Aiglondur. Are you nae kin of mine?"
 msgstr "而你说出了我的猜想，艾格隆达。你不就是和我同宗吗？"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:203
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:196
 msgid "Your great-nephew, my lord."
 msgstr "您的侄孙，阁下。"
 
 #. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:208
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:201
 msgid ""
 "Ye’re young and not tested... but ye have the rank, and ye’ve shown the wits "
-"to use it well. Movrur? What think ye?"
-msgstr ""
-"你还年轻又没经过考验……但你有军衔，而且展现过指挥的智慧，和军衔相配。莫夫鲁"
-"尔，汝意如何？"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:213
-msgid ""
-"As the orcs recently slew one of our invaluable loremasters, we would "
-"welcome the wisdom of one of our kin from Knalga."
-msgstr ""
-"兽人最近杀害了我们的一位宝贵的博学士，因此我们将欢迎来自纳尔加的一位同胞和他"
-"带来的智慧。"
-
-#. [message]: speaker=Hamel
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:218
-msgid ""
-"Then I have decided. Aiglondur, you and Angarthing will fare to Kal Kartha "
+"to use it well. I have decided. You and Angarthing will fare to Kal Kartha "
 "together, as soon as may be, with the best men of your guard."
 msgstr ""
-"我意已决。艾格隆达，你和安伽辛将同去卡尔·卡萨，尽快启程，从你的卫队里挑选精兵"
-"一同前往。"
+"你还年轻，尚未经受考验……但你有这个军衔，也已展现出善用它的才智。我已经决定"
+"了。你和安伽辛将尽快一同前往卡尔·卡萨，带上你卫队中最精锐的战士。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:235
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:218
 msgid "Aye, my Lord Hamel."
 msgstr "遵命，哈梅尔阁下。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:240
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:223
 msgid "The Order thanks you, Lord Hamel."
 msgstr "我代表修会感谢您，哈梅尔领主。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:245
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg:228
 msgid ""
 "We must make haste; winter approaches, and travel over the mountains will "
 "soon grow dangerous."
@@ -604,324 +507,462 @@ msgstr "古怪盟友"
 #. The same word, as '-mark', is in the name of 'the Estmarks': the hills of the eastern border.
 #: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:23
 msgid ""
-"Angarthing, Aiglondur, Movrur, and the dwarvish troop traveled swiftly to "
-"the east through the settled lands of the Northern Alliance. Soon enough "
-"they came to the wilder march country, where raids by large bands of hostile "
-"orcs and men were all too common."
+"Angarthing, Aiglondur, and the dwarvish troop traveled swiftly to the east "
+"through the settled lands of the Northern Alliance. Soon enough they came to "
+"the wilder march country, where raids by large bands of hostile orcs and men "
+"were all too common."
 msgstr ""
-"安伽辛、艾格隆达、莫夫鲁尔以及矮人部队快速行军穿过北方联盟的领地到了东面。很"
-"快他们到了更为荒蛮的边境郊区，在这里，遭遇大群的敌对兽人和人类的袭击是再平常"
-"不过了。"
+"安伽辛、艾格隆达以及矮人部队快速行军穿过北方联盟的领地到了东面。很快他们到了"
+"更为荒蛮的边境郊区，在这里，遭遇大群的敌对兽人和人类的袭击是再平常不过了。"
 
-#. [side]: type=Orcish Warrior, id=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:57
-msgid "Marth-Tak"
-msgstr "马斯-塔克"
+#. [side]: type={ON_DIFFICULTY4 Outlaw Outlaw Fugitive Fugitive}, id=Gorthas
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:46
+msgid "Gorthas’s Gang"
+msgstr "戈萨斯的团伙"
 
-#. [side]: type=Orcish Slayer, id=Gorthas
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:101
-msgid "Invaders"
-msgstr "入侵者"
-
-#. [side]: type=Orcish Slayer, id=Gorthas
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:107
+#. [side]: type={ON_DIFFICULTY4 Outlaw Outlaw Fugitive Fugitive}, id=Gorthas
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:51
 msgid "Gorthas"
 msgstr "戈萨斯"
 
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:145
-msgid "Help Marth-Tak defeat Gorthas"
-msgstr "帮助马斯-塔克击败戈萨斯"
-
-#. [objective]: condition=lose
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:153
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:110
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:125
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:368
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:140
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:225
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:139
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:219
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:766
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:932
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1100
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1153
-msgid "Death of Angarthing"
-msgstr "安伽辛死亡"
-
-#. [objective]: condition=lose
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:157
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:114
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:129
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:372
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:144
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:229
-msgid "Death of Movrur"
-msgstr "莫夫鲁尔死亡"
-
-#. [objective]: condition=lose
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:161
-msgid "Death of Marth-Tak"
-msgstr "马斯-塔克死亡"
-
-#. [note]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:174
-msgid "Your ally will focus on defending."
-msgstr ""
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:196
-msgid "Movrur, I had meant to ask you this before, but why do you wear a mask?"
-msgstr "莫夫鲁尔，我之前就想问你这个问题，你为什么要戴面具？"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:202
-msgid ""
-"Kal Kartha is the stronghold of numerous, ancient forges. We are at home in "
-"deep firepits, as smiths and craftsmen. The mask is a sign of our mastery of "
-"the forge."
-msgstr ""
-"卡尔-卡萨是拥有众多古老锻炉的要塞。我们是铁匠和工匠，很熟悉那深深的火坑。面具"
-"是我们掌握锻造技术的标志。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:207
-msgid ""
-"And more practically, it shields the face from flying sparks and molten "
-"steel. Even the forgemasters of Knalga don the mask, though perhaps not as "
-"continuously as our friend Movrur does. But we have no time to discuss this "
-"further right now; I see trouble brewing down the road!"
-msgstr ""
-"而更实际来说，它可以保护脸部免受飞溅火花和熔化钢铁的伤害。即使是纳尔迦的锻造"
-"师也戴着面具，尽管也许不像我们的朋友莫夫鲁尔那样总是戴着。但我们现在没时间进"
-"一步讨论这个，我看到有麻烦正在酝酿之中！"
+#. [side]: type=Orcish Warrior, id=Marth-Tak
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:81
+msgid "Marth-Tak"
+msgstr "马斯-塔克"
 
 #. [message]: speaker=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:212
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:124
 msgid "In the name of the Alliance, quit these lands now!"
 msgstr "以联盟的名义，马上离开这片土地！"
 
 #. [message]: speaker=Gorthas
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:217
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:128
+msgid ""
+"We will fare where we will and take what we will, dog of an orc. To the dark "
+"gods with you and your precious ‘Alliance’. Even your own kind are fed up "
+"with your peacemaking!"
+msgstr ""
+"我们想去哪儿就去哪儿，想拿什么就拿什么，兽人狗杂。你和你的宝贝“联盟”一起见黑"
+"暗之神去吧。连你们自己人都受够了你的绥靖！"
+
+#. [message]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:132
 msgid ""
 "Stinkin’ weakling! No true orc would fight for somethin’ as stupid as the "
 "Alliance."
 msgstr "讨厌的弱者！没有一个真正的兽人会为像联盟这样愚蠢的东西而战。"
 
 #. [message]: speaker=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:222
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:136
 msgid ""
 "You underestimate our strength. We shall see who the true orc is after this "
 "battle is over!"
 msgstr "你低估了我们的实力。这场战斗结束后，我们将看到谁才是真正的兽人！"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:227
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:141
 msgid ""
 "Now that is a sight still strange to my eyes — an orc fighting for the "
 "Northern Alliance."
 msgstr "现在这倒是个我仍旧不太习惯见到的景象——一个兽人为北方联盟而战。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:232
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:145
 msgid ""
 "I’m surprised myself that so many of the orcish tribes came over to the "
-"Alliance."
-msgstr "我自己也很惊奇有这么多的兽人部落加入了联盟。"
+"Alliance. Not so strange to see humans raiding us, worse luck."
+msgstr ""
+"我自己也很惊讶，这么多兽人部落竟然投靠了联盟。人类来袭击我们倒不稀奇，只是这"
+"运气更糟罢了。"
 
 #. [message]: speaker=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:239
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:150
 msgid "You, on the road! Are you of the Northern Alliance or not?"
 msgstr "你们，路过的！你们是不是北方联盟的？"
 
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:244
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:154
 msgid "We are."
 msgstr "我们是。"
 
 #. [message]: speaker=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:249
-msgid "Well, then, honor the treaty as I have."
-msgstr "好，那就像我一样遵守盟约吧。"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:254
-msgid "That is our duty. For the Alliance!"
-msgstr "这是我们的义务。为了联盟！"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:158
+msgid "Well, then, honor the treaty as I have. Fight to repel these invaders."
+msgstr "好，那就像我一样遵守盟约吧。奋战，击退这些入侵者。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:266
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:162
+msgid "That is our duty."
+msgstr "这是我们的义务。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:166
+msgid "For the Alliance! Axes up!"
+msgstr "为了联盟！举起斧头！"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:174
+msgid "Help Marth-Tak defeat Gorthas"
+msgstr "帮助马斯-塔克击败戈萨斯"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:178
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:175
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:151
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:273
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:212
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:361
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:216
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:908
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1159
+msgid "Death of Aiglondur or Angarthing"
+msgstr "艾格隆达或安伽辛死亡"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:182
+msgid "Death of Marth-Tak"
+msgstr "马斯-塔克死亡"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:206
 msgid "We have failed our duty to the Alliance."
 msgstr "我们没尽到自己对联盟的义务。"
 
 #. [message]: speaker=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:282
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:224
 msgid ""
-"My thanks, dwarves. There have been many attacks on the border tribes of "
-"late, and though we have repelled them thus far, the assaults have gotten "
-"only more fierce with each passing day."
+"My thanks, dwarves. These bandits might have hacked a bloody swathe through "
+"the Alliance’s tribes if we had not killed them here."
 msgstr ""
-"谢谢，矮人。最近，边境部落受到了许多攻击，虽然到目前为止我们都击退了他们，但"
-"攻击每天都变得比前一天更猛烈。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:287
-msgid ""
-"Indeed? What disturbs me is that these orcs bear arms and coins of dwarvish "
-"make. It intimates that this war-band was hired for this purpose."
-msgstr ""
-"真的？令我不安的是，这些兽人持有矮人制造的武器和硬币。这说明这支战帮正是为此"
-"而被雇佣的。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:292
-msgid ""
-"Nonsense. It may very well be that these orcs defeated a garrison of dwarves "
-"and raided their supplies. You need not draw such drastic conclusions from "
-"such an insignificant encounter."
-msgstr ""
-"胡说八道。很可能是这些兽人打败了矮人驻军，掠夺了他们的物资。你不需要从这样微"
-"不足道的遭遇中得出如此激烈的结论。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:297
-msgid ""
-"And what of the orcs that Aiglondur fended off at the East Gate of Knalga? "
-"Their leader’s cloak-pin bore the emblem of Kal Kartha—"
-msgstr ""
-"那么艾格隆德在纳尔迦东门击退的那些兽人呢？他们首领的斗篷针上有卡尔-卡萨的徽章"
-"——"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:302
-msgid ""
-"Several of our scouting bands were ambushed recently. These orcs must have "
-"been among those who slew our kinsmen. It is all the better we slaughtered "
-"them here!"
-msgstr ""
-"我们的几个侦察队最近遭到了伏击。这些兽人肯定是杀害我们同胞的人之一。这么一"
-"想，我们刚在这里杀了他们就更棒了！"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:307
-msgid "Indeed..."
-msgstr "确实……"
+"多谢了，矮人们。如果我们没有在此消灭他们，这些强盗恐怕已经在联盟的部落中大开"
+"杀戒了。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:312
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:228
 msgid ""
-"What matters is that these raiders are defeated now. My thanks to you, Marth-"
-"Tak, for proving there are orcs I can fight alongside rather than against. "
-"But we cannot linger here to celebrate; we are journeying east."
+"My thanks to you, for proving there are orcs I can fight alongside rather "
+"than against. But we cannot linger here to celebrate; we are journeying east."
 msgstr ""
-"重要的是那些掠袭者现在被击败了。向你致谢，马斯-塔克，你证明了这世界上有能与我"
-"并肩作战，而不是互相砍杀的兽人。但我们不能留在这里庆祝了，我们得向东行进。"
+"向你致谢，马斯-塔克，你证明了这世界上有能与我并肩作战，而不是互相砍杀的兽人。"
+"但我们不能留在这里庆祝了，我们得向东行进。"
 
 #. [message]: speaker=Marth-Tak
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:317
-msgid "East, eh? You won’t find many friends in that direction. Travel safely."
-msgstr "东边，嗯？你不会在那个方向上碰到太多朋友的。祝一路顺风。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg:232
+msgid ""
+"East, eh? You won’t find many friends in that direction. There’s talk of "
+"wolves, and worse. Travel safely."
+msgstr ""
+"东边，嗯？你不会在那个方向上碰到太多朋友的。传说有狼，还有更糟糕的东西。祝一"
+"路顺风。"
 
 #. [scenario]: id=04_High_Pass
 #: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:5
 msgid "High Pass"
 msgstr "高原山口"
 
-#. [side]: type=Gryphon, id=Kaara
-#. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:51
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:67
-msgid "Monsters"
-msgstr "怪物"
+#. [part]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:21
+msgid ""
+"Aiglondur and his troop, some still shaking their heads dubiously at the "
+"very notion of fighting alongside orcs rather than against them, continued "
+"north into the snow-covered peaks of the Heart Mountains."
+msgstr ""
+"艾格隆达率领他的部队继续向北，深入心山白雪皑皑的群峰。队伍中仍有人对与兽人并"
+"肩作战而非兵戎相向这一想法心存疑虑，不住地摇着头。"
 
-#. [side]: type=Gryphon, id=Kaara
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:55
-msgid "Kaara"
-msgstr "卡拉"
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:118
+msgid ""
+"Behold, the High Pass. By the old maps, we are two months’ journey from Kal "
+"Kartha here."
+msgstr "看，高原山口。根据旧地图，现在我们到卡尔·卡萨还有两月路程。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:122
+msgid ""
+"I hear the howling of wolves, and the shrill cries of gryphons. Traveling "
+"here may prove dangerous."
+msgstr "我听见狼嚎和狮鹫的尖啸。在这里行进恐怕会很危险。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:126
+msgid ""
+"It may also prove useful. The dwarves of yesteryear rode armies of gryphons "
+"into battle, but few remain in Knalga today."
+msgstr ""
+"但这或许也有用处。昔日的矮人曾骑着成军的狮鹫奔赴战场，但如今在纳尔迦，狮鹫已"
+"所剩无几。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:130
+msgid ""
+"Gryphons here will be wild; unaccustomed to our kind. But perhaps we can "
+"train them to accept riders, if we capture them first."
+msgstr ""
+"这里的狮鹫都是野生的，并不习惯我们。但如果我们先捕获它们，或许可以训练它们接"
+"受骑手。"
 
 #. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:102
-msgid "Move Aiglondur to the signpost at the east end of the pass"
-msgstr "移动艾格隆达至山道东端路标处"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:139
+msgid "Capture as many gryphons as you can"
+msgstr "捕获尽可能多的狮鹫"
 
-#. [message]: speaker=Angarthing
+#. [objective]: condition=lose
 #: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:144
-msgid ""
-"Behold, the High Pass. By the old maps, we are halfway to Kal Kartha here."
-msgstr "看，高原山口。根据旧地图，现在我们到卡尔·卡萨还有一半路程。"
+msgid "Death of Aiglondur, Angarthing"
+msgstr "艾格隆达或安伽辛死亡"
+
+#. [note]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:152
+msgid "To capture a gryphon, injure it below 10 hitpoints without killing it."
+msgstr "要捕获狮鹫，将它的生命值削减到10点以下，但不要杀死它。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:149
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:164
 msgid ""
-"We must push through quickly; there is a vicious storm coming in behind us. "
-"Being caught in a blizzard on those heights would be no laughing matter."
-msgstr ""
-"我们必须快速通过；特大风暴正追赶我们而来。在那么高的地方被暴风雪困住可不是闹"
-"着玩的。"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:254
-msgid ""
-"It has begun to snow. Move, everyone! To be trapped here would be death."
-msgstr "开始下雪了。大家快走！困在这里就死定了。"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:263
-msgid ""
-"We’re snowed in. Our mission has failed, even if we live until the spring."
-msgstr "我们被雪困住了。即使我们能活到春天，我们的任务也失败了。"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:277
-msgid "We’re through the pass!"
-msgstr "我们通过山道了！"
+"It is an honor to travel alongside a loremaster, Angarthing. One cannot "
+"begin to fathom the secrets of your order."
+msgstr "能与一位博学士同行实属荣幸，安伽辛。你们修会的秘密深不可测。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:282
-msgid ""
-"That may not be a blessing. Something has been driving these orcish raiders "
-"to push into Alliance territory. Don’t you wonder what it is?"
-msgstr ""
-"那也不一定算得上什么祝福。有什么东西在驱使那些兽人掠袭者入侵联盟领土。你不好"
-"奇那究竟是什么吗？"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:287
-msgid ""
-"The same that has been driving them to attack us at Kal Kartha. But, no "
-"matter the reason for their aggression, we shall slaughter them all the same."
-msgstr ""
-"那东西也促使他们在卡尔·卡萨攻击我们。但是，不论他们的侵略是出于什么原因，我们"
-"都照样会把他们屠掉。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:168
+msgid "I keep the Law. I witness the Deeds. Act with honor, Aiglondur."
+msgstr "我恪守律法。我见证功业。以荣耀行事，艾格隆达。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:292
-msgid ""
-"We are coming to Kal Kartha to study the Hammer of Thursagan, not mindlessly "
-"slay orcs."
-msgstr "我们来卡尔·卡萨是为了研究瑟萨冈之锤，而不是无脑杀戮兽人。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:312
+msgid "Well done! We have captured one gryphon."
+msgstr "干得好！我们捕获了一只狮鹫。"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:297
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:326
 msgid ""
-"Indeed, you are, but you musn’t lose sight of the end goal. Restoring the "
-"Hammer will revive the ancient art of runecraft and bring dwarven-kind back "
-"to glory. With the Hammer restored, no orc shall ever be a threat to us ever "
-"again."
+"This gryphon has perished! I did not mean to draw blood, only to exhaust and "
+"stun it, but I missed my mark."
 msgstr ""
-"的确，你的目标是这样。但你不能忽视最终的目标。修复圣锤将让古老的符文技艺复"
-"生，使矮人族重获荣耀。圣锤复原之后，将不再会有兽人对我们构成威胁。"
+"这只狮鹫死了！我本意并非要见血，只是想耗尽它的体力并击晕它，但我失手了。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:302
-msgid ""
-"I hope so, for the sake of peace and the safety of our people. For now, "
-"however, we must content ourselves with pressing onward toward Kal Kartha."
-msgstr ""
-"我希望如此，为了和平和我们人民的安全。然而现在，我们只要向卡尔·卡萨推进就好。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:377
+msgid "Do you hear that, Angarthing? There is shouting from the north."
+msgstr "你听见了吗，安伽辛？北边有喊声。"
 
-#. [scenario]: id=05_Fear
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:5
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:395
+msgid "Hail!"
+msgstr "你们好！"
+
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:399
+msgid "Hail, dwarves! I am Ratheln. Are you friends or foes?"
+msgstr "你们好，矮人们！我是拉什伦。你们是敌是友？"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:403
+msgid ""
+"I do not know you, and you have done my kin no harm. I wish no ill upon you."
+msgstr "我与你素不相识，你也未曾伤害我的族人。我对你并无恶意。"
+
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:407
+msgid ""
+"Then please, help us! My colleagues and I are assailed by a flight of drakes!"
+msgstr "那就请帮帮我们！我和同伴们正遭到一群龙人的袭击！"
+
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:411
+msgid ""
+"Our fire magic is useless against those fire-breathing monsters. Our camp is "
+"not far from here, to the northeast."
+msgstr ""
+"我们的火焰魔法对那些喷火的怪物毫无用处。我们的营地离这儿不远，就在东北方向。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg:415
+msgid ""
+"Northeast is the way we are traveling. And I’d not leave anyone who needs "
+"our help stranded to burn. Lead the way."
+msgstr ""
+"东北正是我们要去的方向。我绝不会丢下任何需要帮助的人，让他们被困在这里活活烧"
+"死。带路吧。"
+
+#. [scenario]: id=05_Mages_and_Drakes
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:5
+msgid "Mages and Drakes"
+msgstr "法师与龙人"
+
+#. [side]: type=Drake Flameheart, id=Glashal
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:35
+msgid "Drakes"
+msgstr "龙人"
+
+#. [side]: type=Drake Flameheart, id=Glashal
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:39
+msgid "Glashal"
+msgstr "格拉沙尔"
+
+#. [side]: type=Arch Mage, id=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:61
+msgid "Isle of Alduin"
+msgstr "奥渡因岛"
+
+#. [side]: type=Arch Mage, id=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:65
+msgid "Master Perrin"
+msgstr "佩林大师"
+
+#. [event]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:89
+msgid "Preceptor"
+msgstr "教习"
+
+#. [message]: speaker=Preceptor
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:123
+msgid ""
+"Master Perrin! Ratheln returns from the High Pass, with a company of "
+"dwarves. They look well-armed, and march in battle array."
+msgstr "佩林大师！拉什伦率领一队矮人从高原山口归来。他们装备精良，列阵而行。"
+
+#. [message]: speaker=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:127
+msgid ""
+"Help, if we are fortunate. Hail! You on the road! Who comes bearing arms "
+"into our valley?"
+msgstr "但愿来的是援军。你们好！路上的人！是谁携带武器进入我们的山谷？"
+
+#. [message]: speaker=Glashal
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:131
+msgid ""
+"‘Our’ valley, says Master Perrin.\n"
+"The arrogance of these mages is intolerable."
+msgstr ""
+"“我们的”山谷，佩林大师说。\n"
+"这些法师的傲慢真让人受不了。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:136
+msgid ""
+"A delegation of the Northern Alliance, traveling east. I believe we’ve found "
+"a friend of yours in the High Pass."
+msgstr "北方联盟的代表团，往东去。我想我们在高原山口找到了你的一位朋友。"
+
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:140
+msgid "They can help us, Master Perrin."
+msgstr "他们能帮我们，佩林大师。"
+
+#. [message]: speaker=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:144
+msgid ""
+"Well met, then. My students and I journeyed here to study the nest of drakes "
+"in the cliffs near the valley’s end."
+msgstr "那么幸会。我和我的学生们远行至此，是为了研究峡谷尽头悬崖上的龙人巢穴。"
+
+#. [message]: speaker=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:148
+msgid ""
+"Unfortunately, they’ve proven uncooperative. The brutes attacked us several "
+"times, and show no sign of stopping. I fear that they mean to kill us all!"
+msgstr ""
+"不幸的是，它们很不合作。这些蛮子已经袭击了我们好几次，而且丝毫没有收手的迹"
+"象。我担心它们是想把我们赶尽杀绝！"
+
+#. [message]: speaker=Glashal
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:152
+msgid ""
+"No more shall I suffer your cuts and needles.\n"
+"Long have you Prey harried us.\n"
+"I call a Hunt upon your kind, men and dwarves alike.\n"
+"None will leave this valley alive."
+msgstr ""
+"我绝不再忍受你们的刀割针刺。\n"
+"你们这些猎物，长久以来不断袭扰我们。\n"
+"我宣告对你们全族展开猎杀，人类与矮人一视同仁。\n"
+"没人能活着离开这座山谷。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:159
+msgid "Harrumph. I wonder who is truly at fault here."
+msgstr "哼。我倒想知道，真正该怪的是谁。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:163
+msgid "We must fight or we will all be slain. Axes up!"
+msgstr "我们必须战斗，否则全都要死。举起斧头！"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:171
+msgid "Defeat Glashal"
+msgstr "击败格拉沙尔"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:179
+msgid "Death of Master Perrin or Ratheln"
+msgstr "佩林大师或拉什伦死亡"
+
+#. [message]: speaker=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:213
+msgid "Aaarrgh! This expedition was a terrible idea..."
+msgstr "啊啊啊！这次远征真是个糟糕透顶的主意……"
+
+#. [message]: speaker=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:234
+msgid ""
+"We’re grateful for your assistance, dwarves. Although I am sorry things came "
+"to blows — there is little left for us to study. The drakes are dead, and "
+"their castle is even more decrepit than it was before."
+msgstr ""
+"矮人们，感谢你们的援助。虽然我很遗憾事情最终闹到了动武的地步——我们已经没什么"
+"可研究的了。龙人都死了，而他们的城堡也比以前更加破败不堪。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:239
+msgid ""
+"Hmm. This stonework is of dwarvish make. But long-abandoned and fallen into "
+"disrepair... by the decay, since even before the drakes came. There are orc-"
+"arrows embedded in the walls..."
+msgstr ""
+"呣。这石砌建筑是矮人建造的。但被遗弃已久，早已破败失修……从腐朽程度来看，甚至"
+"在龙人来之前就是这样了。墙里还嵌着兽人的箭矢……"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:243
+msgid ""
+"I’ve a grim feeling about this. Knalga once suffered greatly at the hands of "
+"orcs. Kal Kartha is smaller by half, and not nigh as war-like."
+msgstr ""
+"我对此有种不祥的预感。纳尔迦曾经遭受兽人的重创。卡尔·卡萨只有它一半大小，而且"
+"远没有那么好战。"
+
+#. [message]: speaker=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:248
+msgid ""
+"You have helped us; it is our duty to help you. Ratheln, it was your quick-"
+"thinking that brought Aiglondur here. If the dwarves allow it, will you "
+"accompany them in their journey east?"
+msgstr ""
+"你们帮助了我们，助你们一臂之力是我们的本分。拉什伦，正是你的急智将艾格隆达引"
+"到了此处。若矮人们应允，你可愿随行，与他们一同东行？"
+
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:252
+msgid "I will."
+msgstr "我愿意。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:257
+msgid "I am grateful."
+msgstr "十分感谢。"
+
+#. [message]: speaker=Master Perrin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Mages_and_Drakes.cfg:261
+msgid ""
+"Then go safely and return swiftly. The rest of us shall make our retreat "
+"back to Alduin."
+msgstr "那么一路平安，速去速回。我们其余人将撤回奥渡因。"
+
+#. [scenario]: id=06_Fear
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:5
 msgid "Fear"
 msgstr "恐惧"
 
@@ -929,672 +970,569 @@ msgstr "恐惧"
 #. [side]: type=Dwarvish Masked Lord, id=Dufon
 #. [side]: type=Dwarvish Masked Lord, id=Aragoth
 #. [side]: type=Dwarvish Masked Lord, id=Dranath
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:52
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:58
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:101
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:134
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:163
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:32
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:47
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:87
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:122
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:145
 msgid "Masked Dwarves"
 msgstr "面具矮人"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:78
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:54
 msgid "Peasants"
 msgstr "农民"
 
-#. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:106
-msgid "Raiders"
-msgstr "掠袭者"
-
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:117
-msgid "Find the inhabitants"
-msgstr "寻找居民"
-
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:184
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:131
 msgid ""
-"We should be on the outskirts of the settled country around Kal Kartha, but "
-"something doesn’t feel right here."
-msgstr "我们应该是在卡尔·卡萨周围有人居住的郊区了，但这里感觉不大对劲。"
+"The maps show a village nearby. Their keep should be just ahead, but "
+"something doesn’t feel right."
+msgstr "地图显示附近有一座村庄。他们的要塞应该就在前方，但感觉有些不对劲。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:189
-msgid "It’s too quiet... and I think I smell traces of smoke on the wind."
-msgstr "太安静了……我想我闻到风中有烟味。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:194
-msgid "There has been fire near here recently, and not a clean one."
-msgstr "里附近才起过火，而且还不是干净的火。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:135
+msgid ""
+"It’s too quiet... and I think I smell traces of smoke on the wind. There has "
+"been fire near here recently, and not a clean one."
+msgstr ""
+"太安静了……而且我感觉我闻到风中有烟味。这附近最近起过火，而且不是那种干净的"
+"火。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:199
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:139
 msgid ""
 "Look sharp for the inhabitants here. They might have something to tell us."
 msgstr "仔细寻找这里的居民。他们可能会告诉我们点什么。"
 
-#. [message]: role=peasantry
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:236
-msgid "Help! Someone please help!"
-msgstr "救命啊！谁来帮帮我！"
-
-#. [message]: role=peasantry
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:246
-msgid "Help!"
-msgstr "救命！"
-
-#. [message]: role=slaver
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:256
-msgid ""
-"<i>Quiet, dirtgrubber. Ye’ll not cry for help from these newcomers, else "
-"I’ll torture yer family ta death bef’re yer eyes.</i>"
-msgstr ""
-"<small>安静点，泥巴佬。你丫别向这些新来的家伙求救，否则俺会在你跟前把你家人折"
-"磨到死。</small>"
-
-#. [message]: role=peasantry
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:261
-msgid "They’ll stop you!"
-msgstr "他们会阻止你的！"
-
-#. [message]: role=slaver
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:266
-msgid "<i>Look again, slave. We march among their ranks too!</i>"
-msgstr "<small>再看看，奴隶。他们的队伍中也有我们的人！</small>"
-
-#. [message]: role=peasantry
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:279
-msgid "<i>It can’t be...</i>"
-msgstr "<small>这不可能……</small>"
-
-#. [message]: speaker=slaver
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:284
-msgid "<i>Now, be silent while the master speaks.</i>"
-msgstr "<small>现在，主人说话，给我闭嘴。</small>"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:289
-msgid "What in the world is going on here?"
-msgstr "这里究竟发生了什么？"
-
-#. [message]: speaker=Masked Dwarf Leader
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:294
-msgid ""
-"Fellow dwarves, hail! Kinsman Movrur, are ye back so soon from your journey "
-"to Knalga?"
-msgstr "矮人伙伴们，致礼！莫夫鲁尔同胞，你这么快就从纳尔迦回来了吗？"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:299
-msgid ""
-"Aye. I’ve brought some of our brethren from the Dwarven Doors; we make for "
-"the forges of Kal Kartha to examine the Hammer."
-msgstr "是的。我从矮人之门带来了一些弟兄。我们要去卡尔-卡萨的锻炉检查圣锤。"
-
-#. [message]: speaker=Masked Dwarf Leader
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:304
-msgid "Excellent. As for the current project, we—"
-msgstr "很好。至于目前的工程，我们——"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:309
-msgid ""
-"You two haven’t answered my question. Burnt homes? The peasants in a panic? "
-"Something is very wrong here."
-msgstr "你们两个还没回答我的问题。烧毁的房屋？恐慌的农民？这里很不对劲。"
-
-#. [message]: speaker=Masked Dwarf Leader
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:314
-msgid ""
-"... aye. We’ve been under attack by some marauding orcs, who’re hidin’ out "
-"in some of the villages. I put some guards out in the fields to... protect "
-"the peasants, but we haven’t the forces to root out all of them orcs."
-msgstr ""
-"……是的。我们被一些兽人掠袭者袭击了，他们躲在一些村庄里。我在田里派了一些卫兵"
-"去……保护农民，但我们没有足够的力量来铲除所有的兽人。"
-
-#. [message]: role=peasantry
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:319
-msgid "<i>That’s not what the guards are for...</i>"
-msgstr "<small>这些卫兵不是干这个的……</small>"
-
-#. [message]: role=slaver
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:324
-msgid "<i>Did I not tell you to be silent?</i>"
-msgstr "<small>俺不是叫你丫闭嘴吗？</small>"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:329
-msgid "Orcs, you say?"
-msgstr "你说兽人？"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:334
-msgid ""
-"Yes, orcs. The outskirts of Kal Kartha are a dangerous place. We’ve been "
-"forced to dedicate more of our forces here just to protect the peasants "
-"while they... go about their business."
-msgstr ""
-"是的，兽人。卡尔-卡萨的郊区是个危险的地方。我们被迫在这里投入更多的力量，只是"
-"为了保护农民，保护他们去做……去做他们的事。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:339
-msgid ""
-"Well, then. Since we are already here, why don’t we... help you root out "
-"these orcs? It will help the peasants get back to their lives."
-msgstr ""
-"那好吧。既然我们已经在这里了，那为什么我们不……帮你们铲除这些兽人？这能帮助农"
-"民们恢复他们原本的生活。"
-
-#. [message]: speaker=Masked Dwarf Leader
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:344
-msgid "Certainly..."
-msgstr "当然好啊……"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:349
-msgid "<i>Angarthing, is something wrong?</i>"
-msgstr "<small>安伽辛，有什么不对吗？</small>"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:354
-msgid ""
-"<i>Something is suspicious here. Stay alert and keep an eye on what those "
-"masked dwarves do. Movrur, too.</i>"
-msgstr ""
-"<small>这里有些可疑。保持警惕，注意那些戴面具的矮人的行为。还要注意莫夫鲁尔。"
-"</small>"
-
 #. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:360
-msgid "Find and defeat the orcish intruders"
-msgstr "找到并击败兽人入侵者"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:147
+msgid "Defeat the enemy leader"
+msgstr "击败敌方首领"
+
+#. [event]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:218
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:380
+msgid "Ollin"
+msgstr "欧林"
+
+#. [message]: speaker=Ollin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:221
+msgid "Don’t kill me, masters! Please don’t kill me!"
+msgstr "不要杀我，各位大人！请不要杀我！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:425
-msgid "The orcs are here! Up axes!"
-msgstr "兽人来了！举起斧来！"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:225
+msgid "You’re in no danger from us. What lies to the east of here?"
+msgstr "我们对你并无恶意。这东边是什么地方？"
 
-#. [unit]: type=Orcish Slayer, type=Orcish Nightblade, id=Maluk
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:571
-msgid "Maluk"
-msgstr "马鲁克"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:585
-msgid ""
-"So, the filth shows its face at last. You may think yourself mighty for "
-"preying on weak humans, but you stand no chance against us dwarves."
-msgstr ""
-"这么说，肮脏的东西终于露脸了。你可能以为自己很强大，可以掠夺弱小的人类，但面"
-"对我们矮人，你毫无胜算。"
-
-#. [message]: speaker=Maluk
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:590
-msgid "We shall see, masked one."
-msgstr "拭目以待，蒙面人。"
-
-#. [message]: speaker=Maluk
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:602
-msgid "They are too powerful! Retreat!"
-msgstr "他们太强了！撤退！"
+#. [message]: speaker=Ollin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:229
+msgid "You wear no mask. You... you’re not with them?"
+msgstr "你们没戴面具。你们……你们不是和他们一伙的？"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:615
-msgid "Their leader has fled! We have won!"
-msgstr "他们的首领逃跑了！我们赢了！"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:233
+msgid "What are you talking about?"
+msgstr "你在说什么？"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:626
-msgid "In his haste to escape, it seems like the orc dropped some coins."
-msgstr "在匆忙逃跑时，这个兽人似乎掉了一些金币。"
+#. [message]: speaker=Ollin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:237
+msgid "The masked dwarves. Killing, burning, kidnapping. Look..."
+msgstr "那些戴面具的矮人。杀人、放火、绑架。你看……"
 
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:631
-msgid "Let me see those."
-msgstr "让我看看。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:640
+#. [message]: role=masked_speaker
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:249
 msgid ""
-"These look as if they are of dwarven make! Movrur, what is the meaning of "
-"this?"
-msgstr "这些看起来好像是矮人铸造的！莫夫鲁尔，这是什么意思？"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:651
-msgid ""
-"In his haste to escape, it seems like the orc dropped some coins. It looks "
-"as if they are of dwarven make! Movrur, what is the meaning of this?"
+"Fellow dwarves, hail! We’re looking for a human refugee, a male with a "
+"broken arm. Have you seen him? Our master demands his life."
 msgstr ""
-"在匆忙逃跑时，这个兽人似乎掉了一些金币。这些看起来好像是矮人铸造的！莫夫鲁"
-"尔，这是什么意思？"
-
-#. [message]: speaker=second_unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:658
-msgid ""
-"In his haste to escape, it seems like the orc dropped some coins. It looks "
-"as if they are of dwarven make!"
-msgstr "在匆忙逃跑时，这个兽人似乎掉了一些金币。这些看起来好像是矮人铸造的！"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:663
-msgid "What, are you sure? Movrur, what is the meaning of this?"
-msgstr "什么，你确定吗？莫夫鲁尔，这是什么意思？"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:670
-msgid ""
-"Thieves and raiders, that be what these orcs are. They oft steal our gold "
-"and weapons in their raids, for such beasts have little ability to create "
-"either on their own."
-msgstr ""
-"这些兽人是盗贼和掠袭者。他们经常在袭击中偷取我们的黄金和武器，因为这种野兽几"
-"乎没有能力自己铸造它们。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:675
-msgid "So you say."
-msgstr "你这样说啊。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:680
-msgid ""
-"We of Kal Kartha have no reason to give these foul orcs any of our hard-"
-"earned gold, if that is what you are insinuating, <i>loremaster</i>."
-msgstr ""
-"我们卡尔-卡萨人没有理由给这些肮脏的兽人任何我们辛苦赚来的黄金，如果这就是你所"
-"暗示的，<b>博学士</b>。"
+"矮人同胞们，致敬！我们在找一个人类难民，一个断了胳膊的男人。你们见过他吗？我"
+"们的主人要他的命。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:685
-msgid ""
-"Indeed. Although I find it odd that the orcs would have found such a sum of "
-"dwarven currency from raiding human villages..."
-msgstr ""
-"确实如此。虽然我觉得很奇怪，兽人怎么会在掠夺人类村庄时找到这么多的矮人货币……"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:253
+msgid "He is here. How has he wronged your master, that you seek his death?"
+msgstr "他就在这里。他如何得罪了你们的主人，竟让你们要取他性命？"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:690
+#. [message]: role=masked_speaker
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:257
 msgid ""
-"If it pleases you, I will distribute this gold to these... poor... humans. "
-"That way, they can return to their fields with their money returned to them, "
-"and we can be on our way to Kal Kartha."
-msgstr ""
-"如果能让你高兴的话，我会把这些金币分给这些……贫穷的……人类。这样，他们就可以带"
-"着回到他们手里的钱，回到他们的田地里，而我们就可以上路，前往卡尔·卡萨了。"
+"Does it matter? He is only a dirtgrubbing human, not fit to polish the boots "
+"of the true people."
+msgstr "这重要吗？他不过是个土里刨食的人类，连给真民擦靴子都不配。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:695
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:261
 msgid ""
-"<i>That did not really answer your concern.</i> Very well, that sounds "
-"reasonable to me."
+"What is your name, masked one? Will you stand behind your deed? I am a "
+"witness."
+msgstr "你叫什么名字，戴面具的？你敢为自己的行为负责吗？吾乃见证者。"
+
+#. [message]: role=masked_speaker
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:265
+msgid ""
+"A witness? My name is... my name is not important. My deed will speak its "
+"own truth."
+msgstr "见证者？我的名字是……我的名字不重要。我的行为自会道出真相。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:269
+msgid ""
+"You speak without honor. Mine is the power of our ancient Law; speak your "
+"name and give up your murder, or the Law will cast you forth. I am a witness!"
 msgstr ""
-"<small>这并没有真正回答你关心的问题。</small>很好，我觉得这听起来挺合理的。"
+"你的言辞毫无荣誉可言。古老律法的力量与我同在；报上你的姓名，放弃你的谋杀，否"
+"则律法必将你放逐。吾乃见证者！"
+
+#. [message]: role=masked_speaker
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:277
+msgid ""
+"If you were a witness of the true people, you would not let a dirtgrubber "
+"hide behind your robes. I deny you!"
+msgstr ""
+"若你真是真民的见证者，就不会让一个刨土贱民躲在你的长袍后面。我拒绝承认你！"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:281
+msgid "The Law speaks: you are cast out. You are un-dwarf. I AM A WITNESS!"
+msgstr "律法宣判：汝当被放逐。汝已非矮人。<b>吾乃见证者！</b>"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg:700
-msgid ""
-"<i>Aye, we shall have to watch him more closely. Something is strange about "
-"him and the rest of these masked ones.</i> Lead the way, Movrur."
-msgstr ""
-"<small>是的，我们得更仔细地观察他。他和其余这些蒙面人都有些奇怪。</small>带路"
-"吧，莫夫鲁尔。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:285
+msgid "Up axes!"
+msgstr "举起斧头！"
 
-#. [scenario]: id=06_Forbidden_Forest
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:5
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:305
+msgid ""
+"I have never seen the formal banishment before. One reads of it in the old "
+"tales, of course, but to hear it with one’s own ears? It was... unsettling."
+msgstr ""
+"我从未见过正式的放逐。当然，古老传说里读到过，但亲耳听闻？这……令人不安。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:309
+msgid ""
+"It is not something we do often. The last such was in my grandsire’s time. "
+"But look upon the human’s wrists if you have any doubt it was merited."
+msgstr ""
+"这种事我们不常做。上一次还是我祖父那个时代的事了。但若你怀疑此举是否正当，看"
+"看那人类的手腕便知。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:313
+msgid ""
+"Shackles. Scars. No, Angarthing, I would not doubt you, even if it were my "
+"place to doubt a loremaster."
+msgstr "镣铐印。伤疤。不，安伽辛，我不会怀疑你，即便我有资格去质疑一位博学士。"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:334
+msgid "Argh!"
+msgstr "啊！"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:340
+msgid ""
+"Our castle is small, and these masked dwarves are many. This will be a "
+"bloody fight."
+msgstr "我们的城堡很小，而这些戴面具的矮人数量众多。这将是一场血战。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:344
+msgid ""
+"The masked ones must have raided this place before. Damaging the castle "
+"would have made it harder for the peasants to rally a defense."
+msgstr "这些戴面具的家伙之前一定劫掠过此地。破坏城堡会让农民更难集结防御。"
+
+#. [message]: role=masked_speaker
+#. [message]: speaker=Karrag
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:362
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:252
+msgid "..."
+msgstr "……"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:369
+msgid "They are defeated!"
+msgstr "他们败了！"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:373
+msgid "You have acted in honor. I am a witness."
+msgstr "你以荣耀行事。我乃见证者。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:377
+msgid ""
+"I do not wish to imagine what could drive dwarves to such depravity. These "
+"outlaws must have been desperate; consumed by fear or madness."
+msgstr ""
+"我不敢想象是什么让矮人堕落到如此地步。这些亡命之徒定是已走投无路，被恐惧或疯"
+"狂所吞噬。"
+
+#. [message]: speaker=Ollin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:385
+msgid "Thank you for your help, and for saving us!"
+msgstr "谢谢你们帮忙，谢谢你们救命！"
+
+#. [message]: speaker=Ollin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:389
+msgid ""
+"I do not mean to sound ungrateful, but — the masked ones... they always come "
+"back..."
+msgstr "我不是要有意显得不知感恩，但是——那些戴面具的家伙……他们总会回来的……"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:393
+msgid ""
+"There is a camp of mages not far upriver. If they have not yet departed, "
+"they can help you. Travel westways, to lands of the Northern Alliance. There "
+"you will be safe, and welcomed."
+msgstr ""
+"上游不远处有一个法师营地。如果他们还没离开，可以帮到你们。向西走，去北方联盟"
+"的领地。在那里你会安全，也会受到欢迎。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Fear.cfg:397
+msgid ""
+"We dwarves travel east. We must reach Kal Kartha, more urgently now than "
+"ever. Before anything terrible happens, if we are lucky..."
+msgstr ""
+"我们矮人要向东行进。必须比以往任何时候都更紧迫地赶到卡尔·卡萨。但愿能在祸事发"
+"生前抵达，如果我们运气够好的话……"
+
+#. [scenario]: id=07_Forbidden_Forest
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:5
 msgid "Forbidden Forest"
-msgstr "禁绝森林"
+msgstr "禁忌森林"
 
 #. [side]: type=Elvish High Lord, id=Telcherion
 #. [side]: type=Elvish Enchantress, id=Iluvarda
 #. [side]: type=Ancient Wose, id=Burumardir-Athelorand
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:54
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:79
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:104
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:43
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:76
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:109
 msgid "Forest"
 msgstr "森林"
 
 #. [side]: type=Elvish High Lord, id=Telcherion
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:59
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:48
 msgid "Telcherion"
 msgstr "泰尔切利温"
 
 #. [side]: type=Elvish Enchantress, id=Iluvarda
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:84
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:81
 msgid "Iluvarda"
 msgstr "伊鲁瓦尔达"
 
 #. [side]: type=Ancient Wose, id=Burumardir-Athelorand
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:108
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:113
 msgid "Burumardir-Athelorand"
 msgstr "布鲁玛迪尔-艾瑟洛兰德"
 
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:132
-msgid "Move both Aiglondur and Angarthing to the eastern signpost"
-msgstr "移动艾格隆达和安伽辛至东方路标处"
-
-#. [note]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:151
-msgid ""
-"To win, either move Aiglondur to the signpost and Angarthing next to him, or "
-"move Angarthing to the signpost and Aiglondur next to him."
-msgstr "为赢得胜利，移动艾格隆达至路标处，并移动安伽辛至艾格隆达身旁，或反之。"
-
 #. [unit]: type=Elvish Scout, id=Elurin
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:194
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:194
 msgid "Elurin"
 msgstr "艾鲁林"
 
 #. [message]: speaker=Elurin
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:203
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:206
 msgid "Who disturbs our forest?"
 msgstr "是谁在打扰我们森林的安宁？"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:208
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:211
 msgid ""
-"A delegation of the Northern Alliance, seeking the road through to Kal "
-"Kartha."
-msgstr "北方联盟的代表团，我们正在找条路去卡尔·卡萨。"
+"A delegation of the Northern Alliance, urgently seeking the road through to "
+"Kal Kartha."
+msgstr "北方联盟使团，急寻通往卡尔·卡萨之路。"
 
 #. [message]: speaker=Elurin
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:213
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:216
 msgid ""
-"We allow few outsiders in our forest paths, and no dwarves since the masked "
-"ones began to trouble our eastern margins. No axe-bearers shall come near "
-"our trees. Return whence you came!"
+"We allow few outsiders in our forest paths, and no dwarves since the war in "
+"the east. No axe-bearers shall come near our trees. Return whence you came!"
 msgstr ""
-"我们只允许很少的外来者通过林中道路，自从面具矮人开始骚扰我们的东面边境后，矮"
-"人就不准通行了。带斧头的人不得靠近我们的树林。从哪儿来就回哪儿去！"
+"我们只允许很少的外来者通过林中道路，自从东面开战，矮人就不准通行了。带斧头的"
+"人不得靠近我们的树林。从哪儿来就回哪儿去！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:218
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:221
+msgid ""
+"Winter comes on our heels, and your forest straddles the only gap between "
+"the snow-choked mountains and the river. If there is war in Kal Kartha, as "
+"you say, then that is all the more reason for us to make haste. Please tell "
+"me what you know of our kin, elf."
+msgstr ""
+"严冬紧追在我们身后，而你们的森林正横跨在被大雪封山的山脉与河流之间唯一的通"
+"道。如果卡尔·卡萨确有战事，正如你所说，那我们更应当加紧赶路。精灵，请把你所知"
+"的我们族人的情况告诉我。"
+
+#. [message]: speaker=Elurin
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:226
+msgid ""
+"I will say no more. I have already given our answer. Return whence you came."
+msgstr "我没什么好说的了。我已经给出了我们的答复。从哪儿来就回哪儿去。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:231
 msgid "No. We have our duty. We must pass."
 msgstr "不，我们有我们的使命。我们必须通过。"
 
 #. [message]: speaker=Elurin
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:223
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:236
 msgid "You shall not pass here."
 msgstr "你们不能通过这里。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:228
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:241
 msgid ""
-"Winter comes on our heels, and your forest straddles the only gap in these "
-"mountains. You leave us no choice but to fight you."
+"We must aid our kin. If you will not let us through peacefully, you leave us "
+"no choice but to fight."
 msgstr ""
-"冬天就快要来了，你们的森林跨坐在群山中唯一的缺口之上。你让我们别无选择，只能"
-"和你战斗了。"
+"我们必须援助我们的族人。如果你们不肯和平放行，那我们别无选择，只能开战。"
 
 #. [message]: speaker=Elurin
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:233
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:246
 msgid ""
 "So be it, then. Yours will not be the first bones to nourish the earth of "
 "our forest."
 msgstr "那就这么办吧。你们又不是第一群用尸骨来滋养林中泥土的人。"
 
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:269
+msgid "Move both Aiglondur and Angarthing to the eastern edge of the map"
+msgstr "移动艾格隆达和安伽辛两人至地图东侧边缘"
+
 #. [message]: speaker=second_unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:263
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:300
 msgid "We shall pass!"
-msgstr ""
+msgstr "我们会过去的！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:303
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:340
 msgid ""
 "Rally on me, everyone. We have better things to do than brawl with elves."
 msgstr "振作起来，弟兄们。我们有比和精灵打架更好的事要做。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg:312
-msgid "Kal Kartha should be only another day’s march north of here."
-msgstr "从这儿往北走，卡尔·卡萨应该只有一天的路程了。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Forbidden_Forest.cfg:350
+msgid "Kal Kartha should be only another week’s march east of here."
+msgstr "从这儿往东走，卡尔·卡萨应该只有一周的路程了。"
 
-#. [scenario]: id=07_The_Siege_of_Kal_Kartha
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:5
+#. [scenario]: id=08_The_Siege_of_Kal_Kartha
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:5
 msgid "The Siege of Kal Kartha"
 msgstr "卡尔·卡萨围城"
 
-#. [side]: type=Orcish Warlord, id=Tan-Morgh
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:87
-msgid "Tan-Morgh"
-msgstr "坦-莫嘎"
+#. [side]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:103
+msgid "Kal Kartha"
+msgstr "卡尔·卡萨"
 
-#. [side]: type=Orcish Warlord, id=Tan-Garukh
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:132
-msgid "Tan-Garukh"
-msgstr "坦-嘎鲁卡"
-
-#. [side]: type=Orcish Warlord, id=Tan-Wagran
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:174
-msgid "Tan-Wagran"
-msgstr "坦-瓦格朗"
-
-#. [label]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:208
+#. [event]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:126
 msgid "West Gate"
 msgstr "西之门"
 
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:217
-msgid "Defeat the orcish leaders"
-msgstr "击败兽人首领们"
-
-#. [objective]: condition=lose
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:233
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:143
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:223
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:770
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:936
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1104
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1157
-msgid "Death of Dulcatulos"
-msgstr "杜尔卡图洛斯死亡"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:263
-msgid "Behold! The West Gate of Kal Kartha!"
-msgstr "看啊！卡尔·卡萨的西之门！"
+#. [message]: speaker=Angarthing
+#. Angarthing specifies that Kal Kartha has many entrances. This helps explain how the Fear dwarves managed to leave while the West Gate was under siege.
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:187
+msgid "Behold! The West Gate of Kal Kartha! The largest of their many doors."
+msgstr "看啊！卡尔·卡萨的西门！这是他们众多大门中最大的一座。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:268
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:193
 msgid ""
-"And under siege, I see. There is a mighty host of orcs between us and that "
-"gate."
-msgstr "正被围攻，我看见了。有一群很强大的兽人挡在我们和那扇门之间。"
+"And under siege, as we feared — by orcs. But we are not too late! The "
+"defenders yet hold."
+msgstr ""
+"而且正如我们所担心的，正遭到围攻——是兽人。但我们来得还不算太晚！守军仍在坚"
+"守。"
 
-#. [message]: speaker=Tan-Morgh
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:273
+#. [message]: speaker=leader3
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:197
 msgid ""
 "Ahhh... more stinky-midgets, come to get killed just like these cowards in "
 "their den."
 msgstr "啊……更多的臭矮子，过来挨宰吧，像这些躲在陋穴里的懦夫一样。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:278
-msgid "Let us bring our kin that orc’s head as a guesting-gift."
-msgstr "让我们把那个兽人的脑袋作为带给亲族的见面礼吧。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:201
+msgid ""
+"There is a mighty host between us and our kin. Let us bring them that orc’s "
+"head as a guesting-gift!"
+msgstr ""
+"我们中间隔了一支庞大的军队。让我们把那兽人的脑袋当作见面礼，带给我们的族人！"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:208
+msgid "Defeat any three orcish leaders"
+msgstr "击败任意三名兽人首领"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:216
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:365
+msgid "Death of Dulcatulos"
+msgstr "杜尔卡图洛斯死亡"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:294
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:256
 msgid "Kal Kartha shall not fall!"
 msgstr "卡尔·卡萨不会陷落！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:306
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:274
 msgid "Kal Kartha is taken. Our mission has failed."
 msgstr "卡尔·卡萨沦陷了。我们的任务失败了。"
 
-#. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:319
+#. [message]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:295
+msgid "Useless grunts! We should have taken the gate weeks ago! Fight harder!"
+msgstr "没用的废物！城门几周前就该拿下了！给我拼命打！"
+
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:307
+msgid "I think they’ve been reinforced. I really don’t like orcs."
+msgstr "看来他们有援军了。我真是讨厌兽人。"
+
+#. [message]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:337
 msgid ""
-"Well fought, and our thanks; we were sore pressed. You are our honored "
-"guests, and I will show you to the best quarters we have myself. Our lord, "
-"the runemaster Karrag, will want to have speech with you on the morrow."
-msgstr ""
-"干得漂亮，非常感谢；我们被压制得太惨了。你们是我们光荣的客人，我会带你们去住"
-"我们最好的房间。我们的领主，符文大师卡拉格，希望明天能和你们交谈。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:324
-msgid "<i>Dulcatulos, you dunce...</i>"
-msgstr "<small>杜尔卡图洛斯，你个蠢货……</small>"
-
-#. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:329
-msgid "<i>Did I say something I should have not?</i>"
-msgstr "<small>我是不是说了什么不该说的？</small>"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:334
-msgid "<i>Never mind. I shall deal with you later.</i>"
-msgstr "<small>算了。我待会儿再找你算账。</small>"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:339
-msgid ""
-"A runemaster? There have been none such since Thursagan’s day. And for one "
-"to lead a holding was unheard-of; they tended towards the solitary life."
-msgstr ""
-"一位符文大师？自从瑟萨冈去世那天以来就没再有过这种人。统治一块领地的符文大师"
-"就更没有听说过了。他们倾向于过独居生活。"
+"Grr... nasty stinky-midgets. We know what you’re up to in there. We’ll be "
+"back."
+msgstr "呃啊……臭烘烘的恶心矮子。我们知道你们在里面搞什么鬼。我们会回来的。"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:344
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:351
 msgid ""
-"Aye? Well, you’d know such things better than I, loremaster. Lord Karrag "
-"toiled for long years to recover the craft lore. He was elevated when our "
-"old lord fell in battle against the besieging orcs. Karrag himself was "
-"wounded near to death; none thought he would recover."
-msgstr ""
-"哦？好吧，你对这种事的了解比我多，博学士。卡拉格领主花费了很多年苦心，找回了"
-"这一技艺的知识。我们的老领主在战场上被围城的兽人击倒后，他被提拔了。卡拉格自"
-"己也受了重伤几乎死去。没人想到他恢复了过来。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:349
-msgid ""
-"But he revived himself and stands with us now. That is all that matters."
-msgstr "但他自己恢复了活力，现在与我们站在一起。这是最重要的。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:354
-msgid ""
-"He has grasped the Hammer of Thursagan, then? Else I know not how he "
-"recovered the runelore of old."
-msgstr "这么说，他掌握着瑟萨冈之锤？我不知道他是怎么找回旧时的符文知识的。"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:359
-msgid ""
-"Aye. Shattered though the Hammer may be, it still retains some of its old "
-"power. With your knowledge and help, loremaster, we can reforge the hammer "
-"and use its power to smash all enemies that oppose us."
-msgstr ""
-"是的。尽管圣锤已经破碎，但它仍然保留了一些旧时的力量。有了你的知识和帮助，博"
-"学士，我们就可以重新铸造圣锤，用它的力量粉碎所有反对我们的敌人。"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:364
-msgid "The Hammer is a tool of crafting and making, not a weapon."
-msgstr "圣锤是用来制造和加工的，不是武器。"
+"Hail, fellow dwarves! Well fought, and our thanks; we were sorely pressed."
+msgstr "致敬，矮人同胞！打得漂亮，多谢相助；我们刚才险些抵挡不住。"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:369
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:355
 msgid ""
-"Is it not? Lord Karrag has wielded it in battle to great effect, even broken "
-"as it is."
-msgstr ""
-"不是吗？哪怕圣锤已经碎裂，但卡拉格领主在战斗中挥舞它，取得了巨大的战果。"
+"I had not expected to find allies so far from peopled lands. From whence do "
+"you hail?"
+msgstr "我没想到在远离人烟之地还能找到盟友。你们从何处来？"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:374
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:359
 msgid ""
-"<i>Stop speaking, you imbecile.</i> That would be the power of runecraft you "
-"witness. No fool would take a broken weapon into battle, much less a "
-"precious artifact like the Hammer. Karrag holds it as a symbol of his "
-"knowledge and mastery of lore, no more than that."
-msgstr ""
-"<small>闭嘴，你个低能儿。</small>你见证的正是符文的力量。没有傻瓜会带着一件破"
-"损的武器去战斗，更不用说像圣锤这样珍贵的神器了。卡拉格把它当作他的知识和对符"
-"文技艺的掌握的象征，仅此而已。"
+"We come at the behest of Hamel, Lord of Knalga and Lord Companion of the "
+"Northern Alliance. We seek audience with your lord."
+msgstr "我们奉纳尔迦领主、北方联盟共同领主哈梅尔之命前来，请求觐见贵领主。"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg:379
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg:363
 msgid ""
-"As you say. These things are for lords and loremasters to worry about, not "
-"the likes of me. I must see to my troop’s care. Food will be brought to you; "
-"rest well. We will speak again."
+"You are our honored guests, and I will show you to the best quarters we have "
+"myself. Then I must see to my troop’s care. Lord Karrag will have speech "
+"with you on the morrow."
 msgstr ""
-"您说的对。这些是领主和博学士们该操心的事，我这种人就免了。我要去照看我的部队"
-"了。食物会给你们送过去的。好好休息。我们以后再谈。"
+"你们是我们的贵客，我将亲自引你们去我们最好的住处。然后我还得去安顿我的部队。"
+"卡拉格领主明日会接见你们。"
 
-#. [scenario]: id=08_The_Court_of_Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:5
+#. [scenario]: id=09_The_Court_of_Karrag
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:5
 msgid "The Court of Karrag"
 msgstr "卡拉格的宫廷"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:50
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:100
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:46
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:33
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:26
 msgid "Kal Karthans"
 msgstr "卡尔·卡萨人"
 
-#. [unit]: type=Dwarvish Masked Steelclad, id=Magog
-#. [unit]: type=Dwarvish Masked Ulfserker, id=Hekyll
-#. [unit]: type=Dwarvish Masked Ulfserker, id=Jekyll
-#. [unit]: type={TYPE}
-#. [side]: type=Dwarvish Masked Lord, id=Dufon
-#. [side]: type=Dwarvish Masked Lord, id=Aragoth
-#. [side]: type=Dwarvish Masked Lord, id=Dranath
-#. [event]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:64
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:72
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:80
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:47
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:106
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:139
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:168
-#: data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg:25
-msgid "Masked Dwarf"
-msgstr "面具矮人"
-
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:131
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1092
-msgid "Defeat Karrag"
-msgstr "击败卡拉格"
-
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:180
+#. [message]: speaker=Dulcatulos
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:131
 msgid ""
-"I shall go take my place by Lord Karrag. See to it that you offer him the "
-"respect that he is due."
+"This way, Knalgans. Long has it been since any of your kind found your way "
+"to our humble hold. Our throne room lies just ahead — the runemaster Karrag "
+"will surely be eager to see you."
 msgstr ""
-"我该去站到在卡勒格勋爵身边我该站的位置上了。请注意，你们要给他应有的尊重。"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:192
-msgid "Angarthing... I have a bad feeling about this."
-msgstr "安伽辛……我有一种不祥的预感。"
+"这边请，纳尔迦人。你们族人已经很久没有踏足我们这简陋的要塞了。王座厅就在前方"
+"——符文大师卡拉格想必会很高兴见到你们。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:197
-msgid "Indeed. There is something very wrong here."
-msgstr "的确。这里非常不对劲。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:135
+msgid ""
+"A runemaster? There have been none such since Thursagan’s day. And for one "
+"to lead a holding was unheard-of; they tended towards the solitary life."
+msgstr ""
+"一位符文大师？自从瑟萨冈去世以来就没再有过这种人。统治一块领地的符文大师就更"
+"没有听说过了。他们倾向于过独居生活。"
+
+#. [message]: speaker=Dulcatulos
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:139
+msgid ""
+"Aye? Well, you’d know such things better than I, loremaster. Our Karrag "
+"toiled for long years to recover the craft lore. He was elevated when our "
+"old lord fell in battle against the besieging orcs. Karrag himself was "
+"wounded near to death; none thought he would recover. But he leads us today, "
+"and his runelore has oft been the only shield between us and the orcs."
+msgstr ""
+"是吗？好吧，你比我更了解这种事，博学士。我们的卡拉格多年来辛苦钻研，才恢复了"
+"这门工艺学识。老领主在与围攻的兽人战斗中阵亡后，他便被擢升上位。卡拉格本人也"
+"伤得奄奄一息，没人以为他能挺过来。但他如今领导着我们，而他的符文学识常常是我"
+"们与兽人之间唯一的屏障。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:143
+msgid "He has grasped the Hammer of Thursagan, then?"
+msgstr "那么，他已经掌握了瑟萨冈之锤？"
+
+#. [message]: speaker=Dulcatulos
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:147
+msgid ""
+"Aye. Toils over it in a workshop in the underlevels with his personal "
+"followers. He has promised all of us that the Hammer’s power will smash and "
+"scatter all our enemies."
+msgstr ""
+"没错。他带着亲信在下层的工坊里埋头苦干。他向所有人承诺，圣锤的力量将粉碎并驱"
+"散我们所有的敌人。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:151
+msgid ""
+"That is strange. The Hammer is a tool of crafting and making, not a weapon. "
+"What can he mean to do with it?"
+msgstr "这很奇怪。圣锤是锻造与创造的工具，不是武器。他想拿它做什么？"
+
+#. [message]: speaker=Dulcatulos
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:171
+msgid "We are here."
+msgstr "我们到了。"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:202
-msgid "Hail, fellow dwarves. All Kal Kartha thanks you for your timely rescue."
-msgstr "欢迎，矮人兄弟。所有卡尔·卡萨人民都感谢你们的及时救援。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:188
+msgid "Greetings, Knalgans!"
+msgstr "幸会，纳尔伽人！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:207
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:192
+msgid ""
+"Psst, Angarthing... Karrag and those dwarves on the dais, they’re all "
+"<i>masked</i>."
+msgstr "嗳，安伽辛……卡拉格，还有高台上的那些矮人，他们都<b>戴着面具</b>。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:196
+msgid "I see it. There is something very wrong here."
+msgstr "我看到了。这里非常不对劲。"
+
+#. [message]: speaker=Karrag
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:200
+msgid ""
+"It is good to once more host Knalgans in these halls. All Kal Kartha thanks "
+"you for your timely rescue."
+msgstr ""
+"很高兴能再次在这些厅堂中接待纳尔迦人。卡尔·卡萨全体上下都感谢你们及时的救援。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:204
 msgid ""
 "We are from Knalga; your clans are kin to ours of old. We but did our duty "
 "to kin."
@@ -1602,113 +1540,96 @@ msgstr ""
 "我们来自纳尔迦。你们氏族古时候是我们的亲族。我们只是尽了亲戚的职责而已。"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:212
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:208
 msgid ""
 "All dwarves are kin, and must prevail against orcs and humans and other "
-"dirtgrubbers. You can be part of the fist that smites them through the power "
-"of our ancient heirloom, the Hammer of Thursagan."
+"dirtgrubbers. You can be part of the fist that smites them."
 msgstr ""
-"所有矮人都是一家人，必须战胜兽人、人类以及其他掘土贱民。利用我们古老的祖传遗"
-"物，瑟萨冈之锤的力量，你们也可以成为砸向他们的铁拳的一部分。"
+"所有矮人都是一家人，必须战胜兽人、人类以及其他掘土贱民。你们也可以成为砸碎他"
+"们的铁拳的一部分。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:217
-msgid ""
-"We did not come to smite anyone, especially not using the most prized "
-"artifact of our heritage as a mere weapon."
-msgstr ""
-"我们不是来砸人的，尤其不是来把我们遗产中最珍贵的神器用作单纯的武器去砸人的。"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:212
+msgid "We did not come to smite anyone, but to re-open contact and trade."
+msgstr "我们并不是来砸碎任何人，而是为了恢复往来与贸易。"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:222
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:216
 msgid ""
-"Weapon? No, no, loremaster... you mistake my intentions. You know, as well "
-"as I do, that the Hammer is hardly a paltry weapon. The Hammer holds the "
-"soul of the dwarves, the true people. It is that which forged our flesh and "
-"blood, that which binds our will and forges our resolve. It is a symbol of "
-"our superiority as the true people of Irdya, an image that the other races "
-"shall respect and fear!"
+"Trade? Your destruction of the besieging orcs was a far nobler act than "
+"trade. There can be more such victories. And there will be by the power of "
+"our ancient heirloom, the Hammer of Thursagan."
 msgstr ""
-"武器？不，不，博学士......你搞错了我的意图。你和我一样清楚，圣锤并不是一件微"
-"不足道的武器。圣锤包含了矮人——真正的人——的灵魂。它铸造了我们的血肉，约束了我"
-"们的意志，锻造了我们的决心。它是我们作为伊迪亚的“真人”的优越性的象征，是其他"
-"种族应当尊重并畏惧的意象！"
+"贸易？你们歼灭围攻我们的兽人的壮举，远比贸易高尚得多。这样的胜利还可以有更"
+"多。凭借我们的古老传家宝——瑟萨冈之锤的力量，必将取得更多这样的胜利。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:227
-msgid "... so... what are you suggesting?"
-msgstr "……所以……您想表达什么？"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:220
+msgid "It is remembered in Knalga that Kal Kartha holds the Hammer."
+msgstr "纳尔迦的族人们一直记得，圣锤由卡尔·卡萨保管。"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:232
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:224
 msgid ""
-"The Hammer is still incomplete; we need the knowledge of a loremaster to "
-"reforge the remaining shards and restore the artifact to its most powerful "
-"state. Once that is done, none will be able to stand before me! Join us, "
-"loremaster. We can put your talent to good use."
+"Yes! And the Hammer holds the soul of the dwarves, the true people. "
+"Together, we can march to greater victories! Will you of Knalga join me?"
 msgstr ""
-"圣锤仍然不完整。我们需要博学士的知识来重新锻造剩余的碎片，并将神器恢复到其最"
-"强大的状态。一旦完成，那所有人都将拜倒在我面前！加入我们吧，博学士。我们可以"
-"很好地运用你的才能。"
+"没错！圣锤承载着矮人——真民的灵魂。只要我们齐心协力，就能迈向更伟大的胜利！你"
+"们纳尔迦人，可愿加入我？"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:237
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:232
 msgid ""
 "On one condition. You must take off that mask and show your true face. I am "
 "a witness."
 msgstr "有一个条件。您必须摘下面具以真面目示人。吾乃见证者。"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:242
-msgid "Impertinent cur! You dare—"
-msgstr "无礼之徒！你竟敢——"
-
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:247
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:236
 msgid ""
-"Quiet, Movrur. Loremaster, you... do not wish to see what is beneath this "
-"mask. I was terribly wounded in an orcish attack. Disfigured."
-msgstr ""
-"安静，莫夫鲁尔。你……不会愿意看到这面具下面的东西。我在兽人的一次进攻中受了重"
-"伤。毁容了。"
+"You... do not wish to see what is beneath this mask. I was terribly wounded "
+"in an orcish attack. Disfigured."
+msgstr "你……不会想看到这面具下面的东西。我在兽人的一次进攻中受了重伤。毁容了。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:252
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:240
 msgid ""
 "But the Law must see. A dwarf must put his name and his face behind his "
 "deeds. I am a witness."
 msgstr ""
 "但法典必须看到这些。一个矮人必须用他的名字和面目为他的行为负责。吾乃见证者。"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:257
+#. [message]: speaker=Karrag
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:244
 msgid ""
-"Master, you need not answer to this fool. Even for a loremaster, to dictate "
-"to a lord in his own holding... and one who holds the very soul of the "
-"dwarves in his hand. It is unthinkable!"
+"Impertinent fool! It is not for you to dictate to a lord in his own holding, "
+"much less one who holds the very soul of the dwarves in his hand."
 msgstr ""
-"主人，您不必搭理这个蠢货。就算是博学士……竟在一位领主，一位握有矮人真正灵魂的"
-"领主的领地上对他指手画脚。真是无法想象！"
+"放肆的蠢货！岂容你在一位领主自己的领地上指手画脚，更莫说这位领主手中还握着矮"
+"人一族的灵魂。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:262
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:248
 msgid ""
 "The Law speaks. Against him with the eyes to see, no deception can hold. I "
 "AM A WITNESS!"
 msgstr "如法典所言。明眼人前，无可瞒骗。<big>吾乃见证者！</big>"
 
-#. [message]: speaker=Movrur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:267
-msgid "Master—"
-msgstr "主人——"
+#. [message]: speaker=Karrag
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:256
+msgid "As you wish."
+msgstr "如你所愿。"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:298
-msgid "No... no... it is horrible! My lord, how did you come to this?"
-msgstr "不……不……太恐怖了！阁下，您怎么变成这样了？"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:287
+msgid ""
+"An empty skull?! A lich?! No... no... it is horrible! My lord, how did you "
+"come to this?"
+msgstr ""
+"空无一物的头骨？！巫妖？！不……不……太可怕了！我的领主，您怎么会变成这样？"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:303
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:291
 msgid ""
 "I lingered for weeks in agony. Only my hatred and the runelore of old "
 "sustained me, until I became as I am. I will have revenge; I will destroy "
@@ -1716,78 +1637,103 @@ msgid ""
 msgstr ""
 "我在极大的痛苦中苟延残喘了好几周。只有我的仇恨和古老的符文知识支撑着我，直到"
 "我变成现在这样。我要复仇；我要摧毁兽人，摧毁人类，摧毁精灵，摧毁一切，只剩下"
-"真正的人！"
+"真民！"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:308
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:300
 msgid ""
 "And you have sealed your doom. Hundreds of dirtgrubbers have already died to "
 "weave a web of blood around the Hammer and the soul of the dwarves. You and "
 "your new friends will be the last sacrifices I require to bind the entire "
-"dwarvish race to my purpose. TAKE THEM!"
+"dwarvish race to my purpose. Take the Knalgans, and Dulcatulos too! TAKE "
+"THEM!"
 msgstr ""
-"而你们难逃毁灭的命运。好几百个掘土贱民已经死了，他们的血织成的网围绕着锤子和"
+"而你们难逃毁灭的命运。好几百个掘土贱民已经死了，他们的血织成的网围绕着圣锤和"
 "矮人们的灵魂。你和你的新朋友们将是我所需要的最后祭品，这样我就能让整个矮人族"
 "顺从我的意图了。<b>抓住他们！</b>"
 
 #. [message]: speaker=narrator
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:321
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:346
 msgid ""
 "Neither side can recruit or recall. You must win with the troops you have."
 msgstr "双方都不能征募或者召回。你必须用你现有的部队取胜。"
 
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:338
-msgid ""
-"Wait... the lich’s apparent death was another illusion. In truth he ran "
-"through that doorway behind the throne."
-msgstr ""
-"等等……巫妖看上去死了，但那只是另一个错觉。实际上他从王座背后的门里逃跑了。"
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:357
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:904
+msgid "Defeat Karrag"
+msgstr "击败卡拉格"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:343
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:386
+msgid "A lich is no lord of mine!"
+msgstr "巫妖算我哪门子领主！"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:438
 msgid ""
-"Then Karrag has fled to the underlevels. None but his masked ones go there "
-"any more."
-msgstr "之后卡拉格逃到了下层。除了他的戴面具的仆从，已经没人会去那里了。"
+"Wait... something is not right. Karrag is not fighting back. He is nothing "
+"but an illusion!"
+msgstr "等等……有些不对劲。卡拉格没有还手。他不过是个幻象！"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:472
+msgid "What is this? Karrag did not fight back. He is nothing but an illusion!"
+msgstr "怎么回事？卡拉格没有还手。他不过是个幻象！"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:483
+msgid ""
+"Look — there is a stairway behind the throne! I hear receding footsteps."
+msgstr "看——王座后面有楼梯！我听到脚步声正在远去。"
+
+#. [message]: speaker=Dulcatulos
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:487
+msgid ""
+"Then Karrag has fled to the underlevels. None but the masked ones — his "
+"inner circle — go there any more."
+msgstr ""
+"之后卡拉格逃到了下层。除了他的戴面具的仆从——他的内环密会——已经没人会去那里"
+"了。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg:348
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Court_of_Karrag.cfg:491
 msgid ""
-"We must follow. Quickly! It may be his talk of perverting the Hammer was "
-"merely mad raving, but we cannot allow the risk that his foul spell might "
-"succeed."
+"We must follow. Quickly, and seal the entrance behind us! It may be his talk "
+"of perverting the Hammer was merely mad raving, but we cannot allow the risk "
+"that his foul spell might succeed."
 msgstr ""
-"我们必须跟上。快点！或许他说要污染锤子，只是狂言乱语罢了，但我们可不能承受万"
+"我们必须跟上。快点！或许他说要污染圣锤，只是狂言乱语罢了，但我们可不能承受万"
 "一他的丑恶咒语成功的风险。"
 
-#. [scenario]: id=09_The_Underlevels
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:5
+#. [scenario]: id=10_The_Underlevels
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:5
 msgid "The Underlevels"
 msgstr "下层世界"
 
 #. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:211
-msgid "Find and defeat Karrag"
-msgstr "找到并击败卡拉格"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:212
+msgid "Find Karrag"
+msgstr "找到卡拉格"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:275
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:262
 msgid "This place reeks of death."
 msgstr "这地方散发着死亡的气息。"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:280
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:266
 msgid ""
 "It has been... so many years since I’ve been down here. Only Karrag and his "
-"personal followers used this level. I can’t believe I never wondered about "
-"that before."
+"personal followers — the masked ones — used this level. I can't believe I "
+"never wondered about that before."
 msgstr ""
-"离我上次下到这里来有……有很多年了。只有卡拉格和他的个人追随者们使用这一层。真"
-"不敢相信我竟然从来都没有怀疑过。"
+"离我上次下到这里来有……有很多年了。只有卡拉格和他的个人追随者——那些戴面具的——"
+"使用这一层。真不敢相信我竟然从来都没有怀疑过。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:286
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:270
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:280
 msgid ""
 "It is Karrag’s doing—his will, and his dark magic. I think he has been "
 "casting glamours on all of you ever since he passed over."
@@ -1795,14 +1741,22 @@ msgstr ""
 "这是卡拉格干的好事——他的意志，还有他的黑暗魔法。我想自从去世以后，他就一直在"
 "你们身上施展迷惑魔法。"
 
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:276
+msgid ""
+"Dulcatulos fought with us to the death. How did he not wonder about Karrag "
+"before?"
+msgstr ""
+"杜尔卡图洛斯与我们并肩作战，至死方休。他以前怎么就没对卡拉格起过疑心呢？"
+
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:291
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:287
 msgid ""
 "Where <i>is</i> Karrag? We can’t have been more than seconds behind him."
 msgstr "卡拉格<b>在哪</b>？我们本来只在他后面不足几秒钟的距离上啊。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:296
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:292
 msgid ""
 "Most likely he has cloaked himself, thinking to run ahead to gather his "
 "followers. He could be within a spear-cast of us now and we wouldn’t know it "
@@ -1812,12 +1766,12 @@ msgstr ""
 "过就是长矛能掷到的距离而已，但这里这么阴暗，我们根本不能确定这一点。"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:305
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:301
 msgid "Those are war-drums!"
 msgstr "那是战鼓声！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:310
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:306
 msgid ""
 "Aye. Karrag, calling his troops to battle. Only the Dark Gods know what "
 "hellspawn the lich will summon. AXES UP!"
@@ -1826,102 +1780,88 @@ msgstr ""
 "狗东西。<big>举起斧来！</big>"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:333
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:329
 msgid "Someone died here."
 msgstr "有人死在这儿了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:362
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:358
 msgid "Poor guy didn’t make it."
 msgstr "可怜的家伙没撑过去。"
 
-#. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:393
-msgid "There’s some gold in here!"
-msgstr "这儿有些金币！"
+#. [scenario]: id=10_The_Underlevels
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:404
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:405
+msgid "This chest contains 50 gold pieces."
+msgstr "这个箱子里有50枚金币。"
+
+#. [scenario]: id=10_The_Underlevels
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:406
+msgid "There’s 150 gold in this chest!"
+msgstr "这个宝箱里有150枚金币！"
+
+#. [scenario]: id=10_The_Underlevels
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:407
+msgid "There’s 200 gold in this chest!"
+msgstr "这个宝箱里有200枚金币！"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:413
-msgid "I found some gold!"
-msgstr "我找到了一些金币！"
-
-#. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:447
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:434
 msgid "The gates are locked. I will have to break them open by force!"
 msgstr "门锁住了。我只能用蛮力打开它们了！"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:453
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:440
 msgid "The gates are locked!"
 msgstr "门锁住了！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:458
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:445
 msgid "Force them open!"
 msgstr "用蛮力打开它们！"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:463
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:450
 msgid "Yes, sir!"
 msgstr "是，长官！"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:496
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:483
 msgid "Let us proceed onward."
 msgstr "我们继续前进吧。"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:522
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:510
 msgid "There’s something behind this door. I shall break it down!"
 msgstr "这门背后有东西。我得把它砸破！"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:528
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:516
 msgid "There’s something behind this door."
 msgstr "这门背后有东西。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:533
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:521
 msgid "Break it down!"
 msgstr "把它砸破！"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:570
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:559
 msgid "It looks like there is a rune behind this gate!"
 msgstr "看起来这门后面有个符文！"
 
-#. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:608
+#. [message]: id=$unit.id
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:601
 msgid "The dirtgrubber-friends have come! Slay them all!"
 msgstr "掘土贱民的朋友来了！把他们都砍了！"
 
-#. [message]: speaker=second_unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:613
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:606
 msgid "You could not stop us before and you won’t be stopping us now!"
 msgstr "你之前阻止不了我们，现在也不行！"
 
-#. [message]: speaker=Dufon
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:634
-msgid ""
-"You shall never pass through here! The doors I guard are sealed by the power "
-"of the Hammer itself."
-msgstr "你们休想通过！我守卫的门是被瑟萨冈之锤自身的能量封印的。"
-
-#. [message]: speaker=second_unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:639
-msgid "You won’t stop us!"
-msgstr "你挡不住我们的！"
-
-#. [message]: speaker=Dufon
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:644
-msgid ""
-"Fools! Even should you defeat me, the master’s ritual will soon be complete "
-"and you shall all become his slaves!"
-msgstr ""
-"蠢货！就算你们能击败我，主人的仪式也马上就要完成了，你们都会变成他的奴隶！"
-
 #. [message]: speaker=Aragoth
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:664
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:622
 msgid ""
 "Your path forward ends here! Once the lord’s spell is complete, your souls "
 "will soon be chained to his will!"
@@ -1929,87 +1869,57 @@ msgstr ""
 "你们前进的道路到此为止了！一旦领主的魔咒完成，你们的灵魂都将服从于他的意志！"
 
 #. [message]: speaker=Dranath
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:685
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:643
 msgid "The dirtgrubbers have come! Stop their advance!"
 msgstr "掘土贱民来了！阻止他们前进！"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:712
-msgid "This must be one of the runic keys!"
-msgstr "这肯定是符文钥匙之一！"
-
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:752
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:918
-msgid "We still need to find the other one!"
-msgstr "我们还得要找到另一把！"
-
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:758
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:924
-msgid "Find and activate the runic keys (one remaining)"
-msgstr "找到并激活符文钥匙（还剩一把）"
-
-#. [note]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:774
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:940
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1108
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:658
 msgid ""
-"You may teleport units between matching runes (the destination must be clear)"
-msgstr "你可以在相匹配的符文之间传送单位（目的地必须无人占据）"
+"This must be a transport rune. Now that it is active, we can use to it to "
+"travel back and forth between here and the central gate."
+msgstr ""
+"这一定是个传送符文。既然它已经激活，我们就可以用它来往返于这里和中央大门之"
+"间。"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:878
-msgid "We’ve found a runic key!"
-msgstr "我们找到了一把符文钥匙！"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1034
-msgid "The keys have been found. The door should open..."
-msgstr "我们找到了钥匙，这门该开了……"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:674
+msgid "We have activated another transport rune."
+msgstr "我们又激活了一个传送符文。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1086
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:761
+msgid ""
+"Dark magic swirls in the air. Karrag grows stronger with each passing minute."
+msgstr "黑暗魔法在空气中翻涌。卡拉格每过一分钟都在变得更强。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:874
+msgid "It is done."
+msgstr "完成了。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:879
 msgid "The lich surely awaits us within. We must be on guard."
 msgstr "那巫妖肯定在里面等着我们。我们得警惕。"
 
 #. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1134
-msgid ""
-"It seems that the guard spoke the truth. These doors will not open to us!"
-msgstr "看起来那守卫说的是真的。这些门不会为我们而开！"
-
-#. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1139
-msgid ""
-"They are sealed by the ancient runelore of the Hammer. No amount of force "
-"can open these doors — we will need to find the keys to the seals here."
-msgstr ""
-"它们被瑟萨冈之锤古老的符文术封印了。不管用多大的力气都不可能打开这些门——我们"
-"得找到能打开封印的钥匙。"
-
-#. [objective]: condition=win
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1145
-msgid "Find and activate the runic keys to the sealed door"
-msgstr "找到并激活可以打开门的符文钥匙"
-
-#. [message]: speaker=unit
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1177
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:928
 msgid "My lord, the dirtgrubbers have entered our sanctuary!"
 msgstr "吾主，掘土贱民已经进入了我们的圣域！"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1182
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:933
 msgid "Excellent! Their blood will provide plenty of fuel for my ritual!"
 msgstr "好极了！他们的血可以为我的仪式提供足够多的燃料！"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1203
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:948
 msgid "So, the usurpers have arrived at last."
 msgstr "篡位者终于来了啊。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1208
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:953
 msgid ""
 "We are not the usurpers but the liberators of Kal Kartha! We are here to "
 "free our kin from your dark sorcery!"
@@ -2018,7 +1928,7 @@ msgstr ""
 "解放我们的同胞！"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1213
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:958
 msgid ""
 "You insolent fool! It is I who have led Kal Kartha to glory and I who have "
 "cleansed the lands of the true people from all unworthy scum! Kal Kartha "
@@ -2028,7 +1938,7 @@ msgstr ""
 "清除了所有毫无价值的人渣！全都是卡尔·卡萨欠我的！"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1218
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:963
 msgid ""
 "No! You are the one who owes our brethren their freedom! You have ensnared "
 "their minds with your foul magic and now we are here to put an end to your "
@@ -2038,7 +1948,7 @@ msgstr ""
 "现在我们将在此结束你残暴的统治！"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1223
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:968
 msgid ""
 "Any enemy of my rule is no better than the filthiest of dirtgrubbers. You no "
 "longer belong to the true people. You will become my slaves!"
@@ -2047,32 +1957,32 @@ msgstr ""
 "成为我的奴隶！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1228
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:973
 msgid "Not if we stop you here. AXES UP!"
 msgstr "如果我们在此阻止你，就不会了。<b>举起斧来！</b>"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1246
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:992
 msgid "No! No! No! Dirtgrubbers must die! The true people must rule all!"
 msgstr "不！不！不！掘土贱民必须死！真正的人必须统治一切！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1251
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:997
 msgid "The ‘true people’ speak through our axes. Die, foul lich."
 msgstr "“真正的人”靠我们的斧头说话。死吧，丑恶的巫妖。"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1256
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1002
 msgid "Nooo! My power... it wanes..."
 msgstr "不！我的力量……衰退了……"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1266
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1020
 msgid "And your rule is at an end, Karrag, once the brave lord of Kal Kartha."
 msgstr "而你的统治也结束了，卡拉格，卡尔·卡萨曾经的勇毅领主。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1271
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1024
 msgid ""
 "Do not mourn his passing, Dulcatulos. The Karrag you knew died many years "
 "ago when his lust for power consumed him. It is now time to put the past "
@@ -2081,8 +1991,18 @@ msgstr ""
 "不必哀悼他的离去，杜尔卡图洛斯。你所知的那位卡拉格，在很多年前他被对力量的贪"
 "欲吞噬之时，就已经死了。现在是时候走出过去的阴影，纠正曾经发生在此的错误了。"
 
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1030
+msgid ""
+"And your rule is at an end, Karrag, once the brave lord of Kal Kartha. It is "
+"now time to put the past behind and right the wrongs that have been wrought "
+"here."
+msgstr ""
+"你的统治到此为止了，卡拉格，卡尔卡塔曾经的勇敢领主。现在是时候放下过去，纠正"
+"这里所铸下的错误了。"
+
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1276
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1037
 msgid ""
 "Aiglondur speaks the truth. The deed is done. Though the heart of the "
 "darkness is gone, there is still much to do. Much will have to be done to "
@@ -2093,53 +2013,140 @@ msgstr ""
 "成。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1281
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1042
 msgid ""
 "But first, we must bring this news to the rest of Kal Kartha. A new Lord "
 "must be chosen."
 msgstr "但首先，我们得把这消息传达给卡尔·卡萨的其他人。必须选出一位新的领主。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1286
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1047
 msgid "Aye, let us go."
 msgstr "是的，我们行动吧。"
 
 #. [message]: speaker=Dufon
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1315
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1072
+msgid ""
+"You shall never pass through here! The doors I guard are sealed by the power "
+"of the Hammer itself."
+msgstr "你们休想通过！我守卫的门是被瑟萨冈之锤自身的能量封印的。"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1077
+msgid "You won’t stop us!"
+msgstr "你挡不住我们的！"
+
+#. [message]: speaker=Dufon
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1082
+msgid ""
+"Fools! Even should you defeat me, the master’s ritual will soon be complete "
+"and you shall all become his slaves!"
+msgstr ""
+"蠢货！就算你们能击败我，主人的仪式也马上就要完成了，你们都会变成他的奴隶！"
+
+#. [message]: speaker=Dufon
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1093
 msgid "The master’s ritual... must not be... interrupted..."
 msgstr "主人的仪式……不能……中断……"
 
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1107
+msgid ""
+"It seems that the guard spoke the truth. The eastern way is shut fast! There "
+"are two curious runes on the ground."
+msgstr "看来守卫说的是真的。东边的路被紧紧封死了！地上有两个奇特的符文。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1112
+msgid ""
+"The way is sealed by the ancient runelore of the Hammer. No amount of force "
+"can open these doors."
+msgstr "道路被圣锤古老的符文术封印了。不管用多大的力气都不可能打开这些门。"
+
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1117
+msgid "Most curious. I’ve never encountered magic of this sort before."
+msgstr "真稀奇。我以前从未遇到过这种魔法。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1122
+msgid ""
+"You know something of runes, Angarthing. You have read Thursagan’s notebook."
+msgstr "安伽辛，你对符文颇有了解。你读过瑟萨冈的笔记。"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1127
+msgid "Aye."
+msgstr "是的。"
+
+#. [message]: speaker=Aiglondur
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1132
+msgid "Can you open the doors?"
+msgstr "你能把门打开吗？"
+
+#. [message]: speaker=Angarthing
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1137
+msgid "Perhaps. We must be prepared for what lies beyond."
+msgstr "或许可以。我们必须准备好面对门后的东西。"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1145
+msgid ""
+"Karrag is not recruiting yet, so the longer it takes you to reach and "
+"confront him, the more gold he’ll have had time to stockpile. Open the "
+"Status Table (<i>Alt+S</i>) to check your opponents’ gold and income."
+msgstr ""
+"卡拉格尚未开始征募，因此你们在接触到他并与他交战前耗时越久，他就有越多的时间"
+"囤积金币。打开状态表（<i>Alt+S</i>）即可查看对手的金币和收入。"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1147
+msgid ""
+"Of course, the longer you wait to confront Karrag, the more gold you’ll have "
+"time to stockpile too."
+msgstr "当然，你在与卡拉格交战前拖延得越久，你自己也有越多的时间囤积金币。"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1151
+msgid "Prepare to face Karrag"
+msgstr "准备直面卡拉格"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1155
+msgid "When you are ready, move Angarthing to the marked hex"
+msgstr "当你准备好时，移动安伽辛至标记出来的六角格"
+
 #. [message]: speaker=Dranath
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1327
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1176
 msgid ""
 "Imbeciles! Once the master’s dark rite is complete, I will return to slay "
 "you myself!"
 msgstr "蠢货！一旦主人的黑暗仪式完成，我会亲自回来杀掉你们！"
 
 #. [message]: speaker=Aragoth
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1339
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1188
 msgid "The heathens... have slain me-"
 msgstr "异教徒……杀了我——"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1350
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1200
 msgid "The air is cold with the stench of death."
 msgstr "空气很冷，弥漫着死亡的恶臭。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1355
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1205
 msgid ""
 "No doubt it is this ritual that the masked ones spoke of. We must hurry and "
 "stop Karrag!"
 msgstr "毫无疑问，这就是那些戴面具的家伙所说的仪式。我们必须赶快去阻止卡拉格！"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1374
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1224
 msgid "I feel as if the life is being sapped out of my body!"
 msgstr "我觉得生命力正被吸出我的身体！"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1379
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1229
 msgid ""
 "Karrag’s spell grows more powerful with every passing moment. If we do not "
 "defeat him now, we will all turn into his thralls!"
@@ -2147,7 +2154,7 @@ msgstr ""
 "卡拉格的魔咒随着时间推移越来越强。要是不马上击败他，我们都会变成他的奴隶！"
 
 #. [message]: speaker=Karrag
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg:1388
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg:1238
 msgid ""
 "HAHAHAHA! Yes, yes, YES! The rite of death is complete at last! Die, you "
 "filthy dirtgrubbers, die so that I may raise you again as my mindless slaves!"
@@ -2155,90 +2162,92 @@ msgstr ""
 "哈哈哈哈！是的，是的，<b>是的！</b>死之仪式终于完成了！死吧，你们这些低劣的掘"
 "土贱民，死吧，这样我才能把你们复苏成我没有心智的奴隶！"
 
-#. [scenario]: id=10_Epilogue
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:5
+#. [scenario]: id=11_Epilogue
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:5
 msgid "Epilogue"
 msgstr "尾声"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:51
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:39
 msgid "Glamcatsil"
 msgstr "格拉姆卡希尔"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:52
+#. [then]
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:40
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:127
 msgid "Trithdurus"
 msgstr "崔斯达鲁斯"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:53
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:41
 msgid "Althasol"
 msgstr "艾尔萨索尔"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:54
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:42
 msgid "Dulalas"
 msgstr "杜拉那斯"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:55
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:43
 msgid "Pelalsol"
 msgstr "佩拉索尔"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:56
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:44
 msgid "Aigthaing"
 msgstr "艾格夏"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:57
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:45
 msgid "Pelcatol"
 msgstr "佩尔卡托尔"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:58
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:46
 msgid "Narithil"
 msgstr "纳利希尔"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:59
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:47
 msgid "Glamdrsol"
 msgstr "格拉姆德利索尔"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:60
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:48
 msgid "Pelaithil"
 msgstr "佩莱希尔"
 
 #. [side]
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:61
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:49
 msgid "Alaithus"
 msgstr "艾尔艾萨斯"
 
 #. [unit]: type=Lancer, id=Pelias
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:76
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:64
 msgid "Pelias"
 msgstr "佩利阿斯"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:122
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:145
 msgid ""
 "Dwarves of Kal Kartha, I speak the Law. Your house is cast down; you have "
 "harbored a great evil. Who now will take the burden of cleansing this "
 "holding of its taint?"
 msgstr ""
-"卡尔·卡萨的矮人们，我为法典代言。你们的家族堕落了；你们窝藏了巨大之恶。现在谁"
+"卡尔·卡萨的矮人们，我为律法代言。你们的家族堕落了；你们窝藏了巨大之恶。现在谁"
 "愿意担起从这领地之上清除污秽的重责？"
 
 #. [message]: speaker=narrator
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:127
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:150
 msgid ""
 "The dwarves of Kal Kartha muttered among themselves and looked at one "
 "another uneasily. None stepped forward."
 msgstr "卡尔·卡萨的矮人们交头接耳，窃窃私语，面面相觑。没有人站上前去。"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:133
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:157
 msgid ""
 "Loremaster... None of us is fit to take up the lordship. Karrag fooled us "
 "all, made us the tools of his foul scheme."
@@ -2247,45 +2256,54 @@ msgstr ""
 "丑恶计划的工具。"
 
 #. [message]: speaker=Pelias
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:158
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:183
 msgid ""
 "I was told I’d find Aiglondur of Knalga here. I bear a message from Tallin, "
 "the Lord Protector of the Alliance."
-msgstr "我领命来此寻找纳尔迦的艾格隆达。我带来了联盟的守护王塔林的口信。"
+msgstr "我领命来此寻找纳尔迦的艾格隆达。我带来了联盟的守护领主塔林的口信。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:163
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:188
 msgid "I am he. Speak your message."
 msgstr "我就是。宣读你的口信。"
 
 #. [message]: speaker=Pelias
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:169
+#. these are the peasants Aiglondur helped in "Fear"
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:194
 msgid ""
-"I have been on your track for weeks. Word of your rout of Tan-Morgh and his "
-"allies spread, and reached Tallin. You did the Alliance better service than "
-"you knew that day; Tan-Morgh had exchanged messages with certain orcish "
-"chieftains within the Alliance, and your victory prevented a dangerous "
-"revolt."
+"I have been on your track for weeks. Some time ago the Alliance received a "
+"ragged band of refugees, hailing from a small village west of here."
 msgstr ""
-"我循着您的踪迹追了几周，您击溃坦-马尔嘎和他的盟友的消息四处传播，传入了塔林耳"
-"中。那天您为北方联盟所做出的贡献比您所知的还要大。坦-马尔嘎已经和北方联盟内部"
-"某几个兽人酋长交换了信息，您的胜利阻止了一场危险的叛乱。"
+"我追踪你们的踪迹已有数周。不久前，联盟接收了一群衣衫褴褛的难民，他们来自这西"
+"边的一个小村庄。"
 
 #. [message]: speaker=Pelias
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:174
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:196
 msgid ""
-"Aiglondur, the Protector dubs you a Lord Companion of the Alliance. He bids "
-"you return to Knalga as soon as convenient, for your investiture."
+"They told a tale of terror and torment; of masked dwarves and axes in the "
+"night. As Lord Protector of the Alliance and an ally to all free men, Tallin "
+"bids you vanquish this evil."
 msgstr ""
-"艾格隆达，守护王授予您联盟共事王之职。他吩咐您尽快返回纳尔迦，为你进行授职。"
+"他们讲述了一个充满恐惧与折磨的故事；关于戴面具的矮人，以及黑夜中的斧刃。作为"
+"联盟的守护领主与全体自由人的盟友，塔林命你们铲除这股邪恶。"
+
+#. [message]: speaker=Pelias
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:201
+msgid ""
+"To emphasize the grave importance of the matter, the Protector would dub you "
+"a Lord Companion of the Alliance should you succeed. ...although by the "
+"scene now before me, perhaps you have already?"
+msgstr ""
+"为了强调此事事关重大，守护领主承诺，若你们成功，将册封你们为联盟共同领主……不"
+"过，就我眼前所见的情形，或许你们已经做到了？"
 
 #. [message]: speaker=Dulcatulos
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:179
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:211
 msgid "(<i>Wonderingly</i>) A Lord Companion? And kin of ours..."
 msgstr "（<b>吃惊地</b>）共事王？而且是我们的亲族……"
 
 #. [message]: speaker=Narithil
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:184
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:216
 msgid ""
 "It would be no shame for a Lord Companion to rule this holding, as Hamel "
 "does at Knalga."
@@ -2293,76 +2311,96 @@ msgstr ""
 "由一位共事王来统治这片领地就没什么好羞耻的了，就像哈梅尔统治纳尔迦一样。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:189
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:221
 msgid ""
 "The Kal Karthans looked at each other, and Aiglondur, with dawning hope."
 msgstr "卡尔·卡萨族人们互相看着，又看向艾格隆达，脸上显出了希望。"
 
 #. [message]: speaker=Angarthing
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:195
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:227
 msgid "It would be fitting. The Loremasters will approve."
 msgstr "这很合适。博学士们会认可的。"
 
 #. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg:200
+#: data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg:232
 msgid ""
 "Pelias, my thanks to the Lord Protector; I will attend him in the spring. "
 "But it seems that I have some work to do here first."
 msgstr ""
-"佩利阿斯，请代我向守护王致谢；我会在春天面见他的。不过看起来这里还有些工作我"
-"得先完成。"
+"佩利阿斯，请代我向守护领主致谢；我会在春天面见他的。不过看起来这里还有些工作"
+"我得先完成。"
 
-#. [unit_type]: id=Dwarvish Annalist, race=dwarf
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Annalist.cfg:4
-msgid "Dwarvish Annalist"
-msgstr "矮人述史者"
+#. [dummy]: id=smoke
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:274
+msgid "smoke"
+msgstr "烟雾"
 
-#. [unit_type]: id=Dwarvish Annalist, race=dwarf
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Annalist.cfg:21
+#. [dummy]: id=smoke
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:275
 msgid ""
-"Dwarvish Annalists are the historians of this ancient and proud race. They "
-"are few in number, and their very existence is not generally known to the "
-"other peoples of the Great Continent. To the abilities of the Witness they "
-"add, through the study of herb and mineral lore, the ability to cure poison."
+"Hit or miss, this attack creates a cloud of cloying, caustic smoke on the "
+"targeted hex. Any unit inside suffers halved chance-to-hit and can no longer "
+"enforce a zone of control. The cloud lasts until the start of this unit’s "
+"next turn."
 msgstr ""
-"矮人述史者是这古老而自豪的种族的历史学家。他们人数很少，泰陆上的其他民族并不"
-"普遍知道他们的存在。通过学习草药和矿物的知识，与见证者相比他们多了解毒的能"
-"力。"
+"无论命中与否，此攻击都会在目标格子上制造一团令人窒息的腐蚀性烟雾。任何处于其"
+"中的单位命中率减半，且无法再施加控制区域。烟雾将持续到此单位的下回合开始时。"
 
-#. [attack]: type=impact
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Annalist.cfg:61
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Loremaster.cfg:64
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Witness.cfg:66
-msgid "bolas"
-msgstr "流星锤"
+#. [dummy]: id=smoke
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:277
+msgid "<i>Magical</i> attacks are unaffected by smoke."
+msgstr "<b>魔法</b>攻击不受烟雾影响。"
 
-#. [unit_type]: id=Dwarvish Loremaster, race=dwarf
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Loremaster.cfg:4
-msgid "Dwarvish Loremaster"
-msgstr "矮人博学士"
-
-#. [unit_type]: id=Dwarvish Loremaster, race=dwarf
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Loremaster.cfg:23
-#, fuzzy
-#| msgid ""
-#| "Loremasters are the sages of the dwarvish race. Their counsel is greatly "
-#| "valued by war-leaders and chieftains, and they are viewed with awe by "
-#| "ordinary dwarves, for they alone have plumbed the deepest and most "
-#| "closely-held secrets of dwarven knowledge. It is said that where a "
-#| "loremaster stands, there is the soul of the dwarves. To the abilities of "
-#| "the Annalist they add a limited ability to heal."
+#. [dummy]: id=smoke
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:278
 msgid ""
-"Loremasters are the sages of the dwarvish race. Their counsel is greatly "
-"valued by war-leaders and chieftains, and they are viewed with awe by "
-"ordinary dwarves, for they alone have plumbed the deepest and most closely-"
-"held secrets of dwarven knowledge. It is said that where a Loremaster "
-"stands, there is the soul of the dwarves. To the abilities of the Annalist "
-"they add a limited ability to heal."
+"This unit’s attacks create clouds of caustic smoke, halving chance-to-hit "
+"and nullifying zone of control for any unit caught inside."
 msgstr ""
-"博学士是矮人族的圣贤。他们的忠告对战争指挥者和氏族首领非常有价值，普通矮人则"
-"对他们满怀敬畏，因为他们独自钻研着矮人族知识之中最深、最受保护的秘密。有种说"
-"法，博学士站在哪儿，哪儿就有矮人的灵魂。与述史者相比，他们多出了有限的治疗能"
-"力。"
+"此单位的攻击会制造腐蚀性烟雾，陷入其中的单位命中率减半，且无法施加控制区域。"
+
+#. [unit_type]: id=Dwarvish Grenadier, race=dwarf
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:284
+msgid "Dwarvish Grenadier"
+msgstr "矮人掷弹兵"
+
+#. [unit_type]: id=Dwarvish Grenadier, race=dwarf
+#. The "fine black dust" is a pouch of gunpowder, which a dead Dwarvish Thunderer (or Grenadier) has used for his weapon.
+#. When Ravan mutters his "arcane word of opening", magic causes sparks to leap from his fingers, which detonates the pouch.
+#. The actual detonation is cut off, letting the reader imagine exactly what might or might not have happened.
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:301
+msgid ""
+"Upon the person of a fallen dwarf, the arch-mage Ravan (before his fall to "
+"evil) once espied a pouch, carefully sealed and filled — unbeknownst to him "
+"— of a fine black dust."
+msgstr ""
+"在一个倒下的矮人身上，大法师拉万（在他堕入邪道之前）曾瞥见个密封完好的袋子，"
+"里面装满了他当时并不知晓的——一种精细的黑色粉尘。"
+
+#. [unit_type]: id=Dwarvish Grenadier, race=dwarf
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:303
+msgid ""
+"Arthritic fingers unable to loose the knot that held tight its mouth, Ravan "
+"leaned forward, muttering under his breath an arcane word of opening. Sparks "
+"leapt from his fingers—"
+msgstr ""
+"拉万的手指因关节炎而僵硬，解不开那紧紧扎住袋口的绳结，只得俯身向前，低声念出"
+"一句开启的秘语。火花从他指尖迸射而出——"
+
+#. [attack]: type=blade
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:309
+msgid "dagger"
+msgstr "匕首"
+
+#. [attack]: type=fire
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:318
+msgid "torch"
+msgstr "火炬"
+
+#. [attack]: type=fire
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Grenadier.cfg:327
+msgid "flashpowder"
+msgstr "闪光粉"
 
 #. [unit_type]: id=Dwarvish Masked Berserker, race=dwarf
 #: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Berserker.cfg:4
@@ -2390,7 +2428,7 @@ msgid "Dwarvish Masked Lord"
 msgstr "戴面具的矮人领主"
 
 #. [unit_type]: id=Dwarvish Masked Lord, race=dwarf
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Lord.cfg:17
+#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Lord.cfg:18
 msgid ""
 "Feared in dwarven legend is the Dwarf Lord who masks his face, using the "
 "formidable fighting powers of his kind without accounting to his peers and "
@@ -2429,6 +2467,9 @@ msgid ""
 "make them imposing foes indeed. In the dark dreams of dwarvenkind, some "
 "conceal their faces behind riveted masks."
 msgstr ""
+"身着纳尔迦熔炉所打造的最坚固板甲与锁甲，铁甲兵是矮人军队的先锋。他们以在激战"
+"中的顽强韧性而闻名，且对战斧与战锤的精通确实令他们成为令人畏惧的强敌。在矮人"
+"族最黑暗的梦境中，有些人将面容隐藏在铆接面具之后。"
 
 #. [unit_type]: id=Dwarvish Masked Thunderer, race=dwarf
 #: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Thunderer.cfg:4
@@ -2445,75 +2486,30 @@ msgstr "戴面具的矮人雷霆卫士"
 msgid "Dwarvish Masked Ulfserker"
 msgstr "戴面具的矮人狂狼战士"
 
-#. [unit_type]: id=Dwarvish Witness, race=dwarf
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Witness.cfg:10
-msgid "Dwarvish Witness"
-msgstr "矮人见证者"
+#. [unit_type]: id=Grounded Gryphon, race=gryphon
+#: data/campaigns/The_Hammer_of_Thursagan/units/Sleeping_Gryphon.cfg:4
+msgid "Grounded Gryphon"
+msgstr "落地狮鹫"
 
-#. [unit_type]: id=Dwarvish Witness, race=dwarf
-#: data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Witness.cfg:27
-msgid ""
-"A Witness functions as the eyes of the dwarves’ history, a deep lore that "
-"they never share with outsiders. The presence of a Witness inspires dwarvish "
-"warriors with the knowledge that their deeds (and their deaths) will not go "
-"unrecorded. They learn a fighting style deliberately unlike that of their "
-"fellows, one designed to turn the vaunted strength of the dwarves against "
-"itself. The person of a Witness is considered sacred, and Witnesses are "
-"often used as envoys between dwarvish clans."
-msgstr ""
-"见证者的职责是作为矮人的历史之眼，矮人一族的历史是他们绝不与外人分享的深奥知"
-"识。见证者的存在鼓舞着矮人武士，因为他们知道，自己的事迹（还有死亡）将会被记"
-"录下来。他们学习的是一种特意与同伴们不同的战斗风格，这种战斗风格用矮人们自夸"
-"的强壮来对付自己。见证者被看作是神圣的，他们经常担任矮人氏族之间的外交使节。"
-
-#. [leadership]: id=inspire
-#: data/campaigns/The_Hammer_of_Thursagan/utils/abilities.cfg:10
-msgid "inspire"
-msgstr "鼓舞"
-
-#. [leadership]: id=inspire
-#: data/campaigns/The_Hammer_of_Thursagan/utils/abilities.cfg:11
-msgid "female^inspire"
-msgstr "鼓舞"
-
-#. [leadership]: id=inspire
-#: data/campaigns/The_Hammer_of_Thursagan/utils/abilities.cfg:12
-msgid ""
-"This unit can inspire own units that are next to it, making them fight "
-"better. Adjacent own units of lower or equal level will deal 25% more damage "
-"plus 25% for each level they are below the inspiring unit."
-msgstr ""
-"此单位能鼓舞在他周围的友方单位，让他们更好地战斗。相邻的友方单位中，等级与其"
-"相同或比其低的单位将多输出25%伤害，等级每多差一级，则再多输出25%伤害。"
-
-#. [leadership]: id=inspire
-#: data/campaigns/The_Hammer_of_Thursagan/utils/abilities.cfg:13
-msgid ""
-"The presence of this unit inspires own units next to it to deal more damage "
-"in combat, though this only applies to units of lower or equal level."
-msgstr ""
-"此单位的存在使周围的友方单位在战斗中造成更多伤害，虽然这只对比其低等级或与其"
-"同等级的单位有效。"
-
-#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:6
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:33
 msgid "Aiglondur"
 msgstr "艾格隆达"
 
-#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:19
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:46
 msgid "Angarthing"
 msgstr "安伽辛"
 
-#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:31
-msgid "Movrur"
-msgstr "摩夫鲁尔"
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:59
+msgid "Ratheln"
+msgstr "拉什伦"
 
-#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:43
-#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:56
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:70
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:83
 msgid "Dulcatulos"
 msgstr "杜尔卡图洛斯"
 
-#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:69
-#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:78
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:96
+#: data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg:105
 msgid "Karrag"
 msgstr "卡拉格"
 
@@ -2527,27 +2523,97 @@ msgstr "我失败了！"
 msgid "Oh no! Without a loremaster we cannot complete our mission!"
 msgstr "噢不！没有博学士我们无法完成我们的任务！"
 
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/utils/herodeaths.cfg:48
-msgid "We needed Movrur to accompany us to Kal Kartha!"
-msgstr "我们需要莫夫鲁尔陪我们去卡尔·卡萨！"
+#. [message]: speaker=Ratheln
+#: data/campaigns/The_Hammer_of_Thursagan/utils/herodeaths.cfg:47
+msgid "Aaarrgh! What will become of my students back home..."
+msgstr "啊啊啊！留在家里的学生们该怎么办啊……"
 
-#. [message]: speaker=Aiglondur
-#: data/campaigns/The_Hammer_of_Thursagan/utils/herodeaths.cfg:66
+#. [message]: speaker=Dulcatulos
+#: data/campaigns/The_Hammer_of_Thursagan/utils/herodeaths.cfg:60
+msgid "At least I die with my axe in my hand..."
+msgstr "至少我是手持战斧而死的……"
+
+#. [unit_type]: id=Dwarvish Annalist, race=dwarf
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Annalist.cfg:4
+msgid "Dwarvish Annalist"
+msgstr "矮人述史者"
+
+#. [unit_type]: id=Dwarvish Annalist, race=dwarf
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Annalist.cfg:22
 msgid ""
-"Without Dulcatulos to explain our actions to the Kal Karthans we’ll have to "
-"fight them, too. Our mission has failed."
+"Dwarvish Annalists are the historians of this ancient and proud race. They "
+"are few in number, and their very existence is not generally known to the "
+"other peoples of the Great Continent. They learn a fighting style "
+"deliberately unlike that of their fellows, one designed to turn the vaunted "
+"strength of the dwarves against itself."
 msgstr ""
-"没有杜尔卡图洛斯来向卡尔·卡萨族人解释我们的行动，那我们就也得和他们开战。我们"
-"的任务失败了。"
+"矮人述史者是这古老而自豪的种族的历史学家。他们人数很少，泰陆上的其他民族并不"
+"普遍知道他们的存在。他们学习的是一种刻意有别于同族的战斗风格，旨在将矮人引以"
+"为傲的力量反制于其身。"
 
-#~ msgid ""
-#~ "More experienced dwarvish fighters wear heavy chain mail and plate armor, "
-#~ "for which they are rightly famous. In the dark dreams of dwarvenkind, "
-#~ "some conceal their faces behind riveted masks."
-#~ msgstr ""
-#~ "更有经验的矮人战士们穿着沉重的锁子甲和板甲，他们因此而闻名并名副其实。在矮"
-#~ "人们黑暗的梦境之中，有些人用铆接的面具把自己的脸隐藏起来。"
+#. [attack]: type=impact
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Annalist.cfg:57
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Loremaster.cfg:58
+msgid "bolas"
+msgstr "流星锤"
 
-#~ msgid "Ratheln"
-#~ msgstr "拉什伦"
+#. [unit_type]: id=Dwarvish Loremaster, race=dwarf
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Loremaster.cfg:4
+msgid "Dwarvish Loremaster"
+msgstr "矮人博学士"
+
+#. [unit_type]: id=Dwarvish Loremaster, race=dwarf
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Loremaster.cfg:23
+msgid ""
+"Loremasters are the sages of the dwarvish race. Their counsel is greatly "
+"valued by war-leaders and chieftains, and they are viewed with awe by "
+"ordinary dwarves, for they alone have plumbed the deepest and most closely-"
+"held secrets of dwarven knowledge. It is said that where a Loremaster "
+"stands, there is the soul of the dwarves."
+msgstr ""
+"博学士是矮人族的圣贤。他们的忠告对战争领袖和酋长非常有价值，普通矮人则对他们"
+"满怀敬畏，因为他们独自钻研着矮人族知识之中最深、最受保护的秘密。有种说法，博"
+"学士站在哪儿，哪儿就有矮人的灵魂。"
+
+#. [unit_type]: id=Dwarvish Witness, race=dwarf
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Witness.cfg:5
+msgid "Dwarvish Witness"
+msgstr "矮人见证者"
+
+#. [unit_type]: id=Dwarvish Witness, race=dwarf
+#: data/internal/Dwarvish_Witness/units/Dwarvish_Witness.cfg:18
+msgid ""
+"A Witness functions as the eyes of the dwarves’ history, a deep lore that "
+"they never share with outsiders. The presence of a Witness instils dwarvish "
+"warriors with the knowledge that their deeds (and their deaths) will not go "
+"unrecorded, inspiring them to daunting deeds and great heroics. The person "
+"of a Witness is considered sacred, and Witnesses are often used as envoys "
+"between dwarvish clans."
+msgstr ""
+"见证者的职责是作为矮人的历史之眼，矮人一族的历史是他们绝不与外人分享的深奥知"
+"识。见证者的存在鼓舞着矮人武士，因为他们知道，自己的事迹（还有死亡）将会被记"
+"录下来。见证者被看作是神圣的，他们经常担任矮人氏族之间的外交使节。"
+
+#. [leadership]: id=witness
+#: data/internal/Dwarvish_Witness/utils/abilities.cfg:10
+msgid "witness"
+msgstr "见证"
+
+#. [leadership]: id=witness
+#: data/internal/Dwarvish_Witness/utils/abilities.cfg:11
+msgid "female^witness"
+msgstr "见证"
+
+#. [leadership]: id=witness
+#: data/internal/Dwarvish_Witness/utils/abilities.cfg:12
+msgid ""
+"Adjacent allied dwarves gain +25% damage, or +100% damage when they fight "
+"higher-level opponents."
+msgstr "相邻的友方矮人伤害+25%，对战高等级对手时伤害+100%。"
+
+#. [leadership]: id=witness
+#: data/internal/Dwarvish_Witness/utils/abilities.cfg:13
+msgid ""
+"This unit inspires adjacent allied dwarves, increasing their damage — "
+"particularly when they fight higher-level opponents."
+msgstr "此单位激励相邻的友方矮人，提升其伤害——尤其是在与高等级对手作战时。"

--- a/translations/wesnoth/po/wesnoth-utbs/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-utbs/zh_CN.po
@@ -1,5 +1,5 @@
 # The Battle for Wesnoth - Simplified Chinese Translations
-# Copyright (C) 2005-2022 Wesnoth development team
+# Copyright (C) 2005-2026 Wesnoth development team
 # This file is distributed under the same license as the Battle for Wesnoth package.
 #
 # Translators and their initial years of participation:
@@ -7,26 +7,27 @@
 # MrKing <yideey@gmail.com>, 2012.
 # Brian Lee <haiyuan.2007@gmail.com>, 2015.
 # CloudiDust <cloudidust@gmail.com>, 2017.
+# vimacs <vimacs.hacks@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wesnoth-1.16\n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2025-10-21 01:10 UTC\n"
-"PO-Revision-Date: 2025-03-09 21:46+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
+"POT-Creation-Date: 2026-06-23 03:15 UTC\n"
+"PO-Revision-Date: 2026-08-29 10:01+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
 "Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.9\n"
 
 #. [campaign]: id=Under_the_Burning_Suns
 #. [editor_group]: id=utbs
 #: data/campaigns/Under_the_Burning_Suns/_main.cfg:11
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:241
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:244
 msgid "Under the Burning Suns"
 msgstr "灼热双日之下"
 
@@ -36,7 +37,7 @@ msgid "UtBS"
 msgstr "UtBS"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:20
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:21
 msgid ""
 "In the distant future a small band of elves struggles to survive amidst the "
 "ruins of fallen empires. Lead your people out of the desert on an epic "
@@ -48,7 +49,7 @@ msgstr ""
 "\n"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:22
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:23
 msgid ""
 "Note: This campaign changes some standard mechanics, such as the day/night "
 "cycle, recall costs and general approach to the difficulty levels. The "
@@ -59,62 +60,68 @@ msgstr ""
 "法。奎诺精灵包括可以每回合攻击数次的单位，以及可以攻击后移动的单位。"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:24
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:25
 msgid "(Expert level, 10 scenarios.)"
 msgstr "（专家级别，10幕场景。）"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:28
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:29
 msgid "Challenging"
 msgstr "挑战"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:28
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:29
 msgid "Fighter"
 msgstr "战士"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:29
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:30
 msgid "Difficult"
 msgstr "困难"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:29
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:30
 msgid "Warrior"
 msgstr "武士"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:30
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:31
+msgid "Apocalyptic"
+msgstr "后启示录"
+
+#. [campaign]: id=Under_the_Burning_Suns
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:31
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:32
 msgid "Champion"
 msgstr "斗士"
 
 #. [campaign]: id=Under_the_Burning_Suns
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:30
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:32
 msgid "Nightmare"
 msgstr "噩梦"
 
 #. [about]
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:34
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:36
 msgid "Campaign Design"
 msgstr "战役设计"
 
 #. [about]
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:43
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:45
 msgid "Campaign Maintenance"
 msgstr "战役维护"
 
 #. [about]
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:64
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:69
 msgid "Artwork and Graphics Design"
 msgstr "艺术与图像设计"
 
 #. [about]
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:130
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:135
 msgid "Miscellaneous"
 msgstr "其他"
 
 #. [entry]
-#: data/campaigns/Under_the_Burning_Suns/_main.cfg:148
+#: data/campaigns/Under_the_Burning_Suns/_main.cfg:153
 msgid "And special thanks to everyone else who I forgot to mention."
 msgstr "特别感谢忘记提到的人们。"
 
@@ -148,11 +155,11 @@ msgstr "天亮以后"
 
 #. [side]
 #. [side]: id=Kaleh, type=Quenoth Youth
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:50
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:49
 #: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:34
 #: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:44
 #: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:30
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:34
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:32
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:38
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:32
 #: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:30
@@ -167,11 +174,11 @@ msgid "team_name^Quenoth Elves"
 msgstr "奎诺精灵"
 
 #. [side]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:77
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:108
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:73
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:111
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:68
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:108
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:139
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:115
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:150
 msgid "Monsters"
 msgstr "怪物"
 
@@ -179,160 +186,160 @@ msgstr "怪物"
 #. [side]: id=Panok, type=Direwolf Rider, type=Goblin Knight
 #. [side]: id=Turg, type=Orcish Warrior, type=Orcish Warlord
 #. [side]: id=Ug'lok, type=Orcish Warrior, type=Orcish Warlord
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:98
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:95
 #: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:55
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:101
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:140
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:166
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:108
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:145
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:174
 msgid "Evil"
 msgstr "邪恶"
 
+#. [side]
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:114
+msgid "Animals"
+msgstr "动物"
+
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:119
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:124
 msgid "Rescue surviving elves"
 msgstr "解救幸存的精灵"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:123
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:128
 msgid "Defeat Xanthos"
 msgstr "击败赞瑟斯"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:133
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:213
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:247
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:204
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:355
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:189
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:231
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:422
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:357
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:414
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:277
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:137
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:215
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:246
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:212
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:352
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:204
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:242
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:415
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:366
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:485
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:273
 msgid "Death of Kaleh"
 msgstr "卡勒死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:137
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:217
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:251
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:208
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:359
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:193
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:235
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:426
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:361
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:418
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:141
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:219
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:250
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:216
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:356
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:208
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:246
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:419
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:370
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:489
 msgid "Death of Nym"
 msgstr "妮慕死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:141
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:221
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:255
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:145
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:223
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:254
 msgid "Death of Garak"
 msgstr "伽拉克死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:154
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:225
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:262
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:212
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:363
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:197
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:239
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:430
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:365
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:422
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:158
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:227
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:261
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:220
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:360
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:212
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:250
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:423
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:374
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:493
 msgid "Death of Zhul"
 msgstr "朱尔死亡"
 
 #. [value]: type=Quenoth Fighter, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:181
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:185
 msgid "Lreu"
 msgstr "雷鲁"
 
 #. [value]: type=Quenoth Fighter, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:188
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:192
 msgid "Piyru"
 msgstr "皮鲁"
 
 #. [value]: type=Quenoth Fighter, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:193
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:197
 msgid "Feru"
 msgstr "菲鲁"
 
 #. [value]: type=Quenoth Scout, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:200
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:204
 msgid "Danu"
 msgstr "达努"
 
 #. [value]: type=Quenoth Scout, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:205
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:209
 msgid "Hamuil"
 msgstr "哈缪"
 
 #. [value]: type=Quenoth Scout, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:210
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:214
 msgid "Anioh"
 msgstr "艾尼欧"
 
 #. [value]: type=Tauroch Rider, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:215
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:219
 msgid "Vemuil"
 msgstr "瓦缪"
 
 #. [value]: type=Tauroch Rider, gender=male
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:220
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:224
 msgid "Taliu"
 msgstr "泰柳"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:250
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:268
 msgid "Hey Kaleh, are you in there?"
 msgstr "嘿，卡勒，你在里面吗？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:255
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:273
 msgid "Nym, is that you?"
 msgstr "妮慕，是你吗？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:260
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:278
 msgid ""
 "Yes, come on out already. The storm has passed. With the morning light Naia "
 "has ended the terrible night."
 msgstr "是啊，快出来吧。风暴结束了。那亚的曙光结束了这可怕的夜晚。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:265
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:283
 msgid "Has the sky really stopped falling?"
 msgstr "天上没有东西砸下来了？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:270
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:288
 msgid ""
 "I already told you, the sky is clear and empty. Now come quickly, silly, "
 "others may need our help."
 msgstr "我告诉你了，天空清静了。快来，傻瓜，有人需要帮助。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:275
-#, fuzzy
-#| msgid ""
-#| "What’s happened? Oh Eloh, the craters are everywhere, everything is gone, "
-#| "ruined. I can hardly recognize our village. I didn’t think it could be "
-#| "this bad."
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:293
 msgid ""
 "What’s happened? Oh Eloh! The craters are everywhere. Everything is gone, "
 "ruined! I can hardly recognize our village. I didn’t think it could be this "
 "bad."
 msgstr ""
-"到底发生了什么？噢，伊洛，到处都是陨石坑，一切都完了，都毁了。我都认不出我们"
-"的村子了。这真是太糟糕了。"
+"到底发生了什么？噢，伊洛，到处都是陨石坑，一切都完了，都毁了！我都认不出我们"
+"的村子了。我没想到会这么糟糕。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:280
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:298
 msgid ""
 "Come on, Kaleh, we have to go see if anyone is hurt or needs help. I think I "
 "hear people calling from the south. Now is not a time for fear, we must be "
@@ -346,7 +353,7 @@ msgstr ""
 "事情可能没你想的那么糟。让我们到村里看看还有没有昨夜事件的幸存者。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:285
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:303
 msgid ""
 "Wait, our keep is just to the east. Our leader Tanuil must surely be "
 "recruiting others to help deal with the devastation. Perhaps we should go to "
@@ -356,14 +363,14 @@ msgstr ""
 "援。或许我们该先去要塞再去探查村庄其他部分。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:302
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:320
 msgid ""
 "Tanuil’s keep, our beautiful fortress, it is destroyed. How will we summon "
 "our people to battle?"
 msgstr "泰纽那雄伟的城堡崩塌了，我们如何能召集人员作战？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:307
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:325
 msgid ""
 "We must rally those survivors we can find amidst the rubble. It doesn’t look "
 "like anyone survived, but at least we can thank Eloh it was a quick death. "
@@ -374,50 +381,50 @@ msgstr ""
 "寻找活着的人。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:312
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:330
 msgid "But if Tanuil is dead, who will lead us?"
 msgstr "但若泰纽死了，谁来领导我们？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:317
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:335
 msgid "That’s a question for another time. Let’s keep exploring the wreckage."
 msgstr "留待以后再讨论。继续搜索废墟吧。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:362
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:378
 msgid "Vecnu"
 msgstr "瓦可努"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:363
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:379
 msgid "Eranor"
 msgstr "艾拉诺"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:364
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:380
 msgid "Seil"
 msgstr "赛尔"
 
 #. [message]: speaker=Vecnu
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:398
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:598
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:411
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:587
 msgid "Kaleh, Nym, help us!"
 msgstr "卡勒， 妮慕， 来帮我们！"
 
 #. [message]: speaker=Nym
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:403
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:603
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:834
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4574
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:416
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:592
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:822
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4582
 msgid "What in Uria’s name is that?"
 msgstr "那尤里安的是什么？"
 
 #. [message]: speaker=Vecnu
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:409
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:609
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:422
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:598
 msgid ""
 "They came with the stones that fell from the sky. I know not what they are, "
 "but more seem to be emerging from the craters. If we don’t stop them there "
@@ -427,71 +434,70 @@ msgstr ""
 "如果我们不阻止它们，我们的村庄和同胞就完了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:414
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:614
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:427
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:603
 msgid "To battle, my friends! There are still those left who can fight."
 msgstr "上吧，伙伴们！我们有人可以继续战斗。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:421
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:434
 msgid "There are more of our people fighting the mud monsters!"
 msgstr "我们还有更多人参与战斗！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:426
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:439
 msgid "Then let’s join the battle!"
 msgstr "我们也上！"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:459
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:472
 msgid "Eloshi"
 msgstr "艾路丝"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:460
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:473
 msgid "Illuvin"
 msgstr "伊路温"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:466
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:468
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:482
 msgid "Raynor"
 msgstr "雷诺"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:491
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:494
 msgid "More of these muddy crawlies, let’s get rid of them with haste."
 msgstr "更多的土傀儡，我们快点解决它们。"
 
-#. [event]: role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:575
+#. [event]: role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:564
 msgid "Jorazan"
 msgstr "乔拉森"
 
-#. [event]: role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:576
+#. [event]: role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror, role=Rocky Horror
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:565
 msgid "Zyar"
 msgstr "泽亚"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:584
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:573
 msgid ""
 "This is our training ground. And look, there is Garak, the captain of the "
 "guard. He and his fighters have survived the night!"
 msgstr "这是我们的训练场。看，警卫队长伽拉克和他的战士们活下来了！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:620
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:609
 msgid "But they are fighting many mud creatures. Quick, we must help them!"
 msgstr "但是他们对付的泥怪更多。 赶快， 我们必须帮忙！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:648
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:637
 msgid "Ha! They’re destroyed at last."
 msgstr "哈！ 它们终于覆灭了。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:653
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:642
 msgid ""
 "Thanks for the help. I am glad to see that so many have survived the night. "
 "But there’s no time to talk, we must save the rest of our people and crush "
@@ -501,48 +507,48 @@ msgstr ""
 "人，粉碎这些土里冒出来的怪物。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:682
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:671
 msgid "This bridge leads to the holy island at the center of our lake."
 msgstr "桥通向湖中央的圣岛。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:687
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:676
 msgid ""
 "Hmmmm. Some of the druids that worship on the island may still be alive. We "
 "should go check."
 msgstr "啊。岛上做礼拜的德鲁伊们有可能有人存活。 我们应当去看看。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:692
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:681
 msgid ""
 "Be careful. The bridge is broken, so we’ll have to wade through the shallow "
 "water."
 msgstr "小心。桥坏了，我们得涉水过去。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:724
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:713
 msgid ""
 "The great tree! It has been buried under the rocks. Our most holy sanctuary, "
 "defiled. Oh, Eloh, what shall we do?"
 msgstr "圣树在石头下燃烧！我们的圣地被玷污了。哦，神啊，我们怎么办？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:729
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:718
 msgid "Is anyone still alive?"
 msgstr "有人活着吗？"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:739
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:727
 msgid "Ryoko"
 msgstr "瑞寇"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:741
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:729
 msgid "Yuni"
 msgstr "由妮"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:745
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:733
 msgid "Finally! We were worried that no one else had survived."
 msgstr "终于看到活人了！我们还担心大家都死了。"
 
@@ -550,12 +556,12 @@ msgstr "终于看到活人了！我们还担心大家都死了。"
 # 是怎么翻呢?
 # 祭司?
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:750
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:738
 msgid "Mother priestess, are you all right?"
 msgstr "祭司，您好吗？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:755
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:743
 msgid ""
 "There’s no time to stand on ceremony. I’m fine. I’m afraid only a few of us "
 "survived, but we will lend you what skills we have. Show me to those who "
@@ -565,12 +571,12 @@ msgstr ""
 "中去。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:760
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:748
 msgid "But the great tree, it has been destroyed!"
 msgstr "但是圣树毁了！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:765
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:753
 msgid ""
 "All things of this world come to an end, but the power of Eloh endures. A "
 "new one shall grow in its place. Come now, let us see to the needs of our "
@@ -580,12 +586,12 @@ msgstr ""
 "们所需。"
 
 #. [unit]: type=Cuttle Fish
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:797
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:785
 msgid "Deep One"
 msgstr "深渊乌贼"
 
 #. [unit]: type=Cuttle Fish
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:798
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:786
 msgid ""
 "The Deep Ones are gigantic aquatic monsters that lurk in the dark places of "
 "the world. Rarely do they come to the surface, and when they do the best way "
@@ -597,7 +603,7 @@ msgstr ""
 "施就是呆在岸上。它们能用触须抓住对手，或者远程喷射有毒墨汁。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:828
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:816
 msgid ""
 "The water of the lake suddenly goes dark and unsettled, only to erupt in a "
 "swarm of tentacles the moment the first elf set foot off the island."
@@ -605,46 +611,51 @@ msgstr ""
 "湖水突然变得昏暗浑浊， 深处涌出一大堆怪物触手——就在第一个精灵的脚踏入水中时。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:840
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:828
 msgid ""
 "I felt a great darkness in this lake, but I knew not what it was. The "
 "falling rocks must have woken it from its sleep."
 msgstr "我感到湖里强大的黑暗力量，但不知道那是什么。肯定是落下的陨石唤醒了它。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:845
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:833
 msgid ""
 "Protect the priestesses, we shall send this monstrosity back to the depths "
 "it came from!"
 msgstr "保护圣女， 我们把这个大怪物打回去！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:862
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:850
 msgid "These fields seem strangely vacant. Where are the dustboks?"
 msgstr "奇怪，牧场空荡荡的。尘步兽都去哪儿了？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:867
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:855
 msgid "Maybe they’re hiding in the stables. Let’s go check."
 msgstr "可能正藏在马厩里呢。我们去看看。"
 
+#. [message]: speaker=unit
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:874
+msgid "Wandering Dustboks... A pity they only come to us now."
+msgstr "游荡的尘步兽……可惜它们现在才来我们这儿。"
+
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:905
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:912
 msgid "Naru"
 msgstr "那努"
 
 #. [message]: speaker=Naru
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:909
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:916
 msgid "Is it safe to come out? I was so scared."
 msgstr "外面安全了吗？ 我刚才很害怕。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:914
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:921
 msgid "Where are all the other dustboks?"
 msgstr "剩下的尘步兽都去哪儿了？"
 
 #. [message]: speaker=Naru
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:919
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:926
 msgid ""
 "A hunting party left just yesterday, so unless the rocks fell all over the "
 "land, many of the dustboks have probably survived. The few that remained "
@@ -655,7 +666,7 @@ msgstr ""
 "的尘步兽昨晚受陨石惊吓跑散了。我使尽解数安抚了亚希，他才没有跑掉。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:924
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:931
 msgid ""
 "We’ll need your help in checking to see if the outer settlements survived. "
 "Who knows what kinds of damage they suffered in the night? And perhaps some "
@@ -666,51 +677,51 @@ msgstr ""
 "失。也许在沙漠里的人们已经圈住了一些走失的羚儿。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:929
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:936
 msgid "We can only hope that hunting party returns soon."
 msgstr "我们只能指望狩猎队快些回来。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:939
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:946
 msgid "Hey, Nisen, the rocks have stopped falling. You can come out now!"
 msgstr "喂，尼森，陨石雨停了。你可以出来了！"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:943
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:950
 msgid "Nisen"
 msgstr "尼森"
 
 #. [message]: speaker=Nisen
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:954
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:961
 msgid "Oh, thank Eloh, I thought they would never stop."
 msgstr "哦， 感谢伊洛。我还以为它们不会停呢。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1085
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1092
 msgid ""
 "Oh good, some elves have survived in this outer settlement. They’ve agreed "
 "to help us search for other survivors."
 msgstr "哦好极了， 有些住在外边的精灵活着。。他们愿意帮助我们搜索幸存者。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1093
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1100
 msgid "The encampment is empty. I wonder what happened to the inhabitants?"
 msgstr "营地是空的。。居民们到底发生了什么？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1108
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1115
 msgid ""
 "This encampment has been abandoned. There are signs of a struggle and a few "
 "bloodstains but nothing else. I fear for those elves who lived out here."
 msgstr "这个营地已被废弃。只能看到一些战斗的痕迹和血迹。可能是外围精灵留下的。"
 
-#. [unit]: type=Necromancer, type=Dark Sorcerer, id=Xanthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1156
+#. [unit]: type=Dark Sorcerer, id=Xanthos
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1159
 msgid "Xanthos"
 msgstr "赞瑟斯"
 
 #. [message]: speaker=Xanthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1176
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1179
 msgid ""
 "This place reeks of death, I could smell it from miles away. Oh, how I love "
 "it, it is the smell of power, the inevitable triumph of death over life. "
@@ -722,7 +733,7 @@ msgstr ""
 "对死灵法师赞瑟斯臣服！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1181
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1184
 msgid ""
 "His timing couldn’t be worse. I know that undead cultists often prey on "
 "small targets, but they haven’t had the guts to attack us for years. Why has "
@@ -732,7 +743,7 @@ msgstr ""
 "为何神会降下如此磨难？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1187
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1190
 msgid ""
 "Have some more faith, girl, the goddess does not send us more than we can "
 "handle. With Eloh’s grace we shall yet triumph over this pretender."
@@ -741,7 +752,7 @@ msgstr ""
 "狂妄的家伙。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1192
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1195
 msgid ""
 "Bah, I’ve fought these dark cultists before. They can be killed just like "
 "anyone else, and our riders can easily defeat their skeleton armies."
@@ -750,7 +761,7 @@ msgstr ""
 "手可以轻易击败他们的骷髅军团。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1197
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1200
 msgid ""
 "I have heard of your kind, foul necromancer. You travel the sands, daring to "
 "bring back and enslave those who have passed on. But we will prove to you "
@@ -763,7 +774,7 @@ msgstr ""
 "的愤怒而恐惧吧！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1229
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1232
 msgid ""
 "Some of our people felt crowded in the village, and wanted to live out on "
 "the open sands. They thought they could flee to the safety of our walls if "
@@ -773,17 +784,17 @@ msgstr ""
 "的村庄围墙里面。想象他们的劫难我就不寒而栗。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1258
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1261
 msgid "The necromancer is finally vanquished."
 msgstr "死灵法师终于被击倒了。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1263
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1266
 msgid "And at last the dead shall have their rest."
 msgstr "而逝者终于可得安息。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1274
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1277
 msgid ""
 "The necromancer is dead, but I don’t think we’ve explored the entire "
 "village. There may still be elves that need rescuing. We should go back and "
@@ -793,44 +804,44 @@ msgstr ""
 "去查看吧。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1291
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1294
 msgid ""
 "We’ve explored the village, and I think we’ve rescued the last of the "
 "survivors."
 msgstr "整个村庄搜遍了， 我们已经救出了最后的幸存者。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1328
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1331
 msgid "Pythos"
 msgstr "派瑟斯"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1330
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1333
 msgid "Shea"
 msgstr "舒伊"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1332
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1335
 msgid "Narn"
 msgstr "那安"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1334
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1337
 msgid "Jokli"
 msgstr "乔克利"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1336
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1339
 msgid "Lyer"
 msgstr "莱尔"
 
 #. [message]: speaker=Pythos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1344
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1347
 msgid "Hail, is anyone still alive?"
 msgstr "喂－有人活着吗？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1349
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1352
 msgid ""
 "Yes, and we could certainly use your help. A necromancer has been attacking "
 "us, he intends to use our fallen comrades as fodder for his evil magics. "
@@ -840,7 +851,7 @@ msgstr ""
 "者作为他邪恶魔法的炮灰。你们去哪儿了？"
 
 #. [message]: speaker=Pythos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1354
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1357
 msgid ""
 "We were out far in the sands, searching for prey and roaming orcs. As soon "
 "as we saw the rock storm we raced back as fast as we could. I only wish we "
@@ -850,32 +861,32 @@ msgstr ""
 "要是能更早一点回来就好了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1359
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1362
 msgid "No use crying over spilt water. But we’re sure glad you’re here now."
 msgstr "不要做无意的后悔。你们回来我们相当高兴。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1373
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1376
 msgid "It seems that we finally have some peace. But what do we do now?"
 msgstr "似乎我们暂得片刻安宁。现在我们做什么好？"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1378
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1381
 msgid "Where is Tanuil and his family?"
 msgstr "泰纽和他家人在哪？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1383
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1386
 msgid "The keep has been crushed by the rocks. We could find no survivors."
 msgstr "要塞毁了。没人活下来。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1388
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1391
 msgid "Too many have died this night."
 msgstr "今晚死去的…………太多了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1393
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1396
 msgid ""
 "Our village is in ruins. The walls that were built by our ancestors over "
 "generations have been demolished in a space of hours. Most of our dwellings "
@@ -886,7 +897,7 @@ msgstr ""
 "也没了。显而易见，我们不能呆在这里。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1399
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1402
 msgid ""
 "You are a fool to despair. This has always been our home. The water here is "
 "good, we know this land. We can rebuild; Eloh willing, we can thrive again."
@@ -895,7 +906,7 @@ msgstr ""
 "建并且再次兴盛， 以伊洛之志。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1404
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1407
 msgid ""
 "Think for a moment. Who else has seen the rock storm? What other foes are "
 "coming to pick over the remains of our people? There is no mercy in the "
@@ -906,18 +917,18 @@ msgstr ""
 "有仁慈可言，我们敌人众多，瞅着我们虚弱的机会。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1410
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1413
 msgid ""
 "Impudent girl, you should not speak so to your elders, or to your betters."
 msgstr "无礼的姑娘，不要对长辈们这样说话，学学其他人的谦逊。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1415
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1418
 msgid "I have a right to speak my mind!"
 msgstr "我有发表看法的权利！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1421
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1424
 msgid ""
 "Peace, please calm yourselves. In chaos there is nothing but death and "
 "destruction. Even in this time of trial we must show our fortitude, and "
@@ -930,7 +941,7 @@ msgstr ""
 "的血统最近，成为我们的领导。你有何高见，卡勒？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1426
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1429
 msgid ""
 "Last night, before the rock storm, I heard a voice in my sleep. It sounded "
 "like sweet music, and somehow I knew it was Eloh. I still remember her exact "
@@ -950,7 +961,7 @@ msgstr ""
 "为我们准备新家园，我将带你们前去。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1431
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1434
 msgid ""
 "I fear what dangers lurk in the harsh sands and beyond to the north, but "
 "because you are our leader, I will follow where you go."
@@ -959,7 +970,7 @@ msgstr ""
 "领。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1436
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1439
 msgid ""
 "Then let us collect what supplies we can from the wreckage and head north "
 "with great haste. Our home is protection no longer, we must find a new haven "
@@ -969,14 +980,14 @@ msgstr ""
 "子民找到新的天堂。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1441
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1444
 msgid ""
 "What about the bodies of the dead? We can’t leave them to be torn by crows "
 "or desecrated by other dark mages."
 msgstr "尸体怎么办？ 我们不能让他们受鸦鹫欺辱，或遭黑暗法师亵渎。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1447
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1450
 msgid ""
 "I agree, we should not forget our dead. We should build a huge pyre and burn "
 "them with proper ceremony, so that the smoke may carry them on to the next "
@@ -984,7 +995,7 @@ msgid ""
 msgstr "同意，我们不能忘记死难者。垒起柴堆，祭其火葬，青烟将携彼魂魄至天国。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1452
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1455
 msgid ""
 "Kaleh, I don’t want to tarry longer than necessary, but I agree that we must "
 "see to the dead before we leave. Garak, you and your men start collecting "
@@ -994,7 +1005,7 @@ msgstr ""
 "和我找油和柴火建柴堆。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1457
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1460
 msgid ""
 "And so it was done. The dead were laid reverently on top of what little wood "
 "we could find. But the fire was big enough to burn the bodies to ashes and "
@@ -1007,7 +1018,7 @@ msgstr ""
 "不是前路的好兆头。他们走在了所有人的前头， 但远不是结束。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1513
+#: data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg:1516
 msgid ""
 "What’s that to the north? It looks like even more undead! The rock storm "
 "must have attracted other necromancers. There’s no way we can defeat them "
@@ -1027,22 +1038,22 @@ msgid "Bandits"
 msgstr "强盗"
 
 #. [side]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:148
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:151
 msgid "Undead"
 msgstr "亡灵"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:199
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:202
 msgid "Kaleh must reach the northern edge of the desert"
 msgstr "卡勒必须到达沙漠的北部边缘"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:203
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:206
 msgid "Defeat outlaw leader"
 msgstr "击败游寇首领"
 
 #. [note]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:232
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:234
 msgid ""
 "Your units become dehydrated during the day, losing hitpoints and damage "
 "when they are not on a water hex"
@@ -1051,29 +1062,29 @@ msgstr ""
 "会降低"
 
 #. [note]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:235
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:237
 msgid ""
 "Units are refreshed at the start of your turn when they are on a water or "
 "oasis hex"
 msgstr "当单位在水或绿洲六角格上时，他们会在你的回合开始时补水"
 
 #. [note]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:238
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:240
 msgid "Healers can prevent dehydration from getting worse, but cannot heal it"
 msgstr "医者可以防止脱水状态恶化，但不能治愈此状态"
 
 #. [note]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:241
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:243
 msgid "Healers are unable to heal adjacent units during the day"
 msgstr "医者在白天无法治疗相邻单位"
 
 #. [label]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:265
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:267
 msgid "Pinnacle Rock"
 msgstr "尖塔石"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:288
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:290
 msgid ""
 "I have crossed these sands long ago, when I was a youth, and we went on a "
 "great raid against a foul necromancer who was hiding out in one of the "
@@ -1086,21 +1097,21 @@ msgstr ""
 "过当我们砍下他的头颅之时，任何魔法也不能再拯救他了。啊，在那些日子……"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:293
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:295
 msgid "Do you remember anything about these sands?"
 msgstr "还记得这片沙漠吗？"
 
 #. [message]: speaker=narrator
 #. [modify_unit]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:302
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1729
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1916
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:304
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1750
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1938
 #: data/campaigns/Under_the_Burning_Suns/utils/character-definitions.cfg:33
 msgid "Garak"
 msgstr "伽拉克"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:304
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:306
 msgid ""
 "Do you see that brown spot sticking up on the northern horizon? That’s "
 "Pinnacle Rock. It’s the highest land for miles around, and has a spring at "
@@ -1112,7 +1123,7 @@ msgstr ""
 "只有几里地了。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:309
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:311
 msgid ""
 "But between here and there is a particularly barren stretch of the sands, "
 "with only a few oases and watering holes. Luckily I think there used to be "
@@ -1126,14 +1137,14 @@ msgstr ""
 "走，露出古老的通向绿洲的石头路来。以前这里一定有条通商的大道。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:324
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:327
 msgid ""
 "I believe that there was once a great empire in these lands, long ago, "
 "before the sands came."
 msgstr "我相信这片土地上曾经有过一个庞大的帝国，很久以前，在这里成为沙漠以前。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:330
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:333
 msgid ""
 "I’ve seen the ancient remains of stone castles and markers in the sands. The "
 "paths of the ancients may serve us yet again. If we follow the paths from "
@@ -1146,7 +1157,7 @@ msgstr ""
 "糕的危险还不是缺水，我们需要谨慎和小心地侦察。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:335
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:338
 msgid ""
 "Unfortunately, because of our hasty flight from our village, we are short on "
 "water-skins and rations. We’ll have enough if we move quickly and eat as "
@@ -1159,7 +1170,7 @@ msgstr ""
 "样，加上白天炎热夜晚寒冷，这样的旅程对人民来说将会是很艰难的。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:341
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:344
 msgid ""
 "During the daytime (Dawn, Morning, Midday, Afternoon, and Dusk) at the "
 "beginning of each your turns, every unit in a sand, road, rubble or sand "
@@ -1175,7 +1186,7 @@ msgstr ""
 "在绿洲（也就是浅水地形）中，回合开始的时候这些单位才够恢复完全的攻击力。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:347
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:350
 msgid ""
 "Kaleh, be careful you don’t recruit too many guards to go with us. I doubt "
 "we’re going to find any other villages out in the sands, so the income that "
@@ -1188,33 +1199,33 @@ msgstr ""
 "多的资金支持，所以我可不想半路上资源短缺。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:352
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:355
 msgid "Well, the sooner we reach Pinnacle Rock, the better. Onwards!"
 msgstr "好吧，越快到达尖塔石越好，我们走吧！"
 
 #. [scenario]: id=02_Across_the_Harsh_Sands, role=Hunting Ogre
 #. a variant of the Giant Scorpion unit type
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:368
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:371
 msgid "Scuttler"
 msgstr "凿岩者"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:393
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:396
 msgid "Wait. I think I spotted something ahead of us..."
 msgstr "等一下，我好像看到前面有些东西……"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:397
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:400
 msgid "What? I don’t see a thing."
 msgstr "什么？我什么都没看见。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:401
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:404
 msgid "See those shining speckles ahead? Scorpions. Large. Whole nest of them."
 msgstr "看见前面那个闪光的亮点了吗？蝎子，巨大的蝎子，倾巢而出。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:408
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:411
 msgid ""
 "Do you want us to fight? We can still avoid them, but they are between us "
 "and the next oasis."
@@ -1222,12 +1233,12 @@ msgstr ""
 "你想要我们开战吗？我们仍然能够躲开它们，但是它们正处在我们和下一个绿洲之间。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:437
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:440
 msgid "Scorpions! We must have stumbled across a nest of them."
 msgstr "蝎子！我们肯定是不小心路过了它们的巢穴。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:470
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:473
 msgid ""
 "The scorpions were devouring some poor person’s body. There doesn’t seem to "
 "be much of him left, but wait— What’s this? It looks like a tiny gold ring. "
@@ -1242,45 +1253,45 @@ msgstr ""
 "过关于这些魔法物件的传说，现在我们肯定能用上它。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:475
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:478
 msgid ""
 "One unit wearing this ring is immune to any damage caused during the day by "
 "the heat of the desert."
 msgstr "戴上这个戒指的单位在白天将不会受到沙漠炎热的伤害。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:505
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:705
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:508
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:716
 msgid "Should I take this ring?"
 msgstr "我该拿这枚戒指吗？"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:507
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1544
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:707
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:583
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:575
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:510
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1618
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:718
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:582
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:574
 msgid "Yes, I’ll take it."
 msgstr "好，我来拿。"
 
 #. [object]: id=Travelring
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:512
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:515
 msgid "Traveler’s Ring"
 msgstr "旅行者的戒指"
 
 #. [object]: id=Travelring
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:514
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:517
 msgid "The unit wearing this ring will not become dehydrated by the desert."
 msgstr "戴上此戒指的单位在白天将不会因沙漠炎热而脱水。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:548
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:739
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:551
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:750
 msgid "No, I think someone else should wear it."
 msgstr "不，我想应该让别人来佩戴它。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:573
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:576
 msgid ""
 "Look, an oasis! Its refreshing water will allow our people to regain "
 "strength and rest safely on the grass during the heat of the day."
@@ -1288,13 +1299,19 @@ msgstr ""
 "看啊，绿洲！那是能让我们恢复体力的清水，还有供我们休息而不会受炎热伤害的草"
 "地。"
 
+#. [message]: speaker=unit
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:594
+msgid ""
+"It’s a pack of Wandering Scarabs! They must’ve been burrowed under the sand."
+msgstr "这是一群游荡甲虫！它们肯定一直藏在沙子底下。"
+
 #. [scenario]: id=02_Across_the_Harsh_Sands, role=Hunting Ogre
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:582
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:626
 msgid "Hunting Ogre"
 msgstr "狩猎的食人魔"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:617
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:661
 msgid ""
 "Shh... ogres ahead. Behind that dune there, we have to pass them if we want "
 "to reach the next oasis."
@@ -1302,12 +1319,12 @@ msgstr ""
 "嘘……前面有食人魔，在那沙丘后面。要想到达下一片绿洲，我们必须通过他们的位置。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:621
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:665
 msgid "No chance to sneak around?"
 msgstr "不能绕过去？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:625
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:669
 msgid ""
 "We would have to cover extra distance in difficult terrain. If you want to "
 "bypass them I suggest going straight north in the hopes of finding an oasis "
@@ -1318,18 +1335,18 @@ msgstr ""
 
 #. [message]: type=Ogre, role=Hunting Ogre
 #. [message]: type=Ogre
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:650
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:687
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:694
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:731
 msgid "Fresh meat!"
 msgstr "鲜肉！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:682
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:726
 msgid "Ogre ambush!"
 msgstr "食人魔伏兵！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:692
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:736
 msgid ""
 "Ugh, they smell as bad as they look. And they’re huge! Well, the bigger they "
 "are, the harder they fall."
@@ -1337,14 +1354,14 @@ msgstr ""
 "啊，它们闻起来和看上去一样恶心。而且它们好大啊！它们越大，就越难以击败。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:725
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:769
 msgid ""
 "That’s the last of them. This looks like a hunting party, they must have a "
 "camp around here somewhere."
 msgstr "那是最后一个食人魔了，这看上去像个狩猎集会啊，它们肯定在这附近扎营了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:730
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:774
 msgid ""
 "Hey! Look there, they dropped something... A stone bottle, sealed. I wonder "
 "what’s inside..."
@@ -1352,54 +1369,54 @@ msgstr ""
 "嘿，看看那里，它们落下了什么东西……一个密封着的石瓶，我想知道里面有什么……"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:753
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:799
 msgid "Nym! No! Don’t open—"
 msgstr "妮慕！不！不要打开——"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:763
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:809
 msgid ""
 "Too late. And it’s just sand inside. Not worth... Whoa! What’s happening?!"
 msgstr "太晚了。只是些沙子，没什么值得……哇！ 怎么了？！"
 
 #. [unit]: type=Dust Devil, id=Dust Devil
 #. [unit_type]: id=Dust Devil, race=monster
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:769
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:815
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg:4
 msgid "Dust Devil"
 msgstr "尘土魔"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:783
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:829
 msgid "It’s a dust devil, but I have never seen one so small before."
 msgstr "这是个尘土魔，但是我从没见过这种这么小的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:836
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:882
 msgid "It seems to like you, looks like you just got yourself a pet."
 msgstr "它好像挺喜欢你，就当你只是弄了个宠物吧。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:841
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:887
 msgid ""
 "Girl, I told you not to open it. Let’s go, I’d really like to get to an "
 "oasis soon."
 msgstr "女孩， 我说过不要打开它的。走吧， 我真想快点到下一个绿洲。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:947
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:993
 msgid "Black Lieutenant"
 msgstr "黑手党中尉"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:948
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:949
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:950
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:994
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:995
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:996
 msgid "Black Hand Bandit"
 msgstr "黑手党强盗"
 
 #. [message]: type=Thug
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:975
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1021
 msgid ""
 "And I thought it was going to be another boring patrol. You there! Elf! This "
 "is our oasis, and we will water it with your blood!"
@@ -1408,44 +1425,44 @@ msgstr ""
 "浇灌它！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:980
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1013
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1026
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1059
 msgid ""
 "We need that water, and if we have to go through you to get it, so be it."
 msgstr "我们需要那些水，如果我们必须击败你的话，那么来吧。"
 
 #. [message]: role=Black Lieutenant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1008
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1054
 msgid ""
 "We don’t know who you are, and we don’t much care. Tremble before the might "
 "of the Black Hand!"
 msgstr "我们不知道你们是谁，也不关心这个。在黑手党的力量面前折服吧！"
 
 #. [unit]: type=Red Mage, id=Elyssa, gender=female
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1043
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1089
 msgid "Elyssa"
 msgstr "伊丽莎"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1076
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1122
 msgid "Go’hag"
 msgstr "勾哈格"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1077
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1078
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1079
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1080
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1123
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1124
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1125
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1126
 msgid "Undead Raider"
 msgstr "骷髅骑士"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1092
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1137
 msgid "Back, you fiends! Or I’ll kill you a second time!"
 msgstr "滚开，你这个魔鬼！否则我会再次杀死你！"
 
 #. [message]: speaker=Go'hag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1099
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1144
 msgid ""
 "You have defied our master for the last time. Now you shall die! And I shall "
 "personally make it slow and painful, to thank you for that scorching you "
@@ -1455,37 +1472,37 @@ msgstr ""
 "答你曾经烧焦过我。"
 
 #. [message]: speaker=Go'hag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1106
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1151
 msgid "You have defied our master for the last time. Now you shall die!"
 msgstr "你在蔑视我们的主人，现在你将死去！"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1113
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1158
 msgid "Stupid undead, they never listen. Then have a taste of my flame!"
 msgstr "愚蠢的亡灵，它们从来不会听话。那么尝尝我的火焰吧！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1118
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1163
 msgid "She looks like she’s in trouble. We should help her."
 msgstr "看上去她遇到麻烦了，我们应该帮助她。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1142
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1187
 msgid "Whew! Looks like that’s the last of them."
 msgstr "哇！看上去这是它们中的最后一个了。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1147
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1192
 msgid "Thanks for the help! That was a little too close for comfort."
 msgstr "多谢帮忙！这次有点悬。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1152
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1197
 msgid "That was a lot of undead. Why were they coming after you?"
 msgstr "那些亡灵可真不少啊，为什么它们会跟着你呢？"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1157
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1202
 msgid ""
 "I accidentally managed to anger a powerful necromancer a while ago... It’s a "
 "long story. But who are you? You almost look like elves."
@@ -1494,7 +1511,7 @@ msgstr ""
 "你们看上去像精灵。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1162
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1207
 msgid ""
 "We are, we’re the Quenoth Elves and we are traveling north. You look like "
 "you’re a mage, but I thought your kind were all gone."
@@ -1503,7 +1520,7 @@ msgstr ""
 "早就不见了。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1167
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1212
 msgid ""
 "I am, I’m a fire mage. I’ve been traveling for quite a while now, exploring "
 "and learning. But these sands seem particularly inhospitable! I’ve been "
@@ -1514,39 +1531,39 @@ msgstr ""
 "住！我想穿过北方的山脉，介意我加入你们的行程吗？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1172
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1217
 msgid "We’d be glad to have the help of someone with the mastery of fire."
 msgstr "我们很高兴，能够得到掌握火焰奥秘的人的帮助。"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1180
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1225
 msgid ""
 "The undead are defeated, but we lost her in the fight as well. Darn, if only "
 "we could have saved her."
 msgstr "亡灵被击败了，但是我们也在战斗中失去了她。该死，我们要是救了她多好。"
 
 #. [unit]: type=Wraith, id=Vengeful Lord
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1223
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1268
 msgid "Vengeful Lord"
 msgstr "复仇领主"
 
 #. [then]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1232
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1233
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1236
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1237
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1277
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1278
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1281
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1282
 msgid "Honor Guard"
 msgstr "精英守卫"
 
 #. [message]: speaker=Vengeful Lord
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1242
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1287
 msgid ""
 "The most hated living in my castle! To me! To me stray souls of the deserts! "
 "Let’s cleanse this pollution!"
 msgstr "最讨厌的生物在我的城堡里！来吧，迷失的沙漠之魂！让我们清理这些污秽！"
 
 #. [message]: speaker=Vengeful Lord
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1247
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1292
 msgid ""
 "Elf of the sands, I remember you. You thought me defeated, but I am back "
 "even more powerful than before. Death reigns eternal, your scorched bones "
@@ -1556,33 +1573,33 @@ msgstr ""
 "配，你们烧焦的骨头和殒命的躯体将成为我的部下。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1252
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1297
 msgid ""
 "Still singing the same tune. We defeated you once before, we can do so again!"
 msgstr "还是唱着老调。我们之前击败过你，当然还能再击败你一次！"
 
 #. [message]: speaker=Vengeful Lord
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1266
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1311
 msgid "Noo... (<i>Fades</i>)"
 msgstr "不……（<b>消散</b>）"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1276
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1321
 msgid "Searching his castle, we found a chest filled with gold."
 msgstr "搜索他的城堡，我们发现一个装满金子的箱子。"
 
 #. [else]: role=Ogre Nomad
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1300
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1348
 msgid "Ogre Nomad"
 msgstr "食人魔流浪者"
 
 #. [message]: type=Ogre
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1312
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1360
 msgid "Elves! Kill them all!"
 msgstr "精灵！ 全都杀掉！"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1317
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1365
 msgid ""
 "This ruined castle must be where the ogres make their home. Well, if it’s a "
 "fight they want, it’s a fight they’ll get."
@@ -1591,33 +1608,33 @@ msgstr ""
 "到的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1338
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1386
 msgid ""
 "That’s the last of those stinking beasts. They should trouble us no more."
 msgstr "这是最后一个讨厌的野兽了。它们再也不会骚扰我们了。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1343
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1391
 msgid "This ruin looks oddly familiar."
 msgstr "这废墟看起来很熟悉。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1348
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1396
 msgid "Yuck, there’s still dried blood on the stones. It’s kind of spooky."
 msgstr "是啊，石头上还留有干涸的血迹，真是毛骨悚然。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1376
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1424
 msgid "This land belongs to the Black Hand. Trespass and you will die."
 msgstr "这片土地属于黑手。擅入者死。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1383
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1431
 msgid "Bandits. If they get in our way, they’re going to be sorry."
 msgstr "强盗。如果他们挡住我们的道路，他们会后悔的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1388
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1436
 msgid ""
 "There’s no way we can get all our people safely across the desert with "
 "outlaws harassing us. We must defeat them before we can continue."
@@ -1626,7 +1643,7 @@ msgstr ""
 "们必须击败他们。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1393
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1441
 msgid ""
 "Did you see that? I think I just saw someone disappear behind that dune over "
 "there. I think we’re being watched. I suspect there are more of these "
@@ -1636,19 +1653,48 @@ msgstr ""
 "盗数量比我们预计的要多。"
 
 #. [unit]: id=Thorn, type=Outlaw, gender=female
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1400
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1448
 msgid "Thorn"
 msgstr "斯恩"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1442
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1497
+msgid ""
+"Phew, thank goodness that this oasis is here! I was beginning to worry that "
+"it might have been a mirage, but it appears to be real!"
+msgstr ""
+"呼，谢天谢地，这里居然有片绿洲！我原本还担心这会不会是海市蜃楼，但看来确实是"
+"真的！"
+
+#. [message]: speaker=Nym
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1501
+msgid ""
+"Indeed, your caution was warranted; the oasis may be real this time, but "
+"who’s to say we might not have encountered a mirage under some other "
+"conditions?"
+msgstr ""
+"的确，你谨慎得有道理；这回，绿洲或许是真实存在的，但谁又能说，在其他情况下我"
+"们不会遇到海市蜃楼呢？"
+
+#. [message]: speaker=Zhul
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1506
+msgid "It has been known to happen before."
+msgstr "以前曾发生过这样的事。"
+
+#. [message]: speaker=Kaleh
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1510
+msgid "I don’t even want to think about something like that. Onwards!"
+msgstr "我连想都不想那种事。继续前进！"
+
+#. [message]: speaker=$explorer.id
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1515
 msgid ""
 "Dang. I was sure I saw an oasis here. Must have been a mirage. I’ve been out "
 "in the sand for too long."
 msgstr "该死。我明明看见这里有个绿洲的。这肯定是幻觉，我呆在沙漠里太久了。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1466
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1540
 msgid ""
 "So, the outlaws have made a base around Pinnacle Rock. It’s a good location, "
 "but we will drive them from it all the same."
@@ -1657,18 +1703,18 @@ msgstr ""
 "们驱逐出去。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1484
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1558
 msgid "I surrender! I mean we surrender. Just please don’t kill me."
 msgstr "我投降！我是说我们投降。请你饶命。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1489
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1563
 msgid ""
 "Please, have mercy on us. We’re just trying to survive in this horrible land."
 msgstr "请饶过我们吧，我们只是试图在这片恐怖的土地上生存。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1496
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1570
 msgid ""
 "I will not kill you in cold blood. But leave these lands, and never darken "
 "our path again. Or I will show you no mercy."
@@ -1677,14 +1723,14 @@ msgstr ""
 "过你的。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1509
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1583
 msgid ""
 "Here, take this vial of holy water. You’ll need it with all the undead "
 "around."
 msgstr "这里，拿上这瓶圣水吧，这里四处是亡灵，你们会需要它的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1514
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1588
 msgid ""
 "I will take this vial, in exchange for your life. But leave these lands, and "
 "never darken our path again. Or I will show you no mercy."
@@ -1693,7 +1739,7 @@ msgstr ""
 "则我不会再饶过你的。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1519
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1593
 msgid ""
 "It’s Holy Water. When anointed on a weapon it makes it deadly to magical "
 "creatures. Vials such as these are rare and valuable. We should choose "
@@ -1704,29 +1750,29 @@ msgstr ""
 
 # 改正翻译
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1542
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1616
 msgid "Should I take the holy water?"
 msgstr "我该拿这圣水吗？"
 
 #. [object]: id=PureWater
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1549
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1623
 msgid "Holy Water"
 msgstr "圣水"
 
 #. [object]: id=PureWater
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1551
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1625
 msgid ""
 "This water will make your melee weapons <i>arcane</i>, and thus especially "
 "powerful against the undead."
 msgstr "这瓶水将让你的近战武器发出<b>奥术攻击</b>，这会对亡灵造成强力伤害。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1575
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1649
 msgid "No, I think someone else should take it."
 msgstr "不，我想应该让别人来佩戴它。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1619
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1693
 msgid ""
 "The Black Hand outlaws still threaten the others. While their leader still "
 "fights we won’t be able to get all our people across the sands safely. We "
@@ -1736,7 +1782,7 @@ msgstr ""
 "通过沙漠。继续上路之前，我们必须解决这些黑手党。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1628
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1702
 msgid ""
 "The outlaws are defeated and we’ve made it across these blasted sands. The "
 "hills are just a few miles to the north. We should be able to find water and "
@@ -1746,7 +1792,7 @@ msgstr ""
 "该能在那里找到水源并休息一下。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1651
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1725
 msgid ""
 "Now that we have a moment of peace, I have to ask you, Elyssa, what were you "
 "really doing out in the middle of the desert? It’s a rather barren place to "
@@ -1756,7 +1802,7 @@ msgstr ""
 "么呢？如果要旅游的话，这里也太荒凉了。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1656
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1730
 msgid ""
 "I’ve been searching for secrets from the past. Did you know that this entire "
 "land used to be a huge empire? Apparently all this used to be great plains "
@@ -1766,14 +1812,14 @@ msgstr ""
 "前，曾经是宽阔的平原和农田。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1661
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1735
 msgid ""
 "It’s hard to imagine. There’s barely enough rain here now to support these "
 "tiny cacti, let alone crops."
 msgstr "难以想象。现在这里几乎没有足够的雨水来养活那些小仙人掌，更别说庄稼了。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1666
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1740
 msgid ""
 "And yet the great ruins that I have seen scattered across these sands are a "
 "testament that something was here before us. Perhaps in a time long ago when "
@@ -1783,7 +1829,7 @@ msgstr ""
 "以前，这片地方是适合生存的。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1671
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1745
 msgid ""
 "Before the Great Fall, there were huge cities, with great schools of magery, "
 "libraries of books, vast repositories of knowledge. Most of it was destroyed "
@@ -1796,12 +1842,12 @@ msgstr ""
 "火焰权杖吗？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1676
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1750
 msgid "No, I haven’t. What is it?"
 msgstr "没有，那是什么？"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1681
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1755
 msgid ""
 "I’m not sure. I’ve read various references to it, but nothing specific. I’ve "
 "been searching for it for a long time. All I know is that it was a very "
@@ -1815,13 +1861,13 @@ msgstr ""
 "某处。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1686
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1760
 msgid ""
 "Perhaps. But it has been so long, and so much has been lost. Who can say?"
 msgstr "可能吧。但是这也太久了，太多东西已经失去了。有谁能说明呢？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1706
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1780
 msgid ""
 "We’ve run out of provisions and our people are exhausted. We’ve taken too "
 "long crossing the desert, I fear we shall never reach the other side."
@@ -1830,12 +1876,12 @@ msgstr ""
 "到达另一端了。"
 
 #. [do]: role=LostSoul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1815
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1889
 msgid "Lost Soul"
 msgstr "失落的灵魂"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1839
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1913
 msgid ""
 "The sands are haunted with the spirits of tortured souls long since dead. At "
 "dusk they rise again, and during the Long Dark they can be particularly "
@@ -1847,31 +1893,31 @@ msgstr ""
 "面对夜晚的恐怖。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1844
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1918
 msgid ""
 "The combination of the heat of the day and the rising undead make dusk a "
 "particularly dangerous time of day."
 msgstr "白天的热度和这些亡灵使得黄昏成为一天中最危险的时刻。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1891
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1965
 msgid "What happened? The undead spirits all just disappeared."
 msgstr "发生什么了？亡灵灵魂们突然全部消失了。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1896
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1970
 msgid ""
 "These spirits are weak. They seek to prey on the helpless, but when they "
 "encounter strong resistance they flee."
 msgstr "这些虚弱的灵魂寻找无助的祭品，但遇到抵抗就会逃跑。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1904
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1978
 msgid "You come and rise again, spirits? Have we not defeated you before?"
 msgstr "幽灵们，你又来了？之前我们难道没有击败过你吗？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1909
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1983
 msgid ""
 "These lost souls cannot hold onto anything but memories of lives long gone. "
 "They will rise to plague us again, night after night."
@@ -1880,7 +1926,7 @@ msgstr ""
 "夜都是。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1918
+#: data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg:1992
 msgid "Flee, you craven spirits, and leave us in peace!"
 msgstr "逃啊，你们这些胆小的灵魂，能不能和平一些！"
 
@@ -1893,7 +1939,7 @@ msgstr "匆忙的夜"
 #. Use the same translation as for the string in the wesnoth-help textdomain.
 #. Use the same translation as for the string in the wesnoth-help textdomain.
 #: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:19
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:328
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:327
 msgid "The Long Dark"
 msgstr "漫漫长夜"
 
@@ -1924,92 +1970,94 @@ msgid "Defeat Possessed Garak"
 msgstr "击败被附体的伽拉克"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:222
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:221
 msgid "Defeat Azkotep"
 msgstr "击败阿兹卡提"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:235
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:234
 msgid "Defeat Ystara"
 msgstr "击败伊斯图拉"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:266
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:265
 msgid "You lose control (even temporarily) of more than 6 villages"
 msgstr "你失去对六个以上的村庄的控制（即使是暂时的）"
+
+#. [event]
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:340
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:354
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:359
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:364
+msgid "Zur"
+msgstr "泽"
 
 #. [event]
 #: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:341
 #: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:355
 #: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:360
-msgid "Zur"
-msgstr "泽"
-
-#. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:342
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:356
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:361
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:365
 msgid "Grak"
 msgstr "格拉克"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:372
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:376
 msgid "Kaleh, wake up! Sentries report movement in the sands!"
 msgstr "卡勒，醒醒！ 哨兵报告说沙漠里有东西在动！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:376
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:380
 msgid "Orcs?"
 msgstr "兽人？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:380
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:384
 msgid "I don’t..."
 msgstr "我想……"
 
 #. [message]: speaker=Azkotep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:384
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:388
 msgid "We meet again, Ystara."
 msgstr "又见面了，伊斯图拉。"
 
 #. [message]: speaker=Ystara
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:388
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:392
 msgid "You think you can take me, Azkotep?"
 msgstr "你以为能赢我， 阿兹卡提？"
 
 #. [message]: speaker=Azkotep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:392
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:396
 msgid ""
 "My champion, Zur shall slice you to shreds like the puny adept you once were."
 msgstr "我的拥护者泽会把你撕成碎片，就像你曾经干过的那些事一样。"
 
 #. [message]: speaker=Ystara
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:396
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:400
 msgid ""
 "You always were an arrogant little bastard. Grak will swallow your soul, or "
 "what’s left of it."
 msgstr "自大的小杂种。格拉克会吞噬你灵魂的全部。"
 
 #. [message]: speaker=Azkotep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:400
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:404
 msgid ""
 "You spurned me once and I will make you pay. To battle, my minions! Become "
 "my wrath!"
 msgstr "你竟敢藐视我，我要让你付出代价。我的仆人们，准备战斗！尝尝我的愤怒吧！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:404
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:408
 msgid "... think so. You really know how to pick a campsite, Kaleh."
 msgstr "……不是。你选择的营地真个是好地方，卡勒。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:408
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:412
 msgid ""
 "Where did they come from? I swear those castles weren’t there at sunset."
 msgstr "它们从哪冒出来的？我发誓日落之前那里根本没有城堡。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:412
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:416
 msgid ""
 "Many strange things can happen during the long dark. But despite their "
 "wraith-like forms, I have no doubt that their cold steel can still bite "
@@ -2019,35 +2067,35 @@ msgstr ""
 "会伤到活人。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:416
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:420
 msgid ""
 "Like I haven’t killed enough undead recently. Why can’t these creeps just "
 "stay dead?"
 msgstr "弄得好像最近我杀掉的亡灵还不够多似的。为什么这些家伙死了也不安分呢？"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:420
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:424
 msgid ""
 "Our encampment is out of the direct line of attack, so we should be somewhat "
 "safe, at least."
 msgstr "我们的营地不在进攻直线上，也许是安全的。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:424
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:428
 msgid ""
 "But if the battle spills around our people will be slaughtered by the undead "
 "hordes!"
 msgstr "但是如果亡灵的战斗扩大了，我们的同胞就会受到牵连！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:428
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:432
 msgid ""
 "There’s no way we can escape the battle in time. We must protect the camp "
 "from the undead."
 msgstr "没时间躲避战斗了。我们必须保护营地免受亡灵侵扰。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:432
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:436
 msgid ""
 "I fear that if we lose more than half of the tents we will not have the "
 "strength to go on. Garak, wake your men. We must hold off the undead until "
@@ -2057,41 +2105,41 @@ msgstr ""
 "前我们必须挡住亡灵。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:436
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:440
 msgid "To arms my people, to arms!"
 msgstr "大家拿起武器，准备上！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:514
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:518
 msgid "They’re raising the corpses of our fallen! What a horrible fate!"
 msgstr "他们把我们伙伴的尸体变做僵尸！可恶！"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:519
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:523
 msgid "Then we shall have to give them a proper cremation."
 msgstr "现在我们只能为他们进行火葬了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:589
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:593
 msgid ""
 "Too many of our people have been killed. We will surely be overwhelmed by "
 "the undead now. All is lost!"
 msgstr "我们的人牺牲太多了。我们只能等着被亡灵淹没了。万事皆空！"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:648
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:652
 msgid ""
 "These champions... I will challenge them. Zhul, bless my weapons with light "
 "of Eloh."
 msgstr "那些傀儡……我要挑战它们。朱尔，用伊洛之光来祝福我的武器吧。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:652
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:656
 msgid "Garak, but the suns..."
 msgstr "伽拉克， 但是太阳……"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:656
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:660
 msgid ""
 "You will not do any such thing, anyone trying to fight these creeps "
 "singlehanded will surely die. We need you, we will not make it without you."
@@ -2103,21 +2151,21 @@ msgstr "你不能这么做，独自和这种怪物战斗会死的。我们需要
 #. has had the dream tonight while they were camped here, he hasn't had premonitions beforehand; that's
 #. probably just because of the nearby undead, not some prophetic vision. Neither Garak nor a first-time
 #. player know that the scenario will extend the night indefinitely until the enemies are defeated.
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:666
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:670
 msgid ""
 "I had a dream this night Kaleh, full of gloom and darkness. My journey will "
 "end here one way or another."
 msgstr "卡勒，今晚做了个梦，梦中一片黑暗。不论结果如何，我的旅程将在此结束。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:670
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:674
 msgid ""
 "No! That’s not true, our future is what we make of it, stay behind for this "
 "fight and..."
 msgstr "不！不是这样的，我们的未来要由我们亲手来打造，请呆在后方，然后……"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:674
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:678
 msgid ""
 "And what? You’ll help me become a coward? I lived long, I’m not afraid of "
 "the end, just let me give it some meaning."
@@ -2125,7 +2173,7 @@ msgstr ""
 "然后？帮我变成个懦夫？我活的够久了，我并不怕死，请让我死得更有价值一些吧。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:678
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:682
 msgid ""
 "I bless you with the light that will come, I bless you with the memory and "
 "the promise. Lay down your shield, champion, and let your blade shine in the "
@@ -2136,17 +2184,17 @@ msgstr ""
 
 #. [resistance]: id=garak_steadfast
 #. Custom steadfast ability. Has same name as the as the one in core, but works a bit different.
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:707
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:711
 msgid "Garak’s resistances are increased by 20% when defending."
 msgstr "伽拉克在防守时抗性增加20%."
 
 #. [berserk]: id=berserk
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:719
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:723
 msgid "righteous rage"
 msgstr "正义之怒"
 
 #. [berserk]: id=berserk
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:721
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:725
 msgid ""
 "If used offensively or defensively against champions Grak or Zur, this "
 "attack presses the engagement until one of the combatants is slain, or 30 "
@@ -2156,149 +2204,149 @@ msgstr ""
 "直到一方被杀，或者大战30回合为止。"
 
 #. [chance_to_hit]: id=magical
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:730
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:734
 msgid "true strike"
 msgstr "准确打击"
 
 #. [chance_to_hit]: id=magical
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:732
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:736
 msgid ""
 "This attack always has a 70% chance to hit regardless of the defensive "
 "ability of the champion being attacked."
 msgstr "无论冠军的防守能力如何，此攻击的命中率总为70%。"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:798
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:802
 msgid "You there! Creep! Stand and face me, shade! I challenge you!"
 msgstr "你！小崽子！站著别动，我找你来了！"
 
 #. [message]: speaker=Grak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:808
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:812
 msgid ""
 "Foolish mortal... For daring to challenge me, I’ll devour your soul and "
 "torment it for all eternity..."
 msgstr "愚蠢的东西…… 胆敢挑战我，我要吞噬你的灵魂，叫你永生不得超度……"
 
 #. [message]: speaker=Grak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:814
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:818
 msgid ""
 "So you destroyed Zur... Come mortal, let’s cross our blades... It’s time for "
 "you to take his place..."
 msgstr "你竟然杀死了泽…… 来吧凡人，我要把你千刀万剐……你就跟着泽去吧……"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:836
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:840
 msgid "You there! Pile of bones! I challenge you, stand and face me!"
 msgstr "你！骨头架子！我来了，和我打一架吧！"
 
 #. [message]: speaker=Zur
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:846
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:850
 msgid "Puny elf... Time to die..."
 msgstr "小子……你的死期到了……"
 
 #. [message]: speaker=Zur
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:852
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:856
 msgid ""
 "Grak was weak... But still you deserve respect... Meet my axe and take his "
 "place..."
 msgstr "格拉克软弱…… 但是你值得称赞…… 替他尝尝我的斧头……"
 
 #. [message]: speaker=$second_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:882
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:886
 msgid "And so it ends... Your champion is dead, elves... Come join him..."
 msgstr "到头了…… 你们的主力死了，精灵 …… 和他一起去吧……"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:898
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:902
 msgid "Where is Garak? Has anybody seen him?"
 msgstr "伽拉克在哪里？有人看见么？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:902
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:906
 msgid ""
 "I saw him jumping into deep darkness pursuing a group of enemies. Let’s hope "
 "nothing happened to him."
 msgstr "我看到他冲入黑暗中的敌阵。希望他平安无恙。"
 
 #. [message]: speaker=$lich_lord.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:953
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:957
 msgid ""
 "No! This contest is not over yet, Ystara. I shall show you a taste of my "
 "true power."
 msgstr "不！你我的争斗还没结束，伊斯图拉。给你看看我真正的力量。"
 
 #. [message]: speaker=$lich_lord.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:959
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:963
 msgid ""
 "No! This contest is not over yet, Azkotep. I shall show you a taste of my "
 "true power."
 msgstr "不！你我的争斗还没结束，阿兹卡提。给你看看我真正的力量。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:975
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1006
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1191
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:979
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1010
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1206
 msgid "Possessed Garak"
 msgstr "疯狂的伽拉克"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:979
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:983
 msgid "Eloh protect us, what has he done?"
 msgstr "伊洛保佑，他做了什么？"
 
 #. [message]: speaker=Possessed Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:983
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1162
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:987
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1177
 msgid "I live again! I can feel!"
 msgstr "我又活了！我可以感觉到东西了！"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:998
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1002
 msgid ""
 "I will... not... yield... I defeated... your... champion... I... will... "
 "overcome... you..."
 msgstr "我不……会……屈服……我击败了……你的……手下……我要……战胜你……"
 
 #. [message]: speaker=Possessed Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1010
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1014
 msgid "No, fool! Stop!"
 msgstr "不要，傻瓜！停下！"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1025
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1029
 msgid "The dark lord... is no more..."
 msgstr "黑暗之王……不复存在……"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1029
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1033
 msgid ""
 "Garak collapses to the ground with his own blade sticking from his chest."
 msgstr "伽拉克 的尸体倒下了，胸膛上插着自己的刀。"
 
 #. [message]: speaker=$other_lord.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1041
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1045
 msgid ""
 "No! How dare you? I shall have my vengeance upon you for spoiling this "
 "contest! Darkness shall reign until I have triumphed!"
 msgstr "不！怎么这样？我要复仇！应该是我来之后黑暗才降临的！"
 
 #. [message]: speaker=Possessed Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1149
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1164
 msgid "Hahaha...!"
 msgstr "哈哈哈……！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1153
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1168
 msgid "Eloh protect us, what is happening?"
 msgstr "伊洛保佑我们，发生什么了？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1166
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1181
 msgid "Garak?"
 msgstr "伽拉克？"
 
 #. [message]: speaker=Possessed Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1170
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1185
 msgid ""
 "Hahaha! Your puny friend is no more. With his body I shall crush you all. "
 "Arise again my minions and feast in the slaughter!"
@@ -2307,21 +2355,21 @@ msgstr ""
 "享受杀戮的盛宴吧！"
 
 #. [message]: speaker=$lich_lord.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1208
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1223
 msgid ""
 "No, I shall have my revenge. I shall show you that darkness is strongest "
 "just before dawn. Death and decay, grant me my vengeance!"
 msgstr "不，我要复仇。黎明前就体验黑暗的伟大。死亡和屈服。赋予我复仇的力量！"
 
 #. [message]: speaker=$other_lord.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1212
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1227
 msgid ""
 "In this I shall support you, the darkness will not lift until one of us is "
 "victorious."
 msgstr "只有这一点我同意，太阳不会在我们中任意一人胜利之前升起。"
 
 #. [message]: speaker=Possessed Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1237
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1252
 msgid ""
 "I told you, I will be back, you fools! Now I shall have my vengeance upon "
 "you all. Darkness shall reign until I have triumphed!"
@@ -2330,14 +2378,14 @@ msgstr ""
 "直到我取得胜利！"
 
 #. [message]: speaker=$other_lord.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1241
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1256
 msgid ""
 "In this I shall support you, the darkness shall not lift until one of us is "
 "victorious."
 msgstr "我同意，太阳不会在我们中任意一人胜利之前升起。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1275
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1290
 msgid ""
 "Look, dawn is nigh, our salvation is almost at hand. Even the long dark "
 "can’t last forever, and with the light of the sun the undead power wanes and "
@@ -2347,7 +2395,7 @@ msgstr ""
 "的黑暗魔法也会消散。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1415
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1430
 msgid ""
 "Maybe I spoke too soon. Curse Uria, he has even blotted out the stars, all "
 "is darkness. Kaleh, our course is clear, we must destroy that abomination."
@@ -2356,12 +2404,12 @@ msgstr ""
 "要消灭它们。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1426
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1441
 msgid "But to kill Garak? How can we?"
 msgstr "去杀死伽拉克？ 我们怎能做到？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1430
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1445
 msgid ""
 "That thing is not Garak. This night has lasted long enough, and too many of "
 "our people have died. How many more would you sacrifice for Garak’s sake? "
@@ -2375,22 +2423,22 @@ msgstr ""
 "代价，我们都要击败至少一个恶魔。我不愿意让那……那种东西控制我们朋友的躯体。"
 
 #. [message]: speaker=$other_lord.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1434
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1449
 msgid "The stench of death is in the air."
 msgstr "有死亡的恶臭。"
 
 #. [message]: speaker=Possessed Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1438
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1453
 msgid "Yes, let us end this once and for all."
 msgstr "是的。让我们一次了断吧。"
 
 #. [unit]: type=Orcish Leader, type=Orcish Ruler, id=Ganthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1481
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1499
 msgid "Ganthos"
 msgstr "甘瑟斯"
 
 #. [message]: speaker=Ganthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1525
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1546
 msgid ""
 "What’s this on our borders? Stinkin’ elves and more undead? We’ll teach them "
 "a lesson they won’t soon forget. Attack!"
@@ -2399,7 +2447,7 @@ msgstr ""
 "的教训。进攻！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1529
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1550
 msgid ""
 "If those raiders capture any of our encampments, I fear our people’s fate "
 "will be just as bad as if it was captured by the undead."
@@ -2408,17 +2456,17 @@ msgstr ""
 "将面对悲惨的命运。"
 
 #. ['A unit’s name, should be short.']
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1540
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1561
 msgid "Wounded Scout"
 msgstr "受伤的侦察兵"
 
 #. [message]: speaker=Elven Scout
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1543
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1564
 msgid "Orcs... Not far behind me... From the hills..."
 msgstr "兽人……后面不远处……山上……"
 
 #. [message]: speaker=Ganthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1571
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1592
 msgid ""
 "You got me, elf... But you won’t be so lucky with the tribes of the hills... "
 "(<i>Cough</i>)"
@@ -2426,62 +2474,62 @@ msgstr ""
 "精灵，你赢了……但是等你遇到山里的部落，就不会这么幸运了……（<b>咳嗽</b>）"
 
 #. [message]: speaker=Ganthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1575
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1596
 msgid "I deeply regret... I won’t be able to see that..."
 msgstr "真遗憾……没想到会这样……"
 
 #. [message]: speaker=Ganthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1581
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1602
 msgid "Killed by a dead creep... (<i>Cough</i>)"
 msgstr "死在这种死物手上…… （<b>咳嗽</b>）"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1591
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1612
 msgid "Look, he dropped something! I wonder what it is..."
 msgstr "看，他掉了东西！我想知道那是什么……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1610
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1631
 msgid ""
 "It’s some sort of a map. I think I recognize some of those hills ahead on it."
 msgstr "似乎是张地图。我想我能在这上面认出前方那些丘陵。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1614
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1635
 msgid ""
 "And these look like camps and patrol routes. A lot of camps and patrol "
 "routes. Kaleh, do you think we could sneak up between them?"
 msgstr "看起来是营地和巡逻线路，很多。卡勒，我们能暗中穿过去吗？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1618
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1639
 msgid ""
 "Difficult, but worth a try I guess. But first we must try to survive this "
 "mess."
 msgstr "难，但是值得一试。不过我们得先活下来。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1622
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1643
 msgid "Right, sorry. Damn creeps."
 msgstr "是的，抱歉。可恶的家伙们。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1629
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1650
 msgid "And now we’ll never know what was on that parchment. Shame."
 msgstr "我们再也不能知道那张羊皮纸上有什么了。惭愧。"
 
 #. [message]: race=orc
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1646
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1667
 msgid "Chief has fallen! Flee!"
 msgstr "首领倒下了！跑吧！"
 
 #. [message]: race=goblin,wolf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1654
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1675
 msgid "Boss dead! Run!"
 msgstr "老大死了！跑吧！"
 
 #. [message]: speaker=$unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1697
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1718
 msgid ""
 "You think you have defeated me, don’t you? Foolish boy, I shall assume a new "
 "form more powerful and horrible than you could ever imagine!"
@@ -2490,76 +2538,76 @@ msgstr ""
 "态！"
 
 #. [message]: speaker=$other_creep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1701
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1722
 msgid ""
 "How dare you interfere in our contest! I did not need your help. I shall "
 "teach you not to cross a lord of darkness."
 msgstr "你们敢插手我们的战斗！我不用你们帮忙。我要教会你们以后别惹黑暗领主。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1713
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1909
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1734
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1931
 msgid "Finally. It is over."
 msgstr "最后， 它结束了。"
 
 #. [message]: speaker=Possessed Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1722
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1743
 msgid ""
 "See, I told you I was more powerful. This game is over, now I can leave this "
 "shell of a body."
 msgstr "看吧，我说过了我变强了。游戏结束了，现在我可以离开这副躯壳了。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1734
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1921
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1755
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1943
 msgid "He’s... he’s still breathing!"
 msgstr "他……他还有呼吸！"
 
 #. [message]: speaker=Possessed Garak
 #. [message]: speaker=Garak
-#. Defeated, no longer posessed
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1739
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1851
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1925
+#. Defeated, no longer possessed
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1760
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1872
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1947
 msgid "Protect the boy for me Zhul, (<i>cough</i>) I go to a better place."
 msgstr "朱尔，帮我保护这男孩，（<b>咳嗽</b>）我要去一个好地方了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1750
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1771
 msgid "What about Garak?"
 msgstr "伽拉克怎么办？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1760
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1781
 msgid "I’ve asked and looked around, there is no sign of him or his body"
 msgstr "我问过了，也找过了，但没有发现他，也没看见他的尸体"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1764
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1785
 msgid ""
 "He’s probably dead, then, but he died as a warrior. Let’s respect his wishes "
 "and remember him for that."
 msgstr "他大概已经死了，但他以战士的身份逝去了。让我们尊重他的意愿并铭记他。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1770
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1791
 msgid "He died as a hero. Remember that and tell the tale, for it’s worth it."
 msgstr "他是个英雄，记住这一点并让他的事迹流传于后世，他值得我们怀念。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1806
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1827
 msgid "The undead lords are defeated at last."
 msgstr "亡灵首领终于败了。"
 
 #. [message]: speaker=Ganthos
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1810
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1831
 msgid ""
 "There’s too many of them and the night is almost gone. Pull back you "
 "wretches, pull back!"
 msgstr "他们人太多，夜晚快过去了。撤退，臭小子们，撤退！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1814
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1835
 msgid ""
 "I can see the first rays of Naia shining over the horizon. She never looked "
 "so beautiful. The undead forces have crumbled into dust and the remaining "
@@ -2569,7 +2617,7 @@ msgstr ""
 "剩下的兽人也在黎明时撤退了。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1818
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1839
 msgid ""
 "That was a very brave thing you did, Kaleh, defeating both of those Undead "
 "Lords. It took great courage and strength. Because of your daring attack, we "
@@ -2582,8 +2630,8 @@ msgstr ""
 "晚，我们的损失可能会更多。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1822
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1986
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1843
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2009
 msgid ""
 "Though we saved almost all our people this time, we won’t always be so "
 "lucky. While elves who have fought with you in the past will gladly return, "
@@ -2596,7 +2644,7 @@ msgstr ""
 "好要存点金钱了。"
 
 #. [message]: speaker=Ystara
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1826
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1847
 msgid ""
 "You have triumphed for the moment, but think not that the dark lords can be "
 "so easily vanquished. We shall return, and shall rule long after your bones "
@@ -2606,36 +2654,36 @@ msgstr ""
 "化成灰以后我们还是会统治着这里。这是我们的地盘，没有人能毫发无伤地离开这里。"
 
 #. [message]: speaker=Azkotep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1830
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1851
 msgid ""
 "You fought so hard to protect your precious people, young elf. No great deed "
 "should go unpunished."
 msgstr "为了你的重要同胞，你很拼命，年轻的精灵。不过，逞英雄是要付出代价的。"
 
 #. [message]: id=Ystara,Azkotep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1839
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1860
 msgid "A token to remember us by..."
 msgstr "一个礼物，让你们记得我们……"
 
 #. [message]: speaker=Garak
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1843
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1864
 msgid "Aauugghh!"
 msgstr "啊啊啊！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1847
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1868
 msgid "He just collapsed!"
 msgstr "他瓦解了！"
 
 #. [message]: id=Ystara,Azkotep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1862
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1883
 msgid ""
 "You will never see your champion again. And we will torment his soul for the "
 "rest of the eternity."
 msgstr "你再也见不到你的保护者了。我们会折磨他的灵魂，永远折磨他。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1866
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1887
 msgid ""
 "Don’t listen to them, they are powerless in their defeat. Even if Garak fell "
 "in battle his soul went to a better place and they can’t reach him there."
@@ -2644,19 +2692,19 @@ msgstr ""
 "个更美好的地方，一个这些家伙碰不到的地方。"
 
 #. [message]: speaker=Azkotep
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1897
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1919
 msgid ""
 "Hah, now you have learned the flesh is always weaker than the powers of the "
 "undead."
 msgstr "哈，现在你终于知道，活人是无法与亡灵的力量相抗衡的。"
 
 #. [message]: speaker=Ystara
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1903
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1925
 msgid "My undead zombies shall always defeat the living."
 msgstr "我的僵尸总是击败活着的东西。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1953
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1976
 msgid ""
 "From the sands he came, to the sands he will return. We remember and honor "
 "his sacrifice, and I vow that his death will not be in vain."
@@ -2665,40 +2713,40 @@ msgstr ""
 "白流。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1957
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1980
 msgid "Goodbye, old friend. May Eloh shine her light eternal upon you."
 msgstr "再见，老伙计，愿伊洛的光辉永远笼罩着你。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1961
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1984
 msgid ""
 "He was as brave and valiant a fighter as I have ever seen in my travels."
 msgstr "他是我旅途中见过的最英勇的战士。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1965
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1988
 msgid ""
 "He was a bastard at times... But... but why did he have to die? It... it "
 "just doesn’t make sense."
 msgstr "他有时是很混蛋……但是……为什么必须死啊？这真是……这真是没道理。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1982
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2005
 msgid "Miraculously, all of our encampments survived the night."
 msgstr "不过，我们所有的营地都挺过了这个夜晚。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1992
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2015
 msgid "Well, only $elven_camps encampments remain, but we will survive."
 msgstr "只有 $elven_camps 个营地保留下来，不过我们能活着。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:1996
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2019
 msgid "Yes, but at what cost?"
 msgstr "算是吧。可是以什么样的代价呢？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2006
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2029
 msgid ""
 "Though we saved almost all our people this time, we won’t always be so "
 "lucky. While elves who have fought with you in the past will gladly return, "
@@ -2711,7 +2759,7 @@ msgstr ""
 "好要存点金钱了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2018
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2041
 msgid ""
 "We have suffered losses, but we are not broken yet. We have saved most of "
 "our people tonight. But while elves who have fought with you in the past "
@@ -2724,7 +2772,7 @@ msgstr ""
 "此我们最好要存点金钱了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2026
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2049
 msgid ""
 "We have suffered grievous losses, but we are not broken yet. Long will this "
 "slaughter be remembered by our people. Where was Eloh during the darkness? "
@@ -2738,21 +2786,21 @@ msgstr ""
 "征召新兵的耗费大幅增加。为此我们最好要存点金钱了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2039
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2062
 msgid ""
 "All this death and destruction. What were those shades arguing over? Was "
 "this all just some sort of demented game?"
 msgstr "满目疮痍。那些影子讨论什么？这都是痴狂发呆鬼魂的游戏？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2043
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2066
 msgid ""
 "The lords of the dead are powerful and twisted indeed. Only Eloh knows the "
 "truth of what happened tonight."
 msgstr "死亡的主人是疯狂且强大的。只有伊洛才知道今晚故事的真相。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2047
+#: data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg:2070
 msgid ""
 "I don’t want to be here tomorrow night to find out. The hills to the north "
 "are close. Let’s be far away before another nightfall."
@@ -2770,27 +2818,27 @@ msgid "Panok"
 msgstr "潘洛克"
 
 #. [side]: id=Turg, type=Orcish Warrior, type=Orcish Warlord
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:87
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:94
 msgid "Turg"
 msgstr "特格"
 
 #. [side]: id=Ug'lok, type=Orcish Warrior, type=Orcish Warlord
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:127
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:132
 msgid "Ug’lok"
 msgstr "乌戈洛克"
 
 #. [objectives]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:197
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:205
 msgid "Objectives:"
 msgstr "新任务:"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:199
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:207
 msgid "Kaleh must reach the exit tunnel at the north edge of the map"
 msgstr "卡勒到达地图北边的通道"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:357
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:365
 msgid ""
 "Those mountains are huge! I never thought they would be so big. And what’s "
 "that white stuff on the tops of the peaks?"
@@ -2798,7 +2846,7 @@ msgstr ""
 "这些山岭巨大无比，我从没想过它们能这么大！山顶上那些白色的东西是什么啊？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:362
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:370
 msgid ""
 "I wish Garak were here, he’d know more about these lands than I do. I’ve "
 "never been up here, but I heard stories from the few who have made the "
@@ -2813,7 +2861,7 @@ msgstr ""
 "全，但实际上敌人们正藏在地表之下的洞穴和隧道里。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:373
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:381
 msgid ""
 "Speaking of these lands, we may not have Garak to guide us, but all the "
 "terrain in this area perfectly matches the map we got from the orcs last "
@@ -2825,7 +2873,7 @@ msgstr ""
 "以在不让他们发现的情况下偷偷溜过去。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:380
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:388
 msgid ""
 "I had another vision last night, Eloh told me that we had to continue north, "
 "but instead of trying to go over the mountains, she said that we had to go "
@@ -2835,12 +2883,12 @@ msgstr ""
 "她说我们该从它们下面走。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:385
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:393
 msgid "Underneath them? But how?"
 msgstr "从它们下面？ 但怎么走？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:390
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:398
 msgid ""
 "Orcs and goblins have been living here for hundreds of years and their "
 "network of tunnels and caves is more extensive than you might think. Who "
@@ -2853,7 +2901,7 @@ msgstr ""
 "指的洞穴，但若是要穿越这山脉，我们别无选择。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:395
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:403
 msgid ""
 "Other creatures besides orcs dig tunnels in the earth. Long ago dwarves "
 "mined mountains such as these, and huge trolls like to hide in the deep dark "
@@ -2867,14 +2915,14 @@ msgstr ""
 "该有条穿山的通道。我不惧怕黑暗，你们也不会缺乏火种。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:400
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:408
 msgid ""
 "Well if we are going to go under these mountains, we’re certainly going to "
 "have our hands full fighting all those orcs and goblins."
 msgstr "好吧，如果我们向山下面出发，我们该准备全力和兽人、地精们作战。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:405
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:413
 msgid ""
 "Indeed. I want to warn you again, Kaleh, this isn’t the desert. The orcs "
 "love fighting in hills and caves, and we won’t have the advantages of "
@@ -2890,51 +2938,51 @@ msgstr ""
 "们的人民进入这些通道。希望在地下我们能比在开阔地更好地保护人民。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:410
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:418
 msgid ""
 "Strike hard and fast and also be careful—right, this is going to be fun."
 msgstr "有力和快速地攻击，同时要保持小心——是的，这将是很有趣的。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:439
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:447
 msgid "Goblin Coward"
 msgstr "地精懦夫"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:444
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:448
 #: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:452
 #: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:456
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:460
 #: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:464
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:468
 #: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:472
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:479
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:483
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:476
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:480
 #: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:487
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:596
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:597
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:599
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:600
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:491
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:495
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:607
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:608
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:610
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:611
 msgid "Goblin Scout"
 msgstr "地精侦察兵"
 
 #. [message]: speaker=Goblin Scout
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:498
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:506
 msgid "Attack!"
 msgstr "进攻！"
 
 #. [message]: speaker=Goblin Coward
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:503
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:511
 msgid "Run away!"
 msgstr "快跑！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:508
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:516
 msgid "Goblins are so predictable."
 msgstr "地精的行动总是那么好预测。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:519
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:527
 msgid ""
 "Merely a few steps in and all these goblins already know we’re here! I guess "
 "it’s not that easy to sneak around in someone else’s home territory."
@@ -2943,37 +2991,37 @@ msgstr ""
 "容易。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:544
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:546
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:553
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:555
 msgid "Orac"
 msgstr "欧若可"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:552
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:554
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:561
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:563
 msgid "Scylla"
 msgstr "塞勒"
 
 #. [event]
 #. name of an enemy unit in water, not a geographic feature
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:563
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:566
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:568
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:569
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:573
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:577
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:579
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:580
 msgid "Lake Naga"
 msgstr "湖中的那迦"
 
 #. [event]
 #. name of an enemy unit in water, not a geographic feature
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:565
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:566
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:568
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:569
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:575
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:577
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:579
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:580
 msgid "female^Lake Naga"
 msgstr "湖中的那迦"
 
 #. [message]: speaker=Orac
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:605
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:616
 msgid ""
 "Come forth, creatures of the lake! Fulfill the oaths you have made and help "
 "us drive these hated creatures from our lands."
@@ -2981,30 +3029,30 @@ msgstr ""
 "上前，湖中生物们！履行你们的誓言，帮我们把这些讨厌的生物逐出我们的领地。"
 
 #. [message]: speaker=Scylla
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:610
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:770
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:621
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:781
 msgid "Yesss, we remember the oath... Sssslay them all!"
 msgstr "是嘶嘶，我们还记得誓言……把他们都杀啊啊了！"
 
 #. [message]: speaker=Panok
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:631
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:642
 msgid "These elves are stronger than we thought. Send for more reinforcements!"
 msgstr "这些精灵比我们想象的要强大，请求援军！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:636
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:647
 msgid ""
 "How can he move that fast? He is faster than any goblin rider I have ever "
 "seen. It’s almost unnatural."
 msgstr "他怎么能移动得那么快？他比我见过的其他地精骑士都要快速，太反常了。"
 
 #. [message]: speaker=Panok
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:651
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:662
 msgid "Gaaghh!!"
 msgstr "呃啊！！！"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:664
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:675
 msgid ""
 "Wait a minute. He was wearing a silver ring on one of his fingers. I think "
 "the ring might be magical. Maybe that’s why he was moving so fast."
@@ -3013,17 +3061,17 @@ msgstr ""
 "的秘密。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:672
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:683
 msgid "I think, Kaleh, that you should take the ring."
 msgstr "我想，卡勒，你应该戴上这个指环。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:677
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:688
 msgid "Why me?"
 msgstr "为什么是我？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:682
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:693
 msgid ""
 "Because you tend to move slowly and if we’re going into the caves you’ll "
 "need all the speed you can get. And besides, we can’t afford to lose you; "
@@ -3034,17 +3082,17 @@ msgstr ""
 "去你，你也许不知道，走得快慢之别可能就是生死之别啊。"
 
 #. [object]: id=SpeedyRing
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:712
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:723
 msgid "Ring of Speed"
 msgstr "速度指环"
 
 #. [object]: id=SpeedyRing
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:714
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:725
 msgid "This ring will increase your maximum speed by 1."
 msgstr "此指环将使你的最大速度增加1点。"
 
 #. [message]: speaker=Orac
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:765
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:776
 msgid ""
 "The elves have killed Panok the goblin! The other goblins may flee to the "
 "caves, but we will not give up these hills without a fight. Come forth, "
@@ -3055,7 +3103,7 @@ msgstr ""
 "吧，湖中生物们！履行你们的诺言，帮助我们把这些讨厌的生物驱逐出境。"
 
 #. [message]: speaker=$unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:798
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:809
 msgid ""
 "Ugh! These tunnels are pitch black! It’s as bad as fighting in a moonless "
 "night, and it stinks of orc filth. I can hardly think of a place I would "
@@ -3065,7 +3113,7 @@ msgstr ""
 "简直想不出哪里还有更加讨厌的地方了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:803
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:814
 msgid ""
 "We have no choice. We cannot cross over these mountains, so we must go "
 "beneath them. If the orcs skulk in their tunnels and block our way, we must "
@@ -3075,7 +3123,7 @@ msgstr ""
 "道里堵住我们的去路，我们也必须进入那些地方去战斗，无论什么情况。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:809
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:820
 msgid ""
 "Remember, Kaleh, it’s nasty fighting underground. We will be at a "
 "disadvantage against orcs and other things that prefer the darkness."
@@ -3084,7 +3132,7 @@ msgstr ""
 "劣势。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:814
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:825
 msgid ""
 "Also, any time you find a particularly tough orc blocking a passage, my "
 "fireballs can blast him quick enough."
@@ -3093,25 +3141,25 @@ msgstr ""
 "翻。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:829
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:840
 msgid "Greebo"
 msgstr "格里宝"
 
 #. [message]: speaker=Greebo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:836
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:846
 msgid ""
 "Greebo keeps shinies safe from nasty orcses. And ’specially stinking elves."
 msgstr "格里宝负责保护这些闪光的东西不被阴险的兽人们，特别是讨厌的精灵们抢走。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:860
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:870
 msgid ""
 "Looks like he’s been squirreling away his stolen loot in this cave. Not that "
 "he had much. Must be hard times."
 msgstr "看来他把偷来的赃物储藏在这个洞穴里，并没有多少啊，估计是困难的时期。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:888
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:898
 msgid ""
 "How odd. Someone has carved a crude fountain out of the stone at the end of "
 "the passage. The freezing water pours out into a large pool. At the bottom "
@@ -3127,55 +3175,55 @@ msgstr ""
 "这把剑，你最恐惧的东西将出现。”</b>这看上去是把好剑，但我敢冒险拿起它吗？"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:890
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:900
 msgid "I fear no creature, I will take the blade!"
 msgstr "我无所畏惧，我接受！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:894
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:904
 msgid ""
 "The blade is chill to the touch and gives off a cold glow. I wonder how it "
 "came to be here."
 msgstr "这把剑触感寒冷，能够发出寒冷的攻击。我想知道它是怎么到这里的。"
 
 #. [object]: id=ColdBlade
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:905
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:915
 msgid "Cold Blade"
 msgstr "寒冷之剑"
 
 #. [object]: id=ColdBlade
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:907
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:917
 msgid ""
 "The unit who wields this blade will deal cold damage with its melee attack."
 msgstr "挥舞这把剑的单位在近战攻击时将造成寒冷伤害。"
 
 #. [command]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:921
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:931
 msgid "Purple Abomination"
 msgstr "紫色厌恶"
 
 #. [message]: speaker=Purple Abomination
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:925
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:935
 msgid "I am an abomination, please kill me."
 msgstr "我是可怖的，请杀了我吧。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:930
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:940
 msgid "I’ve seen some ugly creatures in my day, but that thing is just wrong."
 msgstr "今天看到了恶心的东西，怎么会这样。"
 
 #. [message]: speaker=Purple Abomination
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:935
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:945
 msgid "The voices say I have no choice, I must attack!"
 msgstr "这声音说我没有选择……我必须进攻！"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:945
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:955
 msgid "I don’t like the sound of this. I’m out of here."
 msgstr "我不喜欢这个声音。我要离开这里。"
 
 #. [message]: speaker=$unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:971
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:981
 msgid ""
 "This is the end of the line. The water is too deep for me to continue any "
 "further. I’m freezing cold, wet, and I can’t see a thing. I’m not exactly "
@@ -3187,34 +3235,34 @@ msgstr ""
 "预感。"
 
 #. [unit]: type=Dark Assassin Cloaked, id=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1006
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2111
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2396
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1016
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2107
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2406
 msgid "Cloaked Figure"
 msgstr "戴斗篷者"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1039
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1049
 msgid "Kaleh, I am death incarnate."
 msgstr "卡勒，我是死亡的化身。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1045
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1055
 msgid "And I shall avenge all those you have killed!"
 msgstr "我要为被你们杀死的所有人报仇！"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1061
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1071
 msgid "I promise we shall meet again."
 msgstr "我保证我们会再见面的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1072
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1082
 msgid "He just disappeared. That’s odd."
 msgstr "他消失了。真奇怪。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1100
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1110
 msgid ""
 "This passage seems different from the other tunnels and caves. It is wide "
 "and smooth and leads sharply downwards. I bet this was the way that Eloh was "
@@ -3224,7 +3272,7 @@ msgstr ""
 "过的那条路。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1105
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1115
 msgid ""
 "This is no natural passage, and the walls are too well carved and smooth to "
 "be made by orcs. I wouldn’t be surprised if this was once carved out by "
@@ -3234,7 +3282,7 @@ msgstr ""
 "打通的。我想知道在这山里，还有没有矮人活着。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1119
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1129
 msgid ""
 "Having killed all the orc and goblin leaders in the immediate vicinity, we "
 "can take our time and should have no trouble bringing the rest of our people "
@@ -3247,7 +3295,7 @@ msgstr ""
 "她像从前一样继续指引我们。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1126
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1136
 msgid ""
 "Now that you’ve found the way we should be able to get the rest of our "
 "people past the orcs. It’s odd, I guess we’re trading the dangers we know "
@@ -3258,7 +3306,7 @@ msgstr ""
 "前面等着。我们要把自己的生命全都交给伊洛，寄望她的力量再一次指引我们。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1133
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1143
 msgid ""
 "I’ll just be happy when I can breathe fresh air again and see the suns and "
 "stars. Still, who knows what we’ll encounter deep under the earth?"
@@ -3267,12 +3315,12 @@ msgstr ""
 "深深的地下我们会碰见什么呢？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1138
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1148
 msgid "Well, there’s only one way to find out."
 msgstr "其实，想知道会碰见什么，只有一个办法。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1149
+#: data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg:1159
 msgid ""
 "We’ve taken too long to get our people into the tunnels! Even more orcs are "
 "coming across the foothills from the east and west and flanking us. There’s "
@@ -3283,78 +3331,78 @@ msgstr ""
 "攻击我们，我们没法杀死这些兽人和地精，我们不可能保证人民的安全了。"
 
 #. [scenario]: id=05_A_Subterranean_Struggle
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:7
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:5
 msgid "A Subterranean Struggle"
 msgstr "地下挣扎"
 
 #. [side]
 #. [modify_side]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:48
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:96
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1178
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:46
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:94
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1175
 msgid "team_name^Trolls"
 msgstr "巨魔"
 
 #. [side]
 #. [modify_side]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:146
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:195
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1156
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:144
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:193
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1153
 msgid "team_name^Dwarves"
 msgstr "矮人"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:313
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:311
 msgid "Explore underground"
 msgstr "探索地下世界"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:323
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:321
 msgid "Defeat troll leaders"
 msgstr "击败巨魔首领"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:334
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:332
 msgid "Defeat dwarf leaders"
 msgstr "击败矮人首领"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:345
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:343
 msgid "Defeat the Cloaked Figure"
 msgstr "击败戴斗篷者"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:367
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:364
 msgid "Death of Fundin"
 msgstr "凡丁死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:374
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:371
 msgid "Death of Nori"
 msgstr "诺瑞死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:381
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:378
 msgid "Death of Thungar"
 msgstr "萨格死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:388
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:385
 msgid "Death of Gnarl"
 msgstr "诺尔死亡"
 
 #. [unit]: type=Quenoth Flanker
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:439
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:436
 msgid "Rygar"
 msgstr "瑞格"
 
 #. [unit]: type=Quenoth Fighter
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:450
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:447
 msgid "Nantheos"
 msgstr "南斯奥"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:480
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:477
 msgid ""
 "You mentioned that dwarves and trolls often lived underground, Elyssa. I’ve "
 "only heard myths, have you ever met a dwarf or a troll?"
@@ -3363,7 +3411,7 @@ msgstr ""
 "吗？"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:485
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:482
 msgid ""
 "No I haven’t, I don’t often explore underground unless I have to. There are "
 "lots of nasty things that lurk far away from the light of the suns. But I’ve "
@@ -3374,12 +3422,12 @@ msgstr ""
 "的东西。但我从书中读到过他们，也遇到过一些跟矮人打过交道的人。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:490
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:487
 msgid "What are dwarves like?"
 msgstr "矮人是什么样的？"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:495
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:492
 msgid ""
 "They’re a proud people, and some would say greedy. They love their gold and "
 "fine metals, and forge many beautiful things. I should warn you, they have "
@@ -3391,12 +3439,12 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:500
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:497
 msgid "And what about trolls? I’m not sure I’d want to meet one face to face."
 msgstr "那么巨魔呢？听起来好像他们也不是好惹的。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:505
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:502
 msgid ""
 "Trolls and dwarves are natural enemies, living so close together. And many "
 "would say trolls are little more than brutes and savages. Trolls are huge "
@@ -3409,7 +3457,7 @@ msgstr ""
 "伙和他们做过生意，他说只要不去欺骗巨魔，他们就会很好相处。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:510
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:507
 msgid ""
 "Well, with Eloh’s guidance, I hope we find these tunnels deserted. I’ll be "
 "happy if our biggest problem is not getting lost. I have little wish to meet "
@@ -3419,14 +3467,14 @@ msgstr ""
 "会迷路，第二愿望是我们不会遇到矮人或者巨魔。恳请伊洛护佑我们。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:515
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:567
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:512
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:564
 msgid "Will she? I got the impression she was powerless underground."
 msgstr "是么？ 我以为她在地下力量有限。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:520
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:572
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:517
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:569
 msgid ""
 "Where did you get that idea? Certainly Eloh is strongest during the day, "
 "when the suns are shining down on us. But it is said that even in the "
@@ -3444,22 +3492,22 @@ msgstr ""
 "分地担忧人民的命运。只要我们跟随着伊洛的指引，她就会一直保护我们。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:525
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:577
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:522
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:574
 msgid ""
 "Then let us hope the rest of our journey may be as uneventful as it has been "
 "this far."
 msgstr "那就让我们祈祷接下来的旅途像之前那样顺利吧。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:532
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:529
 msgid ""
 "I’ve heard of dwarves, but do you have any idea, Zhul, what kinds of "
 "creatures we might encounter underground?"
 msgstr "朱尔，我只听说过矮人，你知道在地下我们会碰到什么吗？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:537
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:534
 msgid ""
 "These tunnels are foreign to me; I know little more than you do. All I know "
 "about dwarves is from the few tales from the Golden Age."
@@ -3468,12 +3516,12 @@ msgstr ""
 "说。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:542
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:539
 msgid "What are they like?"
 msgstr "他们是什么样子？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:547
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:544
 msgid ""
 "They lived deep under the earth, mining gold and fine metals and forging "
 "many beautiful things. We were once allies during the Golden Age, but in the "
@@ -3486,12 +3534,12 @@ msgstr ""
 "代，我们与兽人以及巨魔的战争中，他们是得力的盟友。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:552
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:549
 msgid "What are trolls?"
 msgstr "巨魔是什么？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:557
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:554
 msgid ""
 "Trolls were huge gray creatures as big as giants and very strong. They were "
 "reclusive creatures, hiding underground. We never had much contact with "
@@ -3504,7 +3552,7 @@ msgstr ""
 "的战士。我不知道他们死绝了没有；无论如何我都不会想去惹一个巨魔的。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:562
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:559
 msgid ""
 "But with Eloh’s guidance, I hope we find these tunnels deserted. I’d be "
 "happy if our biggest problem is not getting lost. Still, even underground "
@@ -3514,12 +3562,12 @@ msgstr ""
 "下，伊洛也会注视着我们的。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:596
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:593
 msgid "All I’m saying is that these tunnels aren’t as bad as I expected."
 msgstr "我想说的是这些坑道不像我想像的那样糟糕。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:602
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:598
 msgid "Shhh! Did you hear something?"
 msgstr "嘘！你听到了吗？"
 
@@ -3638,28 +3686,28 @@ msgid "Troll Leader"
 msgstr "巨魔首领"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:939
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:936
 msgid "Whoa."
 msgstr "哇。"
 
 #. [message]: speaker=$explorer.id
 #. "this" refers to the trolls and dwarves fighting
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:946
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:943
 msgid "Whoa. Kaleh, you have to come see this."
 msgstr "哇。卡勒，你需要来看这个。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1052
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1049
 msgid "I think I preferred the spider and the ants..."
 msgstr "我更喜欢蜘蛛和蚂蚁……"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1057
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1054
 msgid "Stand firm, boys, here they come!"
 msgstr "站好了，弟兄们，他们来了！"
 
 #. [message]: speaker=Troll Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1062
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1059
 msgid ""
 "You invade our tunnels, you slaughter our people, by Griknagh we will make "
 "you pay!"
@@ -3667,7 +3715,7 @@ msgstr ""
 "你们入侵我们的地道，你们伤害我们的族人，以格利克纳之名，你们要付出代价！"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1067
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1064
 msgid ""
 "Tenacious savages, aren’t they? But these tunnels are rich in ore, and we "
 "won’t let a couple of trolls keep them from us."
@@ -3676,44 +3724,44 @@ msgstr ""
 "它们。"
 
 #. [message]: speaker=Troll Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1072
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1069
 msgid "Wait... What... Who are you?"
 msgstr "站住……你们是什么东……什么人？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1077
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1074
 msgid "Uh..."
 msgstr "呃……"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1082
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1079
 msgid "What by the names of my forefathers are they?"
 msgstr "以祖先之名义，它们是什么？"
 
 #. [message]: speaker=first_dwarf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1087
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1084
 msgid "Wait a minute... Vacuous eyes, pointy ears — they must be elves."
 msgstr "等一下……空洞的双眼，尖尖的耳朵——他们肯定是精灵。"
 
 #. [message]: speaker=second_dwarf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1092
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1089
 msgid "Elves?! What in the nine hells are elves doing down here?"
 msgstr "精灵？！精灵来这个地方做什么？"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1097
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1094
 msgid "Never mind that, who are you?"
 msgstr "别管那么多， 你们是谁？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1102
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1099
 msgid ""
 "I am Kaleh, and we are the Quenoth Elves. What in Eloh’s name is going on "
 "here?"
 msgstr "我是卡勒， 我们是奎诺精灵。以伊洛之名， 这里发生什么了？"
 
 #. [message]: speaker=Troll Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1107
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1104
 msgid ""
 "They invade our land and kill our young. Dwarves always want more, always "
 "greedy for glittery rocks."
@@ -3722,19 +3770,19 @@ msgstr ""
 "涎欲滴。"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1112
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1109
 msgid ""
 "Those monsters killed me boys. Kaleh, if you be of stout heart, help us "
 "drive these lummoxes from our tunnels."
 msgstr "那些怪物杀了我的子民。卡勒，如果你有坚强的心，帮我们赶走这些笨蛋。"
 
 #. [message]: speaker=Troll Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1117
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1114
 msgid "No, this is our home. Help us, little ones, and we will help you."
 msgstr "才不是，这是我们的家园。帮助我们，然后我们会帮助你们。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1122
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1119
 msgid ""
 "There’s too many of them for us to try to take them both on, and besides "
 "with all these branching tunnels we’ll have no idea which way to go. I think "
@@ -3746,7 +3794,7 @@ msgstr ""
 "到地面上去。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1127
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1124
 msgid ""
 "But even if we do, what about all of our people? How can we safely escort "
 "them through this war zone?"
@@ -3754,7 +3802,7 @@ msgstr ""
 "但如果我们加入战局，我们的人民怎么办？我们怎么能安全地护送他们穿过这个战区？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1133
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1130
 msgid ""
 "We won’t. If we keep the majority of our people hidden back up the passage "
 "we should be able to protect them, at least for a little while. In the "
@@ -3767,36 +3815,36 @@ msgstr ""
 "果我们够幸运的话，我们可以通过交涉开辟出一条离开这里的安全道路。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1142
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1139
 msgid "But they both look evenly matched. Who should we ally with?"
 msgstr "但是他们看起来势均力敌。帮哪边？"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1145
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1142
 msgid "Let’s aid the dwarves."
 msgstr "让我们援助矮人。"
 
 #. [message]: speaker=Troll Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1161
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1158
 msgid ""
 "Bah! Your kind all the same. Everyone turns on trolls. But you’ll see, "
 "Griknagh will smash you all."
 msgstr "呸！你们都是一样的，都和巨魔作对。走着瞧，格纳福会压扁你们。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1167
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1164
 msgid "Let’s aid the trolls."
 msgstr "我们帮巨魔。"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1183
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1180
 msgid ""
 "I knew elves couldn’t be trusted. Foolish boy, you will regret your "
 "betrayal. Taste dwarven steel!"
 msgstr "我就知道精灵靠不住。傻瓜们，为背叛忏悔吧。尝尝矮人的钢斧！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1198
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1195
 msgid ""
 "There seems to be an abandoned dwarvish fortress right in front of us. If we "
 "can fight our way to the keep, we should be able to start rallying our "
@@ -3807,98 +3855,98 @@ msgstr ""
 
 #. [then]
 #. [modify_unit]
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1212
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1214
 #: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1215
 #: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1217
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1218
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1220
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1284
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1281
 msgid "Troll Skirmisher"
 msgstr "巨魔散兵"
 
 #. [else]
 #. [modify_unit]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1228
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1230
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1232
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1238
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1339
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1225
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1227
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1229
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1235
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1336
 msgid "Dwarf Skirmisher"
 msgstr "矮人散兵"
 
 #. [else]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1235
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1232
 msgid "Dwarf Thunderer"
 msgstr "矮人雷霆战士"
 
 #. [unit]: type=Dwarvish Explorer, id=Fundin
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1348
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1345
 msgid "Fundin"
 msgstr "凡丁"
 
 #. [unit]: type=Dwarvish Explorer, id=Nori
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1361
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1358
 msgid "Nori"
 msgstr "诺瑞"
 
 #. [unit]: type=Troll Warrior, id=Thungar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1376
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1373
 msgid "Thungar"
 msgstr "萨格"
 
 #. [unit]: type=Troll Warrior, id=Gnarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1389
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1386
 msgid "Gnarl"
 msgstr "诺尔"
 
 #. [then]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1516
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1527
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1539
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1550
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1513
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1524
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1536
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1547
 msgid "Troll Flamecaster"
 msgstr "火焰巨魔"
 
 #. [message]: speaker=Troll Flamecaster
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1555
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1552
 msgid "Burn, burn and die!"
 msgstr "烧，烧死你们！"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1566
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1563
 msgid "Dive for cover!"
 msgstr "趴下！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1571
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1568
 msgid ""
 "Those new troll shamans are decimating the dwarves with blasts of fire! This "
 "doesn’t look good."
 msgstr "这些刚出现的萨满用火焰给矮人毁灭性打击！情况不妙。"
 
 #. [message]: id=$casualty
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1610
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1607
 msgid "Aauughh!"
 msgstr "啊啊啊！"
 
 #. [message]: id=$casualty
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1619
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1795
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1616
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1791
 msgid "No...!"
 msgstr "不……！"
 
 #. [message]: id=$casualty
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1628
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1625
 msgid "Help me!!"
 msgstr "救我！！"
 
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1657
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1654
 msgid "More accursed troll magic. Fall back!"
 msgstr "又来了，可恶的巨魔法术。退后！"
 
 # 略有修改
 #. [message]: speaker=Dwarf Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1663
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1659
 msgid ""
 "I need to go back and rally more reinforcements. We’re hurtin’, Kaleh, I’ll "
 "need your men to cover for us. Do your best, boy, and may your ancestors "
@@ -3908,45 +3956,45 @@ msgstr ""
 "子，全力以赴吧，你的祖先会保佑你的。"
 
 #. [else]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1683
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1692
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1703
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1715
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1726
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1679
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1688
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1699
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1711
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1722
 msgid "Dwarf Grenadier"
 msgstr "矮人掷弹兵"
 
 #. [message]: speaker=Dwarf Grenadier
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1731
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1727
 msgid ""
 "Let’s blast those monsters back to the pits they spawned from! Fire in the "
 "hole!"
 msgstr "让我们把那些怪物炸回娘胎里去！开火！"
 
 #. [message]: speaker=Troll Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1742
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1738
 msgid "More dwarven trickery! Fall back!"
 msgstr "又是矮人的奸计！退后！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1747
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1743
 msgid ""
 "Those new dwarves are lobbing explosives at the trolls with devastating "
 "effect! I don’t think the trolls can take this much longer."
 msgstr "那些刚出现的矮人正向巨魔投掷有强大威力的爆炸物！我看巨魔撑不了多久了。"
 
 #. [message]: id=$casualty
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1786
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1782
 msgid "Aaughh!"
 msgstr "啊啊啊！"
 
 #. [message]: id=$casualty
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1804
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1800
 msgid "Gaaghh!"
 msgstr "呃啊！！！"
 
 #. [message]: speaker=Troll Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1833
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1829
 msgid ""
 "I must go back and find more trolls to fight. You must hold them back, "
 "Kaleh. Be strong like rock. Griknagh will be with you."
@@ -3955,32 +4003,32 @@ msgstr ""
 "强，格纳福与你们同在。"
 
 #. [unit]: type=Troll Shaman, id=Thu'lok, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1866
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1862
 msgid "Thu’lok"
 msgstr "苏洛克"
 
 #. [unit]: type=Troll Whelp, id=Harpo, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1881
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1877
 msgid "Harpo"
 msgstr "哈珀"
 
 #. [unit]: type=Troll Whelp, id=Groucho, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1896
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1892
 msgid "Groucho"
 msgstr "古愁"
 
 #. [unit]: type=Troll Whelp, id=Chico, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1911
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1907
 msgid "Chico"
 msgstr "崔寇"
 
 #. [unit]: type=Troll Rocklobber, id=Groo, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1927
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1923
 msgid "Groo"
 msgstr "古鲁"
 
 #. [message]: speaker=Thu'lok
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1942
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1938
 msgid ""
 "Our leader sent us to help you. We fight for you until all the dwarves are "
 "dead. We will avenge the deaths of our people!"
@@ -3989,39 +4037,39 @@ msgstr ""
 "复仇！"
 
 #. [message]: role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1956
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1952
 msgid ""
 "The dwarves use stone cairns to mark their territory. What a waste of good "
 "throwing stones."
 msgstr "矮人用石头做领地标记。真是浪费了这些投掷物。"
 
 #. [unit]: type=Dwarvish Fighter, id=Dwalim, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1976
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1972
 msgid "Dwalim"
 msgstr "瓦林"
 
 #. [unit]: type=Dwarvish Pathfinder, id=Moin, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1993
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:1989
 msgid "Moin"
 msgstr "莫音"
 
 #. [unit]: type=Dwarvish Thunderer, id=Nordi, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2010
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2006
 msgid "Nordi"
 msgstr "诺迪"
 
 #. [unit]: type=Dwarvish Berserker, id=Byorn, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2027
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2023
 msgid "Byorn"
 msgstr "毕勇"
 
 #. [unit]: type=Dwarvish Fighter, id=Runin, role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2046
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2042
 msgid "Runin"
 msgstr "如宁"
 
 #. [message]: speaker=Dwalim
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2063
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2059
 msgid ""
 "Looks like we came just in time. Our chief told us we’re to fight with you "
 "until all the trolls are dead. Tell us where to go — I want to kill me some "
@@ -4031,14 +4079,14 @@ msgstr ""
 "死更多的巨魔！"
 
 #. [message]: role=ally
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2078
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2074
 msgid ""
 "The trolls display the skulls of their enemies as a way of marking their "
 "territory. How barbaric."
 msgstr "巨魔用敌人的头盖骨做领地标记。真是野蛮。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2143
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2139
 msgid ""
 "Did you think you had escaped me, Kaleh? I am your shadow, I will always be "
 "there until you pay for what you have done."
@@ -4047,7 +4095,7 @@ msgstr ""
 "你的所作所为受到报应。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2149
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2145
 msgid ""
 "You want to flee, don’t you? But you cannot. They couldn’t escape her "
 "either. Even death could not save them. She will devour us all. But first I "
@@ -4058,26 +4106,26 @@ msgstr ""
 "曲吧！跳啊！跳啊！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2221
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2217
 msgid "Nasty dwarves and stinkin’ elves, we will smash you all!"
 msgstr "肮脏的矮人和臭精灵们，我们会把你们统统砸扁！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2229
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2225
 msgid ""
 "Kill the elves! We must stop them here. This is our land, crush the "
 "intruders!"
 msgstr "杀掉精灵！我们必须阻止他们。这是我们的土地，消灭入侵者！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2235
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2231
 msgid ""
 "What are you doing back here? The trolls hide in the southern tunnels, not "
 "this way."
 msgstr "你们折回来干什么？巨魔躲在南边的通道，不是这边。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2251
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2247
 msgid ""
 "Treacherous elves, how can you fight with such horrid creatures as trolls? I "
 "will cleave all in two with my axe!"
@@ -4085,7 +4133,7 @@ msgstr ""
 "卑鄙的精灵，你们竟然和巨魔这样讨厌的生物狼狈为奸。看我一斧子把你们劈成两半！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2259
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2255
 msgid ""
 "If you think you can take these caves from us, then you are fools. We are "
 "masters of fighting underground and we will die to defend our home. Fight "
@@ -4095,54 +4143,54 @@ msgstr ""
 "师啊，我们会誓死保卫我们的家园。给我上，兄弟们！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2265
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2261
 msgid ""
 "What you doing back here? Nasty dwarves are to the north, no dwarves this "
 "way. Go back and fight bravely."
 msgstr "你回来这里干什么？肮脏的矮人在北边，这里没有矮人。快回去作战，勇敢点。"
 
 #. [message]: speaker=Fundin
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2296
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2292
 msgid "The rest is silence..."
 msgstr "让我安息吧……"
 
 #. [message]: speaker=Nori
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2309
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2305
 msgid "I go to my ancestors..."
 msgstr "我去见先祖了……"
 
 #. [message]: speaker=Thungar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2322
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2318
 msgid "Arrghh!!"
 msgstr "呃啊！！"
 
 #. [message]: speaker=Gnarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2335
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2331
 msgid "I will be avenged..."
 msgstr "会有人为我复仇……"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2429
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:351
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1658
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2425
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:362
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1668
 msgid "Zurg"
 msgstr "泽格"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2447
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2443
 msgid ""
 "Congratulations! Some of trolls didn’t think you strong enough to beat "
 "dwarves."
 msgstr "恭喜！有些巨魔还觉得你们不够强壮，不能击败矮人呢。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2452
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2549
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2448
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2544
 msgid "Where did you come from?"
 msgstr "你们从哪里来？"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2457
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2453
 msgid ""
 "There many secret tunnels that you sun dwellers not know of. Only troll "
 "know. We smarter than you think. Zurg would have killed dwarves himself, but "
@@ -4153,12 +4201,12 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2462
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2458
 msgid "The real fighting? I thought that was what we were waist-deep in?"
 msgstr "难道这里不是真正的战斗吗，难道我们这里是在过家家吗？"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2468
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2463
 msgid ""
 "While you fighting, another clan of dwarves sneak around and flank us. They "
 "tricksy like that. We must leave you and run back to defend women and little "
@@ -4172,12 +4220,12 @@ msgstr ""
 "是我们巨魔的秘密武器。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2473
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2468
 msgid "How do you mean?"
 msgstr "秘密武器？"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2478
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2473
 msgid ""
 "Right before battle, we find secret passage just to the north leading "
 "straight to big dwarf stronghold. Hiding in stronghold is big important "
@@ -4196,22 +4244,22 @@ msgstr ""
 "秘道。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2483
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2579
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2478
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2574
 msgid ""
 "Their knowledge of these tunnels is uncanny. I could have sworn a minute ago "
 "that that wall was solid rock."
 msgstr "他们的坑道知识真是太神奇了。我发誓一分钟前那堵墙还只是坚固的石头。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2494
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2489
 msgid ""
 "Wait a moment, Zurg, we must deal with this mysterious cloaked figure before "
 "we can follow you."
 msgstr "泽格，等一下，我们要先料理了这个神秘的戴斗篷者，然后才能跟你走。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2504
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2499
 msgid ""
 "It sounds like our work is not yet done. Very well, gather yourselves "
 "together, we must follow Zurg."
@@ -4219,20 +4267,20 @@ msgstr "看来我们的工作还没有结束。好吧，集合队伍，我们得
 
 #. [event]
 #. [unit]: type=Dwarvish Pathfinder, id=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2530
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:263
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1465
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2525
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:283
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1499
 msgid "Grimnir"
 msgstr "格里姆尼尔"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2544
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2539
 msgid ""
 "Congratulations, some of me boys didn’t think you could beat the trolls."
 msgstr "祝贺你，我手下有些人还以为你们打不退巨魔呢。"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2554
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2549
 msgid ""
 "Don’t think you know all the tunnels and passages that twist through these "
 "caves, elf. I would have killed him myself, but I was just sent back from "
@@ -4242,12 +4290,12 @@ msgstr ""
 "我却从主站场被派了回来。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2559
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2554
 msgid "The front? I thought this was the front."
 msgstr "主战场？我还以为这里就是前线呢。"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2564
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2559
 msgid ""
 "While you were fighting, a separate clan of trolls sneaked around our "
 "sentries and flanked us, attacking our supply depots. There are more of "
@@ -4261,12 +4309,12 @@ msgstr ""
 "过，你们的胜利是个意外的收获啊。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2569
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2564
 msgid "It has?"
 msgstr "有什么？"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2574
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2569
 msgid ""
 "Right before the trolls overran this area of the mines, our scouts had found "
 "an old tunnel south of here that leads almost straight to the main lair of "
@@ -4287,21 +4335,21 @@ msgstr ""
 "远。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2590
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2585
 msgid ""
 "Wait a moment, Grimnir, we must deal with this mysterious cloaked figure "
 "before we can follow you."
 msgstr "格里姆尼尔，等一下，我们要先料理了这个神秘的戴斗篷者，然后才能跟你走。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2600
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2595
 msgid ""
 "It sounds like our work is not yet done. Very well, gather yourselves "
 "together, we must follow Grimnir."
 msgstr "看来我们的工作还没有完成。好吧，行动起来，让我们跟着格里姆尼尔。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2637
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2632
 msgid ""
 "Where did he go? How does he disappear like that? And what in Uria’s name "
 "was he ranting about? Whoever that is is starting to make me get edgy."
@@ -4310,14 +4358,14 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2652
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2647
 msgid ""
 "The cloaked figure is gone. Still, our work is not yet done. Gather "
 "yourselves together; we must follow Zurg."
 msgstr "戴斗篷者消失了。但是我们的工作还没结束。团结起来，我们必须跟着泽格。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2674
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2669
 msgid ""
 "The cloaked figure is gone. Still, our work is not yet done. Gather "
 "yourselves together; we must follow Grimnir."
@@ -4325,9 +4373,9 @@ msgstr ""
 "戴斗篷者消失了。但是我们的工作还没结束。团结起来，我们必须跟着格里姆尼尔。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2700
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1769
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:2013
+#: data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg:2695
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1804
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:2023
 msgid ""
 "Oh no, we took too long and enemy reinforcements have arrived. We’ll surely "
 "be overwhelmed now!"
@@ -4351,45 +4399,45 @@ msgid "Dwarf Ally"
 msgstr "矮人同盟"
 
 #. [objectives]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:183
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:224
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:198
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:235
 #: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:69
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:69
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:68
 msgid "Starting Objectives:"
 msgstr "任务目标:"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:185
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:200
 msgid "Kill troll leader"
 msgstr "击杀巨魔首领"
 
 #. [unit]: type=Troll, id=Troll Interrogator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:280
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:300
 msgid "Troll Interrogator"
 msgstr "巨魔审问者"
 
 #. [unit]: type=Troll Whelp, id=Troll Assistant
 #. [unit]: type=Troll Whelp
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:295
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:323
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:315
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:343
 msgid "Troll Assistant"
 msgstr "巨魔助手"
 
 #. [unit]: type=Troll Whelp, id=Ulg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:309
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:329
 msgid "Ulg"
 msgstr "阿尔戈"
 
 #. [unit]: type=Troll Shaman, role=Troll High Shaman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:340
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:365
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1230
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1264
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:360
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:385
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1260
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1294
 msgid "Troll High Shaman"
 msgstr "萨满长老"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:403
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:423
 msgid ""
 "This passage leads very close to the trolls’ main lair; you can hear them "
 "tromping back and forth just past the eastern wall. All that separates us "
@@ -4406,19 +4454,19 @@ msgstr ""
 "而且非常丑陋。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:408
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:428
 msgid ""
 "I thought that’s what all the trolls looked like. I suppose we’ll just try "
 "to find the one that shouts the loudest."
 msgstr "我想所有的巨魔都长那个样子。我看喊的最大声的那个应该就是他们的首领。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:413
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:433
 msgid "So you dug these tunnels all by yourselves?"
 msgstr "那你们完全自己开掘的这些通道？"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:418
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:438
 msgid ""
 "Long ago, before the damned trolls invaded, we spent our days digging "
 "tunnels all through these mountains. Oh the ore and precious stones we "
@@ -4438,19 +4486,19 @@ msgstr ""
 "个人也答应你，如果你帮我们的忙，你一定会得到丰厚的回报。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:423
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:460
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:443
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:471
 msgid "It shall be done."
 msgstr "我们会把这个完成的。"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:440
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:460
 msgid ""
 "Once you are done moving your people into position, I will blow the charges."
 msgstr "你的人一到达指定位置，我就会启动机关。"
 
 #. [unit]: id=Troll Brute, type=Troll
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:466
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:486
 msgid "Troll Brute"
 msgstr "狂暴巨魔"
 
@@ -4458,34 +4506,34 @@ msgstr "狂暴巨魔"
 #. [unit]: type=Troll
 #. [unit]: type=Troll Rocklobber
 #. [unit]: type=Troll Whelp
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:479
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:482
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:486
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:487
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:490
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1330
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1331
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1332
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1335
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1337
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:179
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:193
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:236
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:250
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:264
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:278
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:292
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:306
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:499
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:502
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:506
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:507
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:510
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1360
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1361
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1362
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1365
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1367
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:178
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:192
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:235
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:249
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:263
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:277
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:291
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:305
 msgid "Troll Guard"
 msgstr "巨魔守卫"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:497
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:517
 msgid "Fire in the hole!"
 msgstr "开火！"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:541
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:561
 msgid ""
 "My work here is done. I must report back to my king. I have many more things "
 "to do before the day is done, but I will return once you finish your "
@@ -4495,34 +4543,34 @@ msgstr ""
 "任务时我就会回来。祝旗开得胜！"
 
 #. [message]: speaker=Troll Guard
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:572
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:592
 msgid "Intruders! Kill them!"
 msgstr "有入侵者！干掉他们！"
 
 #. [unit]: type=Dwarvish Fighter, id=Wounded Dwarf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:605
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:625
 msgid "Wounded Dwarf"
 msgstr "负伤矮人"
 
 #. [message]: speaker=Troll Interrogator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:614
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:634
 msgid "Tell us where your leader is hiding!"
 msgstr "你们的首领藏在哪里！"
 
 #. [message]: speaker=Wounded Dwarf
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:619
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:600
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:639
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:595
 msgid "Never!"
 msgstr "绝不！"
 
 #. [message]: speaker=Troll Assistant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:624
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:644
 msgid "Master, look!"
 msgstr "长官，看！"
 
 #. [message]: speaker=Troll Interrogator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:629
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:649
 msgid ""
 "Hah! You think you can save your friends. You are wrong. Ulg, go kill the "
 "other prisoner. We will deal with these fools."
@@ -4531,34 +4579,34 @@ msgstr ""
 "傻瓜。"
 
 #. [message]: speaker=Ulg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:634
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:654
 msgid "Yes master, I’ll make him suffer."
 msgstr "是的，主人，我会让他痛不欲生的。"
 
 #. [message]: speaker=Wounded Dwarf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:673
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:693
 msgid "Aaahh!"
 msgstr "啊啊啊啊！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:683
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:703
 msgid ""
 "If we move fast we might be able to save the other prisoner before he gets "
 "killed too."
 msgstr "如果我们快点，也许可以救回更多被囚的矮人。"
 
-#. [unit]: type=Dwarvish Stalwart, id=Rogrimir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:694
+#. [unit]: type=Dwarvish Sentinel, type=Dwarvish Stalwart, id=Rogrimir
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:718
 msgid "Rogrimir"
 msgstr "若格瑞莫"
 
 #. [message]: speaker=Ulg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:715
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:739
 msgid "I’m gonna make you squeal, dwarf!"
 msgstr "我会让你痛的尖叫的，小矮子！"
 
 #. [message]: speaker=Rogrimir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:774
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:798
 msgid ""
 "I owe you my life. I can’t believe I was captured when those all around me "
 "died fighting gloriously. I’m so ashamed. I could not protect them... but I "
@@ -4570,12 +4618,12 @@ msgstr ""
 "命来保护你们的。请带我去找巨魔，我要为我的朋友们复仇！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:886
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:911
 msgid "Whoa. This place is hot."
 msgstr "呼。这里真热。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:891
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:916
 msgid ""
 "This cavern is so hot it’s stifling; I can already feel my armor heating up. "
 "If we tarry here too long we’ll roast alive. I don’t even want to think "
@@ -4588,14 +4636,14 @@ msgstr ""
 "穴都加热了。我真感谢巨魔在岩浆上建了一座桥。"
 
 #. [message]: role=Troll High Shaman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:896
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:921
 msgid ""
 "They have broken through the outer guard-line. Destroy the bridge, they must "
 "not pass!"
 msgstr "他们从外围冲进来了，毁掉桥，别让他们通过！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:926
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:951
 msgid ""
 "Uh, I take that back. Still, the trolls don’t seem to be advancing. I guess "
 "they think the lava can hold us back. Well, we’ll show them. It will take "
@@ -4606,37 +4654,45 @@ msgstr ""
 
 # 游戏中双日之下没有出现中文
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:932
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:957
 msgid ""
 "Any unit that ends its turn on a lava hex, except those who can fly over the "
-"lava, will take 25 damage at the beginning of the next turn. This lava "
-"damage can kill units. Flying units will just take $heat_damage damage per "
-"turn when flying over lava, though they too can die if they spend too much "
-"time over it. Also because of the heat in the cavern, all units on cave "
-"floor hexes will take $heat_damage damage at the start of each turn. This "
-"heat damage can reduce a unit to 1 hit point, but it can’t kill it."
+"lava, will take $lava_damage damage at the beginning of the next turn. This "
+"lava damage can kill units. Flying units will just take $heat_damage damage "
+"per turn when flying over lava, though they too can die if they spend too "
+"much time over it."
 msgstr ""
 "除了可以飞越岩浆的单位之外，任何在回合结束时停留在岩浆格子上的单位都会在下一"
-"回合开始时受到25点伤害。岩浆造成的这种伤害可以杀死单位。飞跃岩浆时，飞行单位"
-"每回合只会受到 $heat_damage|点伤害，但如果他们在岩浆上空停留太久，也是会死"
-"的。并且由于洞穴里的高温，所有在洞穴地面格子上的单位每回合开始时都会受到"
-"$heat_damage|点伤害。热量造成的这种伤害可以让单位的生命值减少到1点，但不会致"
-"死。"
+"回合开始时受到$lava_damage|点伤害。这种岩浆伤害可以杀死单位。飞跃岩浆时，飞行"
+"单位每回合只会受到$heat_damage|点伤害，但如果他们在岩浆上空停留太久，也是会死"
+"的。"
+
+#. [message]: speaker=narrator
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:962
+msgid ""
+"Also, because of the heat in the cavern, all units on cave floor hexes will "
+"take $heat_damage damage at the start of each turn. This heat damage can "
+"reduce a unit to 1 hit point, but, unlike the lava damage, the heat damage "
+"can’t kill the unit."
+msgstr ""
+"此外，由于洞穴内的高温，位于洞穴地面六角格上的所有单位在每回合开始时都会受到"
+"$heat_damage|点伤害。这种高温伤害可能会使单位的生命值降至1点，但与熔岩伤害不"
+"同，高温伤害不会直接杀死单位。"
 
 #. [message]: role=Troll High Shaman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:941
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:971
 msgid "Arise! Arise and engulf the intruders in your holy fire!"
 msgstr "起来吧！起来用你们神圣的火焰吞噬这些入侵者！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:951
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:981
 msgid ""
 "What the heck is that? It sure doesn’t look good. The last thing we need in "
 "here is even more fire."
 msgstr "那是什么鬼东西？看起来太糟糕了，我们现在最不缺的东西就是火了。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:972
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1002
 msgid ""
 "There is a small pool of water here. It must come from some spring deep "
 "underground. The water is cool and refreshing. Let me bathe in it a while "
@@ -4647,7 +4703,7 @@ msgstr ""
 
 # 里面的数值源文本没有显示
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:978
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1008
 msgid ""
 "At the start of each turn, any unit currently in this pool will heal 10 "
 "hitpoints and will not be affected by the heat in the cavern. Of course, if "
@@ -4658,46 +4714,46 @@ msgstr ""
 "的影响。不过，如果单位离开了这个池子，他还是会在每回合受到 $temp_damage 点的"
 "高温伤害。"
 
-#. [unit]: type={ON_DIFFICULTY (Fire Guardian) (Fire Guardian2) (Fire Guardian3)}, role=Guardian Phoenix
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1007
+#. [unit]: type={ON_DIFFICULTY4 (Fire Guardian) (Fire Guardian2) (Fire Guardian3) (Fire Guardian2)}, role=Guardian Phoenix
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1037
 msgid "Guardian Phoenix"
 msgstr "凤凰守卫"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1051
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1081
 msgid "That thing just won’t stay dead!"
 msgstr "这东西不安份！"
 
 #. [message]: role=Troll High Shaman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1097
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1127
 msgid "Arise, hallowed guardians, and destroy them!"
 msgstr "起来，神圣的守卫们，摧毁他们！"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1104
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1105
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1108
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1143
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1144
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1146
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1181
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1182
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1184
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1134
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1135
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1138
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1173
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1174
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1176
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1211
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1212
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1214
 msgid "Fire Guardian"
 msgstr "火焰守卫"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1114
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1144
 msgid "Look, more fire guardians!"
 msgstr "看，又有火焰守卫！"
 
 #. [message]: role=Troll High Shaman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1136
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1166
 msgid "Arise and attack them now, while they are vulnerable!"
 msgstr "起来，攻击他们，现在正是时候！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1152
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1182
 msgid ""
 "Oh great, even more fire guardians. When I get through this inferno I’m "
 "going to kill those trolls."
@@ -4706,52 +4762,52 @@ msgstr ""
 "魔。"
 
 #. [message]: role=Troll High Shaman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1174
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1204
 msgid "They must not be allowed to cross to the other side! Kill them!"
 msgstr "绝对不能让他们到对岸来！杀了他们！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1189
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1219
 msgid ""
 "How surprising, more fire guardians. I’m going to be really glad to get out "
 "of this cavern."
 msgstr "太吓人了，这么多火焰守卫。如果让我离开这个洞穴我会很高兴的。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1208
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1238
 msgid "Despite the fire guardians, the elves have almost crossed the lava!"
 msgstr "火焰守卫挡不住他们，精灵已经快要闯过岩浆区了！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1213
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1243
 msgid ""
 "They obviously weren’t enough. You go alert the others and summon "
 "reinforcements. I will hold them off for as long as I can."
 msgstr "看来仅有它们是不够的。你去通知其他人，召集援军。我会尽量拖住他们。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1218
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1248
 msgid "May Griknagh protect you. I’ll be back soon!"
 msgstr "愿格纳福保佑你，我马上回来！"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1255
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1256
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1285
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1286
 msgid "Troll Reinforcements"
 msgstr "巨魔援军"
 
 #. [unit]: type=Great Troll, id=Troll Chieftain
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1292
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1322
 msgid "Troll Chieftain"
 msgstr "巨魔首领"
 
 #. [unit]: type=Troll Shaman, id=High Advisor
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1349
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1379
 msgid "High Advisor"
 msgstr "高阶顾问"
 
 #. [message]: speaker=High Advisor
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1362
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1392
 msgid ""
 "Invade our most holy cavern at your peril. Long have we protected our sacred "
 "burial grounds from your foul kind, and we shall scatter your bones next to "
@@ -4761,33 +4817,33 @@ msgstr ""
 "们这些愚蠢种族的侵扰，我们会用你们的骨头来祭奠我们的祖先。"
 
 #. [message]: speaker=Troll Chieftain
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1367
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1397
 msgid "Destroy the invaders! Make them pay for the murders they have done!"
 msgstr "消灭入侵者！为他们的屠杀偿命！"
 
 #. [message]: speaker=High Advisor
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1390
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1420
 msgid "Arise, our brothers of ages past! Arise and destroy the intruders!"
 msgstr "起来，我们以前的兄弟！再来消灭入侵者！"
 
 #. [message]: speaker=Troll Chieftain
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1431
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1466
 msgid "Argh! Curse you! May you never live to see daylight again!"
 msgstr "啊！我诅咒你们！诅咒你们再也见不到阳光！"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1437
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1620
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1472
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1630
 msgid "And so, at last, it ends."
 msgstr "好了，终于结束了。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1444
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1478
 msgid "Da big troll is dead. Run for your lives!"
 msgstr "大头目死了。逃命！"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1481
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1515
 msgid ""
 "News travels fast. The chaos you have sown has caused the foul trolls to "
 "start retreating. And now the architect of our suffering is dead. This war "
@@ -4805,7 +4861,7 @@ msgstr ""
 "荣耀。精灵杀死了一名巨魔酋长！我们会一直传诵这个故事的。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1486
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1520
 msgid ""
 "With their knowledge of all these secret tunnels, you’d think they could "
 "have led us straight here instead of making us go through those ‘light "
@@ -4817,7 +4873,7 @@ msgstr ""
 "斗。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1491
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1525
 msgid ""
 "Perhaps they wanted to further test our prowess in battle. And besides, "
 "every troll we kill is one they don’t have to. Still, I think we caused a "
@@ -4827,7 +4883,7 @@ msgstr ""
 "个敌人。而且，我想我们引起的混乱已经超出了他们的预期。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1496
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1530
 msgid ""
 "Shhhh, you two. Yes, of course, we would be honored to come and meet your "
 "king. But first, we left many of our people back up near the entrance to the "
@@ -4839,7 +4895,7 @@ msgstr ""
 "都还不安全。你们能帮我把族人带去安全的地方吗？"
 
 #. [message]: speaker=Grimnir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1501
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1535
 msgid ""
 "Hmmmm, yes, after what you have done, I think I could arrange something. We "
 "have a few larger halls that should hold your people, a bit cramped, but "
@@ -4854,7 +4910,7 @@ msgstr ""
 "的地方的。我们也不想出现任何意外。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1506
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1540
 msgid ""
 "You are full of surprises. But I feel better knowing a few of your kind were "
 "watching out for the rest of my people. All right everyone, no celebrating "
@@ -4864,18 +4920,18 @@ msgstr ""
 "是庆祝的时候，我们还有事要做！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1539
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1573
 msgid "It’s cooler here, there seems to be a draft to the west."
 msgstr "那里更冷，似乎西边有一个筏子。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1547
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1618
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1581
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1652
 msgid "Dwarf Ghost"
 msgstr "矮人幽灵"
 
 #. [message]: speaker=Dwarf Ghost
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1557
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1591
 msgid ""
 "Hail, friend. Ages ago, I too fought the trolls and came to this place. But "
 "by ill luck I was burned to death by the lava and died nearby unblessed and "
@@ -4887,7 +4943,7 @@ msgstr ""
 "让你们通过。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1584
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1618
 msgid ""
 "Look, a crumbling skeleton. I think this might be the body of the dwarven "
 "ghost. It shouldn’t take long to dig a shallow grave."
@@ -4896,7 +4952,7 @@ msgstr ""
 "墓吧。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1600
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1634
 msgid ""
 "May Eloh, or whatever god you worship, grant you peace and safe passage to "
 "the afterlife. We will avenge your death."
@@ -4904,7 +4960,7 @@ msgstr ""
 "愿伊洛，或者其他你信奉的神，赐予你安宁，让你死后安乐。我们会为你报仇的。"
 
 #. [message]: speaker=Dwarf Ghost
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1625
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1659
 msgid ""
 "Thank you. You have done for me what all my dwarven kin never could. I will "
 "no longer block your way. I leave now for the halls of my ancestors..."
@@ -4913,20 +4969,20 @@ msgstr ""
 "你们。我要随祖先而去了……"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1645
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2358
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1679
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2368
 msgid "Crypt Guardian"
 msgstr "地穴守卫"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1658
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1692
 msgid ""
 "This looks like a troll crypt. Whoever it was must have been very important, "
 "because they have their own undead guardian."
 msgstr "看起来是巨魔的房间。这似乎不重要，毕竟它们都沦为亡灵。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1679
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1713
 msgid ""
 "There is a chasm here cutting off the end of the crypt. It must be rather "
 "recent; the edges are still raw and crumbling. It cuts off the path leading "
@@ -4936,7 +4992,7 @@ msgstr ""
 "隔了去对面那个华丽的石棺的路。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1704
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1738
 msgid ""
 "For a troll this is quite an ornate tomb. The coffin itself is quite "
 "impressive. Inside, the skeleton has crumbled to dust and there are a few "
@@ -4951,30 +5007,30 @@ msgstr ""
 "得在旅程结束之前或许能用得上它。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1706
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1740
 msgid "It might be useful, I’ll take it."
 msgstr "它应该会有用的——我要带上它。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1714
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1748
 msgid ""
 "The wand fits comfortably in my hand. It doesn’t seem to have much of a "
 "range, but in close combat it could be quite useful."
 msgstr "这个魔杖我拿着很顺手啊。它似乎打得不远，但是用来近战还不错。"
 
 #. [object]: id=Troll Wand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1723
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1757
 msgid "Emerald Wand of Poison"
 msgstr "剧毒翡翠魔杖"
 
 #. [object]: id=Troll Wand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1724
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1758
 msgid "This wand makes this unit’s melee attacks deal poison damage."
 msgstr "这根魔杖使这个单位的近身攻击附带给敌人毒素伤害。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1744
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1985
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg:1778
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1995
 msgid "On second thought, it’s better to leave the dead in peace."
 msgstr "想了想，还是让死者安息比较好。"
 
@@ -4987,8 +5043,8 @@ msgstr "矮人地界"
 #. [side]: type=Dwarvish Lord, id=Dwarf Chieftain
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:48
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:87
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:129
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:161
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:133
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:165
 msgid "Enemies"
 msgstr "敌人"
 
@@ -4996,49 +5052,51 @@ msgstr "敌人"
 #. [side]: id=King Thurongar, type=Dwarvish Lord
 #. [side]: id=Great Leader Darmog, type=Great Troll
 #. [side]: id=Melusand, type=Mermaid Diviner
+#. [modify_side]
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:73
 #: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:52
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:53
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:52
 #: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:50
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1205
 msgid "Allies"
 msgstr "同盟"
 
 #. [side]: type=Dwarvish Lord, id=Dwarf Chieftain
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:143
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:147
 msgid "Dwarf Chieftain"
 msgstr "矮人领主"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:226
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:237
 msgid "Kill dwarf chieftain"
 msgstr "击杀矮人酋长"
 
 #. [unit]: type=Dwarvish Steelclad, id=Dwarf Sergeant
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:321
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:493
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:332
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:504
 msgid "Dwarf Sergeant"
 msgstr "矮人军士"
 
 #. [unit]: type=Dwarvish Fighter, id=Vengeful Dwarf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:339
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:350
 msgid "Vengeful Dwarf"
 msgstr "复仇的矮人"
 
 #. [unit]: type=Dwarvish Stalwart, id=East Scout
 #. [unit]: type=Dwarvish Stalwart, id=West Scout
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:358
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:383
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:369
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:394
 msgid "Dwarf Scout"
 msgstr "矮人哨兵"
 
 #. [unit]: type=Troll, id=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:421
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:432
 msgid "Grog"
 msgstr "果洛格"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:445
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:456
 msgid ""
 "This amazing tunnel, it leads very close to dwarves’ main lair. You can hear "
 "their tiny footsteps just on other side of wall. All that separates us from "
@@ -5055,12 +5113,12 @@ msgstr ""
 "比其他矮人还要丑。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:450
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:461
 msgid "Did you dig these tunnels all by yourselves?"
 msgstr "这些坑道是你们挖的吗？"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:455
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:466
 msgid ""
 "No, most are tiny dwarf tunnels. We like natural tunnels, big and tall "
 "enough for mighty trolls. When the world was young, Griknagh cut many "
@@ -5082,7 +5140,7 @@ msgstr ""
 "并杀死矮人首领，我们会好好答谢你们的。"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:477
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:488
 msgid "Once you done moving into position, Zurg will destroy wall."
 msgstr "一旦你靠近了那个位置，泽格就会打通那面墙。"
 
@@ -5091,27 +5149,27 @@ msgstr "一旦你靠近了那个位置，泽格就会打通那面墙。"
 #. [unit]: type=Dwarvish Steelclad
 #. [unit]: type=Dwarvish Berserker
 #. [unit]: type=Dwarvish Dragonguard
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:497
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:498
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:500
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:501
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:507
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:508
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:509
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:511
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:512
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:513
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1160
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1161
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1162
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1164
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1165
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1166
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1169
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:518
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:519
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:520
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:522
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:523
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:524
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1171
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1172
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1173
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1175
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1176
 #: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1177
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1179
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1180
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1182
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1184
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1188
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1190
 #: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:181
 #: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:195
 #: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:209
@@ -5126,12 +5184,12 @@ msgid "Dwarf Guard"
 msgstr "矮人守卫"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:520
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:531
 msgid "Fist and fire, crumble stone!"
 msgstr "火与拳之力，石头——击碎！"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:560
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:571
 msgid ""
 "My work here is done. Zurg must report back to Great Leader. Many things to "
 "do and dwarves to kill before rest. Zurg return later to see how little "
@@ -5141,12 +5199,12 @@ msgstr ""
 "呢。泽格很快就会回来看看亲爱的小精灵们做得怎样。祝你们胜利！"
 
 #. [message]: speaker=Dwarf Guard
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:588
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:599
 msgid "Intruders! Sound the alarm!"
 msgstr "入侵者！敲响警报！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:602
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:613
 msgid ""
 "Zurg must have collapsed the tunnel. Perhaps he didn’t want to give the "
 "dwarves an easy access route if they defeated us. So much for an escape "
@@ -5156,39 +5214,39 @@ msgstr ""
 "就只有一条逃生通道，我猜我们仅仅需确保不会失败。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:636
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:637
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:640
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:647
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:648
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:651
 msgid "Dwarf Conscript"
 msgstr "矮人新兵"
 
 #. [message]: speaker=Dwarf Sergeant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:645
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:656
 msgid "Do you know what the first task of any dwarven warrior is, runt?"
 msgstr "小子们，你们知道作为一位矮人武士的第一个考验是什么吗？"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:650
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:661
 msgid "Sir?"
 msgstr "先生？"
 
 #. [message]: speaker=Dwarf Sergeant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:655
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:666
 msgid "Constant vigilance, boys; the enemy could be anywhere!"
 msgstr "是时刻警戒，孩子；敌人可能出现在任何地方！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:660
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:671
 msgid "But sir—"
 msgstr "但是，长官——"
 
 #. [message]: speaker=Dwarf Sergeant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:665
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:676
 msgid "Did I give you permissions to speak? Did I?"
 msgstr "我让你说话了吗？啊？"
 
 #. [message]: speaker=Dwarf Sergeant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:670
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:681
 msgid ""
 "I was killing trolls when you were in swaddling clothes. I wrote the book on "
 "killing trolls. And you’re not going anywhere until I’m done with you."
@@ -5198,12 +5256,12 @@ msgstr ""
 
 #. [message]
 #. "you" is singular and referring to a superior officer
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:676
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:687
 msgid "But sir, behind you...!"
 msgstr "但是长官，您背后……！"
 
 #. [message]: speaker=Dwarf Sergeant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:681
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:692
 msgid ""
 "Oh let me guess, a big nasty troll, right? And when I turn around you flee "
 "like the cowards you are. Do you think I’m stupid enough to fall for that "
@@ -5213,23 +5271,23 @@ msgstr ""
 "小杂种就跑了。以为我那么傻么？"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:690
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:701
 msgid "No, it’s an elf!"
 msgstr "不，它是个精灵！"
 
 #. [message]: id=Dwarf Sergeant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:700
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:770
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:711
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:781
 msgid "What...?! Right... First task, boys, kill the intruder!"
 msgstr "什么？！好吧，首要任务，兄弟们，杀死这个入侵者！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:707
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:718
 msgid "I’m too young to die, save me!"
 msgstr "我还很年轻，我不想死，救我！"
 
 #. [message]: speaker=Dwarf Sergeant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:717
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:728
 msgid ""
 "Oh, grow a backbone... Huh? Hey, for once the runt was telling the truth. "
 "Come on, boys, kill the intruder!"
@@ -5237,53 +5295,53 @@ msgstr ""
 "噢，有点骨气好不好……哈？嘿，这个小子说得是真的。来吧，孩子们，杀了入侵者！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:724
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:735
 msgid "No, it’s a... human?"
 msgstr "不，这是……人类？"
 
 #. [message]: speaker=Dwarf Sergeant
 #. the human is female (Elyssa), but even if gender matters then the speaker is probably already speaking while turning to see her
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:735
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:746
 msgid "What is a human doing here? Come on, boys, kill the intruder!"
 msgstr "人类来这儿干啥？上啊，兄弟们，杀死入侵者！"
 
 #. [message]
 #. "it" is referring to the dust devil
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:743
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:754
 msgid "No, it’s a... what is that?"
 msgstr "不，这是……这是啥？"
 
 #. [message]: speaker=Dwarf Sergeant
 #. 'earth’s guts' references the underground. What is being talked about is the dust devil.
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:754
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:765
 msgid "What in the earth’s guts is that? Kill it!"
 msgstr "这到底是啥鬼？杀掉它！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:760
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:771
 msgid "No, look behind you!"
 msgstr "不，注意背后！"
 
 #. [message]: speaker=unit
 #. "Sarge" is short for "Sergeant". This is intended to be a funny death message.
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:793
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:804
 msgid "I love you, Sarge..."
 msgstr "我爱你，军士……"
 
 #. [message]: speaker=Vengeful Dwarf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:910
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:921
 msgid ""
 "Ha, you’re trapped. I’ve got you right where I want you, and this time no "
 "one is gonna save you."
 msgstr "啊，你跑不了了。要抓住你是易如反掌，这回可没有人会来救你。"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:916
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:927
 msgid "How did a troll get stuck all the way back here?"
 msgstr "巨魔怎么会被困在这里？"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:939
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:950
 msgid ""
 "Thank you. Grog got lost and there were so many smelly dwarves. If you "
 "hadn’t come Grog would have been killed. Grog owes you his life."
@@ -5293,34 +5351,34 @@ msgstr ""
 
 #. [message]: speaker=East Scout
 #. [message]: speaker=West Scout
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:976
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1061
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:987
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1072
 msgid "Here they come! Blow the charges!"
 msgstr "他们来了！打开机关！"
 
 #. [message]: speaker=East Scout
 #. [message]: speaker=West Scout
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1011
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1111
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1022
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1122
 msgid "They’re coming this way too! Blow the charges!"
 msgstr "他们也来了！打开机关！"
 
 #. [message]: speaker=East Scout
 #. [message]: speaker=West Scout
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1031
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1131
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1042
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1142
 msgid ""
 "What?! Nothing happened! Who rigged the darn charges anyway? I’m going to "
 "have to hold them off by myself."
 msgstr "什么？！什么也没发生！这机关是那个臭小子布置的？我只好亲自去打开它了。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1157
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1168
 msgid "Jorgi"
 msgstr "乔吉"
 
 #. [message]: speaker=Jorgi
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1184
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1195
 msgid ""
 "It was a mistake to depend on trickery. We will defeat you fighting face to "
 "face. A true dwarf always looks his opponent in the eye when he kills him!"
@@ -5329,21 +5387,21 @@ msgstr ""
 "视他的眼睛！"
 
 #. [message]: speaker=Jorgi
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1189
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1200
 msgid ""
 "So I challenge you, man to man. If you are not cowards, step out onto these "
 "bridges and meet your fate!"
 msgstr "我要挑战你，一对一。如果你不是个懦夫，那就到桥上来接受命运的审判吧！"
 
 #. [message]: speaker=Jorgi
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1227
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1238
 msgid ""
 "I couldn’t do it. Blow the backup charges! If we can’t stop them then maybe "
 "the black lake will."
 msgstr "我失败了。启动备用机关！我们不能阻止他们，但也许黑湖可以阻断他们。"
 
 #. [message]: speaker=Jorgi
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1269
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1280
 msgid ""
 "They’ve crossed the chasm! Blow the backup charges! If we can’t stop them "
 "then maybe the black lake will."
@@ -5351,7 +5409,7 @@ msgstr ""
 "他们已经越过峡谷了！启动备用开关！我们不能阻止他们，但也许黑湖可以阻断他们。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1293
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1304
 msgid ""
 "It’s a huge underground lake. The water looks dark and deep and is cold to "
 "the touch. There also seems to be some glowing moss on the walls which "
@@ -5361,33 +5419,33 @@ msgstr ""
 "植物，我们可以清楚地分辨出洞的大小。"
 
 #. [unit]: id=Extra Hairy Bat, type=Dread Bat
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1311
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1322
 msgid "Extra Hairy Bat"
 msgstr "毛特多蝙蝠"
 
 #. [unit]: type=Dwarvish Stalwart, id=Dwarf Hermit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1344
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1355
 msgid "Dwarf Hermit"
 msgstr "矮人隐居者"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1377
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1388
 msgid ""
 "Incoming! Ugh, it’s big, hairy, and nasty. I hate bats, I really hate bats."
 msgstr "有情况！啊，又大毛又多，还很脏。我讨厌蝙蝠，相当讨厌。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1392
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1402
 msgid "Graaawk!"
 msgstr "格拉克！"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1398
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1408
 msgid "Good riddance."
 msgstr "太好了。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1423
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1433
 msgid ""
 "The ledge just drops off here. The water might be shallow enough to wade "
 "across, but I think I vaguely see something moving underneath the surface. "
@@ -5397,49 +5455,49 @@ msgstr ""
 "到有什么东西从水里游过，希望那只是条鱼，可我有种不好的预感。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1486
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1496
 msgid "What are those?!"
 msgstr "那些是啥？！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1494
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1504
 msgid "Here come more of them!"
 msgstr "好多！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1527
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1537
 msgid ""
 "The movement under the water has stopped. I think we killed the last of "
 "them. Whatever ‘them’ was."
 msgstr "水里没有动静了。不管那是什么东西，我想我们应该把它们都杀光了。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1570
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1572
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1575
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1577
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1578
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1580
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1582
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1585
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1587
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1588
 msgid "Dwarf High Guard"
 msgstr "矮人高阶守卫"
 
 #. [message]: speaker=Dwarf Chieftain
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1596
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1606
 msgid "So you’ve come at last. Let it end, here and now!"
 msgstr "你们最终还是来了。就在这里做个了断吧！"
 
 #. [message]: speaker=Dwarf Chieftain
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1614
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1624
 msgid ""
 "Faugh! Even in death I curse you! You will never escape these tunnels alive!"
 msgstr "呸！我做鬼也不会放过你们！我诅咒你们永远都不能活着离开这些地道！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1629
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1639
 msgid "The chieftain has fallen! Flee for your lives!"
 msgstr "领主倒下了！逃命啊！"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1666
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1676
 msgid ""
 "Little elves fight good. Zurg impressed. With dwarf chieftain dead, cowardly "
 "dwarves flee before us. Our struggle not over, still much more fighting, but "
@@ -5454,7 +5512,7 @@ msgstr ""
 "要和你谈谈，他要奖赏你们。请跟我来。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1671
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1681
 msgid ""
 "With their knowledge of all these secret tunnels, you’d think they could "
 "have led us straight here instead of making us go through those ‘light "
@@ -5465,7 +5523,7 @@ msgstr ""
 "那个所谓的“薄弱防线”。如果我们能直接接近矮人首领，可以省去很多不必要的战斗。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1676
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1686
 msgid ""
 "Perhaps they wanted to further test our prowess in battle. And besides, "
 "every dwarf we kill is one they don’t have to. Still, I think we caused a "
@@ -5475,7 +5533,7 @@ msgstr ""
 "敌人。我想我们造成的混乱超乎他们的预期。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1681
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1691
 msgid ""
 "Shh, you two. Yes, of course, we would be honored to come and meet the Great "
 "Leader. But first, we left many of our people back up near the entrance to "
@@ -5487,7 +5545,7 @@ msgstr ""
 "在不安全。你们能帮我把我的同胞们带到安全的地方吗？"
 
 #. [message]: speaker=Zurg
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1686
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1696
 msgid ""
 "Hmm, yes, yes we can help. We have a few big caves you little people can "
 "stay in, and I get some big trolls to help escort you there. The Great "
@@ -5499,15 +5557,15 @@ msgstr ""
 "人躲在哪儿，我们会把他们带到我们的洞穴里去。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1691
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1701
 msgid ""
 "I thank you. Come on people, no celebrating yet, we still have work left to "
 "do!"
 msgstr "谢谢你。来吧伙计们，现在还不是庆祝的时候，我们还有许多事要做！"
 
 #. [message]: speaker=Dwarf Hermit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1725
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1747
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1735
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1757
 msgid ""
 "They’ve come for my precious. It’s mine, yes it is. They shan’t have it, no "
 "they shan’t. We shall kill them all, yes, yes we will."
@@ -5516,12 +5574,12 @@ msgstr ""
 "到。我们要把他们全杀了，杀了他们。"
 
 #. [message]: speaker=Dwarf Hermit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1763
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1773
 msgid "Curse them! We hates them!"
 msgstr "诅咒他们！我们恨他们！"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1769
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1779
 msgid ""
 "What’s this? His clothes were in rags, and yet he had this ancient jeweled "
 "amulet hanging around his neck. It contains a huge amethyst that seems to "
@@ -5532,7 +5590,7 @@ msgstr ""
 "紫水晶，一道淡淡的紫光环绕着那水晶。他从哪里弄来这么个东西的？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1778
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1788
 msgid ""
 "Hey, wait a minute, that amulet glows the same color as this rune. Maybe if "
 "I put the amulet on and step into the rune..."
@@ -5541,24 +5599,24 @@ msgstr ""
 "看……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1798
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1808
 msgid ""
 "Whoa. That was pretty impressive. The amulet stopped glowing and the rune is "
 "gone, but what have they revealed?"
 msgstr "哇，太神奇了。护身符不发光了，魔法阵也不见了，怎么回事？"
 
 #. [message]: speaker=Smaller Tentacle
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1858
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1868
 msgid "<i>Splash! Splash!</i>"
 msgstr "<b>哗！哗！</b>"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1864
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1874
 msgid "More tentacles?! What, did that thing have a baby?"
 msgstr "这么多触手？！怎么，难道这玩意儿还会生孩子？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1884
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1894
 msgid ""
 "What in Eloh’s name is this? Someone has carved a glowing purple rune in the "
 "floor at the end of this passage. It must be magical. And this passage ends "
@@ -5570,7 +5628,7 @@ msgstr ""
 "么坚固。谁为什么刻了这个魔法阵？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1909
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1919
 msgid ""
 "The rune is still there, glowing mysteriously. I still have no idea why it "
 "was put here, but it’s obviously powerful and magical, a combination of "
@@ -5580,7 +5638,7 @@ msgstr ""
 "有着强大的法力，我弄不清它是由什么组成的。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1940
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1950
 msgid ""
 "Based on the runes covering the walls this must be the tomb of some ancient "
 "dwarf. The tomb seems empty except for this ornate stone coffin. The "
@@ -5598,12 +5656,12 @@ msgstr ""
 "失去它吧。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1942
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1952
 msgid "I fear no ghosts, I’ll take it."
 msgstr "我不怕幽灵，让我把它拿走。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1950
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1960
 msgid ""
 "The belt fits perfectly! Somehow I feel stronger and tougher. This is too "
 "easy, there seem to have been no traps set upon the coffin. Today’s my lucky "
@@ -5613,28 +5671,28 @@ msgstr ""
 "置任何陷阱。今天是我的幸运日。"
 
 #. [object]: id=DwarvenBelt
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1961
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1971
 msgid "Dwarven Belt"
 msgstr "矮人腰带"
 
 #. [object]: id=DwarvenBelt
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1962
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1972
 msgid ""
 "The maximum hit points of the unit who wears this belt will increase by 12."
 msgstr "穿戴这个腰带的单位的最大输出伤害点数将增加12点。"
 
 #. [command]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1970
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1980
 msgid "Angry Ghost"
 msgstr "生气的幽灵"
 
 #. [message]: speaker=Angry Ghost
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1974
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1984
 msgid "You who disturb my rest, come and join me in death!"
 msgstr "你们打扰我休息，那就来和我们做伴吧！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1979
+#: data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg:1989
 msgid "Then again, maybe I spoke too soon."
 msgstr "看来，我又说错话了。"
 
@@ -5650,7 +5708,7 @@ msgstr "瑟荣阁国王"
 
 #. [objective]: condition=win
 #: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:71
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:71
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:70
 msgid "Choose a unit to take the Fire Blade"
 msgstr "选择一个单位来取走烈火刃"
 
@@ -5674,17 +5732,17 @@ msgstr ""
 "板，一条光滑的地砖铺成的小路指引着来访者走到王座前面的一个小石椅边。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:333
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:332
 msgid "Hail Kaleh, I am Thurongar, King of the Dwarves."
 msgstr "你好，卡勒。我是瑟荣阁，矮人之王。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:338
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:337
 msgid "I am Kaleh, leader of the Quenoth Elves."
 msgstr "我是卡勒，奎诺精灵领导人。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:343
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:342
 msgid ""
 "I’ve heard of your recent exploits against the troll menace. They’ve been "
 "quite a thorn in our side for a while now. They used to be just an "
@@ -5701,7 +5759,7 @@ msgstr ""
 "来地底下干什么？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:348
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:347
 msgid ""
 "It’s a long story, but we come from the south, where we lived in the desert. "
 "Our village was destroyed, and I am leading my people on a journey to find a "
@@ -5716,7 +5774,7 @@ msgstr ""
 "了这里。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:353
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:352
 msgid ""
 "Interesting. We’d offer to let you live with us, but I’m afraid we don’t "
 "have much free space; this city is almost filled to capacity. And looking at "
@@ -5728,7 +5786,7 @@ msgstr ""
 "它什么地方为你们安排了个新家。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:358
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:357
 msgid ""
 "Indeed, although I admire this great city you have carved from the rock, I "
 "think many of my people find these tunnels scary and alien. All we really "
@@ -5739,7 +5797,7 @@ msgstr ""
 "同胞都对这些坑道感到陌生与害怕。我们现在只想找到一条通向山脉北侧地面的路。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:363
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:362
 msgid ""
 "That I may be able to help you with. We haven’t sent anyone to the surface "
 "in years, but we do know of a passage that leads to the ancient northern "
@@ -5754,7 +5812,7 @@ msgstr ""
 "是都一去不回。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:375
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:374
 msgid ""
 "But dwarves are excellent delvers, and we keep meticulous maps of all the "
 "tunnels we have explored. We should still have maps of the tunnels leading "
@@ -5766,7 +5824,7 @@ msgstr ""
 "你们到地面上去。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:382
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:381
 msgid ""
 "But dwarves are excellent delvers, and we keep meticulous maps of all the "
 "tunnels we have explored. We should still have maps of the tunnels leading "
@@ -5778,14 +5836,14 @@ msgstr ""
 "到地面上去。"
 
 #. [message]: speaker=Rogrimir
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:396
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:395
 msgid ""
 "You saved my life and my debt to you is still unpaid. Showing you the way to "
 "the surface and protecting you is the least I can do."
 msgstr "你救了我的命，我欠你的还没还清。我愿意做你的向导并且保护你。"
 
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:401
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:400
 msgid ""
 "You rescued my brother, and though he died fighting, he died a warrior’s "
 "death instead of a coward’s. For that I thank you. I will take his place and "
@@ -5795,7 +5853,7 @@ msgstr ""
 "是一个懦夫。你给他这个机会，我谢谢你们。我会替他帮助你们回到地面的。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:408
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:407
 msgid ""
 "You did a great service for my brothers. In exchange, as much as I hate the "
 "light, I am the one who knows the upper tunnels the best, so I’ll be your "
@@ -5805,7 +5863,7 @@ msgstr ""
 "些上层的通道的矮人之一，我愿意成为你们的向导。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:423
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:422
 msgid ""
 "Thank you very much for your help. We were worried about getting lost in all "
 "these twisting tunnels. And we would be honored to have you come with us, "
@@ -5815,7 +5873,7 @@ msgstr ""
 "和我们同行。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:430
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:429
 msgid ""
 "Thank you very much for your help. We were worried about getting lost in all "
 "these twisting tunnels. And we would be honored to have you come with us, "
@@ -5825,13 +5883,13 @@ msgstr ""
 "们同行。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:443
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:442
 msgid ""
 "The dwarves who fought by your side have come to pay their respects as well."
 msgstr "曾和你们一起作战的矮人们也会来向你们表示他们的敬意。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:448
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:447
 msgid ""
 "You helped us strike a huge blow against those savages and it was an honor "
 "to fight by your side. You are the bravest elves we have ever known. We’d "
@@ -5844,8 +5902,8 @@ msgstr ""
 "不过在地底的时候，你们会需要我们的支援。你放心，我们一定会杀光所有的巨魔。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:453
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:446
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:452
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:445
 msgid ""
 "I understand. Thank you, you were a huge help to us. It was an honor to "
 "fight by your side."
@@ -5853,21 +5911,21 @@ msgstr ""
 "我明白。谢谢。你们的帮忙一直发挥着重大作用。和你们一起作战是我们的光荣。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:466
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:459
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:465
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:458
 msgid "I’m afraid, Kaleh, that the time has come for our paths to separate."
 msgstr "卡勒，很抱歉，恐怕到了我们分道扬镳的时候了。"
 
 #. [message]: speaker=Kaleh
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:471
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:464
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2072
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:470
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:463
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2082
 msgid "What?!"
 msgstr "什么？！"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:477
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:476
 msgid ""
 "I have learned a lot about the dwarves in my time here, and yet there’s so "
 "much more to learn. Have you seen their forges? They really know how to work "
@@ -5885,13 +5943,13 @@ msgstr ""
 "矮人，会发生什么呢！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:482
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:474
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:481
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:473
 msgid "But we need you! What would we do without you?"
 msgstr "但是我们需要你！没有你我们该怎么办？"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:487
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:486
 msgid ""
 "With the help of the dwarves, I think you will do just fine. I don’t know "
 "what home your god has planned for you, Kaleh, but I believe in you, and I "
@@ -5903,26 +5961,26 @@ msgstr ""
 "里，在矮人这里。你们并不需要我，你们可以彼此扶助。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:492
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:484
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:491
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:483
 msgid ""
 "If your mind is set, then I won’t try to convince you. But we will miss you."
 msgstr "既然你心意已决，那我就不再强求了。但是，我们会想念你的。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:497
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:489
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:496
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:488
 msgid "I thank Eloh for the brief time that she has let you spend with us."
 msgstr "衷心感谢伊洛，让我们能和你度过这段时光。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:502
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:494
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:501
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:493
 msgid "You take care of yourself, and someday maybe we’ll meet again."
 msgstr "保重自己，也许我们某天会再次相逢。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:507
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:506
 msgid ""
 "Thank you. And I owe you so much for helping me meet the dwarves. I never "
 "would have come down here myself. With some help from the dwarves I have "
@@ -5935,27 +5993,27 @@ msgstr ""
 "助你们驱逐敌人。我把这把寄托着我的感激之情的剑送给你们。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:514
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:506
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:513
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:505
 msgid "A flaming sword. That’s amazing. I just don’t know who should use it."
 msgstr "一把燃烧的剑。太神奇了。我只是不知道该让谁来用它。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:519
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:511
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:518
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:510
 msgid "I will let you decide; use it in the best way that you see fit."
 msgstr "我想让你决定，寻找最好的方式来利用它。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:524
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:516
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:523
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:515
 msgid ""
 "You can choose which unit you want to take the flaming sword. If you want "
 "another unit to wield the sword, Kaleh can recruit or recall other units."
 msgstr "选择单位持起烈火剑。如果需要，卡勒可以征募或召回其他人。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:545
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:544
 msgid ""
 "And now I think you should be off as soon as possible. The trolls have "
 "retreated into their holes for the present, but who knows when they will "
@@ -5964,42 +6022,42 @@ msgstr ""
 "现在我想你应该尽快离开了。巨魔退回了洞穴，但谁知道它们什么时候会再来进攻呢。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:550
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:623
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:611
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:549
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:622
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:610
 msgid ""
 "This is a marvelous city, but I for one can’t wait to feel the sun upon my "
 "face again and the wind in my hair."
 msgstr "这是座伟大的城市，但是我个人更希望能沐浴在阳光和清风之中。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:581
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:573
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:580
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:572
 msgid "Should I take this sword?"
 msgstr "我该拿这把剑吗？"
 
 #. [object]: id=FlamingSword
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:597
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:589
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:596
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:588
 msgid "Flaming Sword"
 msgstr "烈火剑"
 
 #. [object]: id=FlamingSword
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:598
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:590
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:597
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:589
 msgid "This sword will make all your melee attacks do fire damage."
 msgstr "这把剑使您的近战攻击造成火焰伤害。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:613
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:601
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:612
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:600
 msgid ""
 "I will wield this blade proudly, and whenever I look upon it I shall "
 "remember you, Elyssa."
 msgstr "我会自豪的挥舞这利刃，看到它，我会想起你，伊丽莎。"
 
 #. [message]: speaker=King Thurongar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:618
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:617
 msgid ""
 "And now I think you should be off as soon as possible. The trolls have "
 "retreated back into their holes for the present, but who knows when they "
@@ -6007,8 +6065,8 @@ msgid ""
 msgstr "现在我想你应该尽快离开了。巨魔退回了洞穴，但不知什么时候会再来进攻。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:643
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:629
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg:642
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:628
 msgid "No, I think someone else should wield it."
 msgstr "不，我想应该换别人使用它。"
 
@@ -6023,19 +6081,19 @@ msgid "Great Leader Darmog"
 msgstr "大首领大摩格"
 
 #. [unit]: type=Troll, id=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:160
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:159
 msgid "Nog"
 msgstr "诺格"
 
 #. [unit]: type=Troll Shaman, id=Spiritual Advisor
 #. [unit]: type=Troll Shaman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:208
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:222
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:207
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:221
 msgid "Spiritual Advisor"
 msgstr "圣言者"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:325
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:324
 msgid ""
 "It is clear that this chamber used to be quite ornately decorated, but "
 "almost all of it has been destroyed, revealing a stone and dirt floor. What "
@@ -6054,17 +6112,17 @@ msgstr ""
 "没有被破坏。它连着一张小石椅，对面是巨大的王座。"
 
 #. [message]: speaker=Great Leader Darmog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:331
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:330
 msgid "I, Great Leader Darmog, greet you, Kaleh."
 msgstr "我，大首领大摩格，向你致意，卡勒。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:336
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:335
 msgid "I Kaleh, leader of the Quenoth Elves, thank you for meeting with me."
 msgstr "我卡勒，奎诺精灵的领袖，感谢您接见我。"
 
 #. [message]: speaker=Great Leader Darmog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:341
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:340
 msgid ""
 "On behalf of all trolls, Darmog thank you for great victory over the "
 "dwarves. You have helped drive back the nasty dwarves and given us time to "
@@ -6082,7 +6140,7 @@ msgstr ""
 "我们要让矮人不得安宁，直到他们全部死绝！"
 
 #. [message]: speaker=Spiritual Advisor
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:346
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:345
 msgid ""
 "But I am curious, we do not know of your kind. We thank you for your help, "
 "but who are you and why do you come down here with so many of your people?"
@@ -6091,7 +6149,7 @@ msgstr ""
 "是谁，你为什么带这么多人来这里？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:351
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:350
 msgid ""
 "It’s a long story, but we come from the south, where we lived above ground "
 "in the desert. Our village was destroyed, and I am leading my people on a "
@@ -6107,7 +6165,7 @@ msgstr ""
 "住，我们只想找一条通向山那边的道路。"
 
 #. [message]: speaker=Great Leader Darmog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:356
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:355
 msgid ""
 "Darmog has never been above ground, but Darmog understand your story. A "
 "leader must protect and care for his people. Every people deserve to find "
@@ -6117,7 +6175,7 @@ msgstr ""
 "人民。每一个人都应该找到他的家。我们会尽可能帮助你们。"
 
 #. [message]: speaker=Spiritual Advisor
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:368
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:367
 msgid ""
 "We may be able to help you find a way back to the sunlit lands. In our "
 "temples we do keep records of the past. We have not walked above the earth "
@@ -6135,7 +6193,7 @@ msgstr ""
 "地面上去。"
 
 #. [message]: speaker=Spiritual Advisor
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:375
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:374
 msgid ""
 "We may be able to help you find a way back to the sunlit lands. In our "
 "temples we do keep records of the past. We have not walked above the earth "
@@ -6153,7 +6211,7 @@ msgstr ""
 "面上去。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:389
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:388
 msgid ""
 "You saved Grog’s life. Grog still owe you a debt of thanks. In return Grog "
 "will protect little elves and show them the way back to lighted lands."
@@ -6162,7 +6220,7 @@ msgstr ""
 "地面上去。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:394
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:393
 msgid ""
 "You rescued Nog’s brother, and he died like a warrior in battle, not like a "
 "coward in chains. Nog is very grateful. You proved yourselves to be brave "
@@ -6172,7 +6230,7 @@ msgstr ""
 "激你们。你们证明了自己是非常勇敢的强大的战士。诺格会帮助你们找到回地面的路。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:401
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:400
 msgid ""
 "You did trolls big service. Nog like to wander in tunnels, and Chief say "
 "that he knows the upper tunnels the best. Nog want to help elves so even "
@@ -6183,7 +6241,7 @@ msgstr ""
 "了。虽说不想脱离战斗，但诺格也想帮助精灵，诺格愿意带精灵回去有光亮的地方。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:416
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:415
 msgid ""
 "Thank you very much for your help. We were worried about getting lost in all "
 "these twisting tunnels. And we would be honored to have you come with us, "
@@ -6193,7 +6251,7 @@ msgstr ""
 "我们在一起，我们非常荣幸。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:423
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:422
 msgid ""
 "Thank you very much for your help. We were worried about getting lost in all "
 "these twisting tunnels. And we would be honored to have you come with us, "
@@ -6203,14 +6261,14 @@ msgstr ""
 "们在一起，我们非常荣幸。"
 
 #. [message]: speaker=Great Leader Darmog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:436
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:435
 msgid ""
 "The trolls who fought with you also want to thank you. They tell great tales "
 "of your valor."
 msgstr "曾和你一起作战的巨魔也想和你们一起去。他们一直念叨着你们的英勇。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:441
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:440
 msgid ""
 "We thank you for all you have done for trolls. You are bravest small people "
 "we know. We will tell stories of your battles to all our families so that "
@@ -6224,7 +6282,7 @@ msgstr ""
 "结束。格纳福会保佑你们的，愿他指引你们。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:469
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:468
 msgid ""
 "I have learned a lot about the trolls in my time here, and yet there’s so "
 "much more to learn. Their magic is amazing. Have you seen their shamans? "
@@ -6240,7 +6298,7 @@ msgstr ""
 "底下的巨魔们居然还在教授魔法？我能从他们身上学到很多东西，我不想走了。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:479
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:478
 msgid ""
 "With the help of the trolls, I think you will do just fine. I don’t know "
 "what home your god has planned for you, Kaleh, but I believe in you, and I "
@@ -6252,7 +6310,7 @@ msgstr ""
 "这里，在巨魔这里。你们并不需要我，你们可以彼此扶助。"
 
 #. [message]: speaker=Elyssa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:499
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:498
 msgid ""
 "Thank you. And I owe you so much for helping me discover the trolls. I never "
 "would have come down here myself. I found this sword when we were fighting "
@@ -6266,8 +6324,8 @@ msgstr ""
 "激之情的剑送给你们。"
 
 #. [message]: speaker=Great Leader Darmog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:537
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:606
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:536
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:605
 msgid ""
 "And now Darmog think you should be off as soon as possible. The dwarves are "
 "sneaky, they retreat today but may attack again tomorrow. The sooner you "
@@ -6277,7 +6335,7 @@ msgstr ""
 "早离开越安全。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:542
+#: data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg:541
 msgid ""
 "I heartily agree, I for one can’t wait to feel the sun upon my face again "
 "and the wind in my hair."
@@ -6305,64 +6363,64 @@ msgid "Human Ally"
 msgstr "人类同盟"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:392
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:387
 msgid "Escape the caves"
 msgstr "逃离洞窟"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:399
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:394
 msgid "Explore outside"
 msgstr "探索外界"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:413
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:406
 msgid "Defeat Sergeant Durstrag"
 msgstr "击败德崔格长官"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:434
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:427
 msgid "Death of Grog"
 msgstr "果洛格死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:442
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:435
 msgid "Death of Nog"
 msgstr "诺格死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:450
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:443
 msgid "Death of Rogrimir"
 msgstr "若格瑞莫死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:458
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:451
 msgid "Death of Jarl"
 msgstr "查尔死亡"
 
 #. [objective]: condition=lose
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:466
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:459
 msgid "A human messenger escapes the valley"
 msgstr "人类信使逃离山谷"
 
 #. [note]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:476
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:469
 msgid "The messenger is the leader of the special white colored units"
 msgstr "信使是白色特殊单位的首领"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:496
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:489
 msgid ""
 "We’ve come far and we’re almost to the surface. But first we should stop and "
 "rest here for a while."
 msgstr "我们已经走了很远，我们应该快到地面了。我想我们该停下来休息一下。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:501
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:494
 msgid "That’s a big river; the water is really moving fast."
 msgstr "这是一条大河，河水非常湍急。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:513
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:506
 msgid ""
 "Yes, this time of year the snow melts from the mountains, and rivers like "
 "this often go deep underground. Sometimes the rivers break through and flood "
@@ -6372,7 +6430,7 @@ msgstr ""
 "河流被堵住了，会淹没洞穴，那致命的灾难有时会夺取我的同胞的性命。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:520
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:513
 msgid ""
 "Deep and dark are the waters that flow in our caves. Sometimes raging waters "
 "flood tunnels without warning. A stream can sustain a village, a sudden "
@@ -6382,39 +6440,39 @@ msgstr ""
 "养一个村庄，也能突然摧毁一个村庄。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:527
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:520
 msgid "Well, the faster we get out of here, the happier I’ll be."
 msgstr "好吧，越快离开这里我越高兴。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:538
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:531
 msgid "Wait, did you feel that?"
 msgstr "等下，你们感觉到什么了吗？"
 
 #. [message]: speaker=Nym
 #. [message]: role=mystic_speaker
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:543
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1751
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:536
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1755
 msgid "What?"
 msgstr "什么？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:549
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:542
 msgid "It felt like a distant rumbling. And what’s that roaring sound?"
 msgstr "远处似乎传来轰隆隆的异响。这个轰鸣声是什么？"
 
 #. [unit]: type=Troll Rocklobber
 #. [unit]: type=Troll Whelp
 #. [unit]: type=Troll Shaman, role=avenger
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:572
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:593
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:614
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:565
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:589
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:613
 msgid "Troll Avenger"
 msgstr "巨魔复仇者"
 
 #. [message]: role=avenger
 #. The grammar here is troll speech, and its second sentence merges the second and third sentences of the dwarven equivalent.
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:630
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:632
 msgid ""
 "Foul elves, you not escaped us yet. Great Leader will be avenged! We plugged "
 "river and you all drown with us!"
@@ -6425,14 +6483,14 @@ msgstr ""
 #. [unit]: type=Dwarvish Fighter
 #. [unit]: type=Dwarvish Thunderguard
 #. [unit]: type=Dwarvish Pathfinder, role=avenger
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:644
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:665
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:686
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:646
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:670
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:694
 msgid "Dwarf Avenger"
 msgstr "矮人复仇者"
 
 #. [message]: role=avenger
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:701
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:712
 msgid ""
 "Foul elves, you have not escaped yet. Our chieftain shall be avenged! We "
 "have dammed the river and soon all shall drown in its dark waters. Come join "
@@ -6442,40 +6500,40 @@ msgstr ""
 "黑水淹没。和我们一起去死吧！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:708
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:719
 msgid ""
 "That sound must be the rushing water. We have to get our people out of here, "
 "and fast!"
 msgstr "听起来是水声，我们必须带着人民离开这里，快！"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:713
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:724
 msgid "Quick, the southern passage!"
 msgstr "快，南边的通道！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:718
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:729
 msgid "We haven’t a moment to lose!"
 msgstr "没时间浪费了！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:809
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:820
 msgid "Hey look, ants!"
 msgstr "嘿看啊，蚂蚁！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:815
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:826
 msgid "Hey look, more ants!"
 msgstr "嘿看啊，又是蚂蚁！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:831
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:842
 msgid "Are you sure there aren’t any spiders?"
 msgstr "你确定那儿没有蜘蛛吗？"
 
 # 有所改进翻译
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:836
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:847
 msgid ""
 "No, but the water is rising to the southeast as well. The river must lead to "
 "more tunnels than we first thought."
@@ -6483,7 +6541,7 @@ msgstr "没有。但东南边也涨水了，河水一定流向了比我们最初
 
 # 改进翻译
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:843
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:854
 msgid ""
 "I don’t see any spiders, but the water is rising to the southeast as well. "
 "The river must lead to more tunnels than we first thought."
@@ -6491,41 +6549,41 @@ msgstr ""
 "我没看到蜘蛛。但东南方也涨水了。河水肯定流过了比我们最初想到更多的洞穴。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:850
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:861
 msgid "The ants must be fleeing from the flood too."
 msgstr "蚂蚁也一定是躲洪水来了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:855
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:866
 msgid ""
 "They seem confused, leaderless. I guess it’s every ant for itself. Uh, oh. "
 "Some of them seem to have noticed us."
 msgstr "它们看起来很慌乱，没有组织。每个蚂蚁都独自行动。噢，有些注意到我们了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:860
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:871
 msgid ""
 "Well, we have to get out of here too. Looks like we don’t have any choice "
 "but to fight our way through the chaos."
 msgstr "好，我们也想离开这里。看样子除了在这混乱中杀出一条路来，我们别无选择。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:892
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:903
 msgid "Bellerin"
 msgstr "贝勒宁"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:902
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:913
 msgid "Durth"
 msgstr "德斯"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:912
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:923
 msgid "Othgar"
 msgstr "欧斯格"
 
 #. [message]: speaker=Durth
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:917
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:927
 msgid ""
 "<i>Huff, huff.</i> First the boss tells us to patrol these caves, and then "
 "these durn caves start flooding. What next?"
@@ -6534,22 +6592,22 @@ msgstr ""
 "呢？"
 
 #. [message]: speaker=Bellerin
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:922
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:932
 msgid "Shut up and keep running, or we’ll be fish-bait for sure!"
 msgstr "闭嘴，继续跑，要不然我们就成鱼食了！"
 
 #. [message]: speaker=Othgar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:931
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:941
 msgid "Hey look! It’s a troll!"
 msgstr "嘿看呐！那是个巨魔！"
 
 #. [message]: speaker=Durth
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:935
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:945
 msgid "Huh? A troll?"
 msgstr "啥？巨魔？"
 
 #. [message]: speaker=Bellerin
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:939
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:949
 msgid ""
 "Yeah, just like my old grandmam used to tell us: dark gray skin, beady red "
 "eyes, hulking brutes with brains as small as a barnacle. They lurk deep in "
@@ -6561,23 +6619,23 @@ msgstr ""
 "搞出来的！"
 
 #. [set_variable]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:944
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:954
 msgid ""
 "Fish bait? Barnacles? Who are these humans and what were they talking about?"
 msgstr "鱼食？甲壳动物？这些人类是谁，他们在说什么？"
 
 #. [message]: speaker=Othgar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:951
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:961
 msgid "Hey look! It’s a dwarf!"
 msgstr "嘿看呐！那是个矮人！"
 
 #. [message]: speaker=Durth
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:955
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:965
 msgid "Huh? A dwarf?"
 msgstr "啥？矮人？"
 
 #. [message]: speaker=Bellerin
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:959
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:969
 msgid ""
 "Yeah, just like my old grandmam used to tell us: short and stocky, long "
 "beards, filthy bastards who are as sneaky as a cuttlefish. They lurk "
@@ -6590,23 +6648,23 @@ msgstr ""
 "一部分。洪水是矮人弄出来的！"
 
 #. [set_variable]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:963
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:973
 msgid ""
 "Fish bait? Cuttlefish? Who are these humans and what were they talking about?"
 msgstr "鱼食？乌贼？这些人类是谁，他们在说什么？"
 
 #. [message]: speaker=Othgar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:969
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:979
 msgid "Hey look! Those must be elves!"
 msgstr "看啊！他们一定是精灵！"
 
 #. [message]: speaker=Durth
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:973
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:983
 msgid "Huh? Elves?"
 msgstr "啊？精灵？"
 
 #. [message]: speaker=Bellerin
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:977
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:987
 msgid ""
 "Yeah, just like my old grandmam used to tell us: pointy ears, those shifty "
 "eyes, hearts as hard as a hermit crab’s shell. It must be an invasion! They "
@@ -6616,36 +6674,36 @@ msgstr ""
 "肯定是入侵！洪水肯定是他们搞出来的！"
 
 #. [set_variable]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:982
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:992
 msgid ""
 "Fish bait? Hermit Crabs? Who are these humans and what were they talking "
 "about?"
 msgstr "鱼食？寄居蟹？这些人类是谁，他们在说什么？"
 
 #. [message]: speaker=Othgar
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:989
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:999
 msgid "Then let’s kill them!"
 msgstr "那么杀了他们！"
 
 #. [message]: speaker=Durth
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:994
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1004
 msgid "Yeah!"
 msgstr "好嘞！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:999
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1009
 msgid "They’re definitely of the ‘attack first, ask questions later’ variety."
 msgstr "他们肯定是那种“先打后问”的类型。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1055
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1065
 msgid ""
 "No time for questions now, the water shows no signs of stopping. We’ve got "
 "to get out of here while we still can!"
 msgstr "没时间发问了，水还在涨。我们再不逃的话就来不及了！"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1060
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1070
 msgid ""
 "Curses, the water is rising too fast. That tunnel those humans were fleeing "
 "down was the fastest way out of here, but it’s already flooding."
@@ -6654,39 +6712,39 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1072
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1082
 msgid "There must be another way out. There must!"
 msgstr "肯定还有别的出路。一定有！"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1077
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1087
 msgid "There might be, but I don’t—"
 msgstr "或许有吧，但是我不——"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1082
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1092
 msgid "Then show us the way already! We’re running out of time."
 msgstr "只有一条路可以走了！我们在浪费时间。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1087
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1097
 msgid "Fine. Just keep going west, but be careful."
 msgstr "好吧，继续向西，但是要小心。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1125
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1135
 msgid "Whoa, what is this place? It sure seems well protected."
 msgstr "哇，这是什么地方？这里好像被保护得很好。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1131
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1141
 msgid ""
 "This is an ancient fortress. Who lived here I do not know, but it has been "
 "long since abandoned."
 msgstr "这是个古代的要塞。我不知道以前谁住在这里，但这里肯定已经被遗弃很久了。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1138
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1148
 msgid ""
 "Behold, we come now to an ancient fortress. Who lived here I do not know, "
 "but it has been long since abandoned."
@@ -6695,24 +6753,24 @@ msgstr ""
 "久了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1145
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1155
 msgid "You’ve been this way before?"
 msgstr "你来过？"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1150
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1160
 msgid ""
 "Yes, but I didn’t explore very far. This foul place is still protected by "
 "wards and guards. It reeks of dark magic."
 msgstr "是的，来过这附近。这肮脏的地方还是被守卫着，它沾染了黑暗魔法。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1155
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1165
 msgid "I wish there was another path, but it seems we have no choice."
 msgstr "我希望还有别的路，但现在看来我们别无选择。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1160
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1170
 msgid ""
 "Wait. The chamber in front of us is probably trapped and well guarded. There "
 "is another way. When I explored here before, I found a secret passage that "
@@ -6727,49 +6785,49 @@ msgstr ""
 "决定走不走吧。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1187
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1197
 msgid ""
 "Hmmm, the entrance to the secret tunnel should be right around here "
 "somewhere."
 msgstr "呃，秘道的入口应该就在这附近。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1192
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1209
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1202
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1219
 msgid "Got it!"
 msgstr "找到了！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1199
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1209
 msgid "I think I see a door-shaped crack in this wall."
 msgstr "我看到了墙上有个门形状的裂口。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1204
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1214
 msgid ""
 "Good, that should be the entrance to the secret tunnel. Now just push hard "
 "inwards."
 msgstr "很好，这应该就是秘道的入口了。现在让我们小心地进去吧。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1247
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1257
 msgid ""
 "Well, this is the end of the tunnel. Which means the other secret door "
 "should be right here."
 msgstr "好了，这条路走到尽头了。这里应该有另一个秘道的门才对。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1252
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1262
 msgid "Hold on, I think I’ve found it."
 msgstr "等下，也许我已经找到了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1259
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1269
 msgid "The passage just halts at a dead end."
 msgstr "这路是个死胡同。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1264
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1274
 msgid ""
 "You didn’t expect the other end to be left wide open did you? There should "
 "be another secret door hidden right in front of you."
@@ -6777,27 +6835,29 @@ msgstr ""
 "你已经料到路的尽头不会是宽阔的，是吧？前面应该有另一个秘道的入口隐藏在某处。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1269
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1279
 msgid "Oh, right. Hold on, I think I’ve found it."
 msgstr "哦，好了，等一下，我想我找到了。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1346
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1347
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1351
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1352
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1356
 #: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1357
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1361
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1358
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1362
 #: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1363
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1365
 #: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1367
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1369
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1368
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1372
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1373
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1377
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1379
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1381
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1383
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1385
 msgid "Gate Guard"
 msgstr "门卫"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1437
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1453
 msgid ""
 "This cave seems pretty empty, except for those two glowing runes in the "
 "center. This fort must have once been heavily occupied because countless "
@@ -6809,7 +6869,7 @@ msgstr ""
 "走？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1443
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1459
 msgid ""
 "This cave seems pretty empty, except for those two glowing runes in the "
 "center. This fort must have once been heavily occupied because countless "
@@ -6820,7 +6880,7 @@ msgstr ""
 "向的曾经频繁使用的小路，以前这要塞里肯定驻扎过很多人。诺格，我们该往哪边走？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1449
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1465
 msgid ""
 "This cave seems pretty empty, except for those two glowing runes in the "
 "center. This fort must have once been heavily occupied because countless "
@@ -6832,7 +6892,7 @@ msgstr ""
 "走？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1455
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1471
 msgid ""
 "This cave seems pretty empty, except for those two glowing runes in the "
 "center. This fort must have once been heavily occupied because countless "
@@ -6843,7 +6903,7 @@ msgstr ""
 "向的曾经频繁使用的小路，以前这要塞里肯定驻扎过很多人。查尔，我们该往哪边走？"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1461
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1477
 msgid ""
 "I don’t know. When I last came this way I got scared by all the runes and "
 "things moving in the shadows, and I explored no further."
@@ -6852,7 +6912,7 @@ msgstr ""
 "就不敢再往前了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1468
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1484
 msgid ""
 "The many tracks left by countless feet clearly show that this fort must have "
 "once been heavily occupied, but now this area is empty, except for those two "
@@ -6865,13 +6925,13 @@ msgstr ""
 "什么东西给吓到了，然后我就不敢再往前了。现在我也不知道该往哪条路走了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1475
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1491
 msgid ""
 "Well, we can’t spend all day thinking about it. Pick a direction, Kaleh."
 msgstr "好了，我们不能在这里浪费时间。卡勒，选一条路吧。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1480
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1496
 msgid ""
 "Wait, those runes are giving off a cool blue light and for some reason they "
 "don’t seem as threatening as the burning red ones we saw before. Perhaps "
@@ -6883,17 +6943,17 @@ msgstr ""
 "上我们的忙。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1523
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1539
 msgid "I feel refreshed and rejuvenated!"
 msgstr "我觉得焕然一新！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1544
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1560
 msgid "The rune is gone. I guess the magic only had limited uses."
 msgstr "符文消失了。我猜这魔法有使用次数限制。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1578
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1594
 msgid ""
 "There isn’t much left of the furnishings of this room. I think it was some "
 "sort of storeroom, but it looks like scavengers have taken anything useful."
@@ -6902,7 +6962,7 @@ msgstr ""
 "的东西都搬走了。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1583
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1599
 msgid ""
 "Curse Uria! The water is rising over here as well. Already the western end "
 "of this chamber is flooded. And I think I see shapes rising out of the "
@@ -6912,72 +6972,72 @@ msgstr ""
 "现了。不管那是什么，肯定不是好东西。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1621
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1637
 msgid ""
 "This looks like a training hall. There are still a few old swords and spears "
 "lying in the corners. But otherwise it seems quite abandoned."
 msgstr "看起来是练习场。一些古老的剑和矛散落在角落里。还有，这里好破。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1637
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1653
 msgid "Blessed Kali"
 msgstr "被祝福的凯利"
 
 #. [message]: speaker=Blessed Kali
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1649
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1660
 msgid ""
 "All right you runts, let’s try this again. Pior, remember to swing your "
 "sword with your whole body, not just your arms."
 msgstr "好了，小鬼们，再来。派尔，记着挥剑要用整个身体，不只是胳膊。"
 
 #. [message]: speaker=Novice Pior
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1654
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1665
 msgid "Yes, sir."
 msgstr "是的， 先生。"
 
 #. [message]: speaker=Blessed Kali
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1659
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1670
 msgid "Dani, keep your feet moving. If you stand still you’re a dead man."
 msgstr "戴尼，保持脚步移动。如果你站着不动，就会死的。"
 
 #. [message]: speaker=Novice Dani
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1664
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1675
 msgid "Right, sir."
 msgstr "是的，长官。"
 
 #. [message]: speaker=Blessed Kali
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1669
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1680
 msgid "Iona, try to vary your attacks more. You’re becoming too predictable."
 msgstr "艾欧纳，灵活些好不好，你的攻击太容易识破了。"
 
 #. [message]: speaker=Novice Iona
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1674
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1685
 msgid "I’ll try, sir."
 msgstr "我会试试看，长官。"
 
 #. [message]: speaker=Blessed Kali
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1679
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1690
 msgid ""
 "And remember, everyone, we’re going to keep practicing until I’m satisfied. "
 "So, ready... attack!"
 msgstr "记住，所有人，你们要练习到我满意为止。那么，准备……进攻！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1688
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1699
 msgid ""
 "Wait a minute, I don’t see any targets or practice dummies. Who are they "
 "supposed to be attacking?"
 msgstr "等下，我还没看到练习用的靶子。他们要拿什么练习？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1693
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1704
 msgid ""
 "I believe that would be us. But perhaps we can give them a few lessons in "
 "proper fighting style."
 msgstr "是我们吧。让我们来教教他们什么是真正的战斗。"
 
 #. [message]: speaker=Blessed Kali
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1718
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1729
 msgid ""
 "Come on! I ain’t going anywhere for the rest of the day, and unless you can "
 "fight better than that, neither are you. Now get your sorry behinds up off "
@@ -6988,37 +7048,37 @@ msgstr ""
 "落心情收起来，重新给我操练一遍。你们的小伎俩瞒不过我，瞒不过的！"
 
 #. [message]: speaker=Novice Pior
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1747
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1758
 msgid "Finally, we get to take a break. I am so sick of fighting practice."
 msgstr "我们终于可以歇一下了。我烦透了战斗练习。"
 
 #. [message]: speaker=Novice Dani
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1752
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1763
 msgid ""
 "Kali’s just a hardass because he’s bitter that he never became a high priest."
 msgstr "凯利这么严格是因为他也很苦闷，他没能成为高阶术士。"
 
 #. [message]: speaker=Novice Iona
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1758
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1768
 msgid ""
 "Hey, c’mon, maybe we can grab some food from the kitchen before we have to "
 "go to prayers."
 msgstr "嘿，来吧。我们可以在为他祷告之前先从厨房抓点食物回来。"
 
 #. [message]: speaker=Novice Pior
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1763
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1773
 msgid "Good idea! I hope they let us go outside tomorrow; I so miss the sun."
 msgstr "好主意！我希望他们明天能让我出去，我太想晒太阳了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1774
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1784
 msgid ""
 "Still lambasting those novices after all these years, that guy definitely "
 "had too much of a work ethic."
 msgstr "这么多年了还对这些新手这样严厉，那家伙的工作要求很高嘛。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1779
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1789
 msgid ""
 "Sniff, who were those children? Why did they die, in the dark, so many years "
 "ago? May Eloh shine her eternal light upon their souls."
@@ -7027,7 +7087,7 @@ msgstr ""
 "些灵魂。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1784
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1794
 msgid ""
 "The past is the past, and there’s nothing we can do about it. Right now we "
 "have our own people to worry about."
@@ -7035,22 +7095,22 @@ msgstr ""
 "过去的事已经过去了，我们不能改变过去。现在我们应该关心一下我们自己的同胞。"
 
 #. [then]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1800
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1810
 msgid "Novice Dani"
 msgstr "新人戴尼"
 
 #. [then]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1815
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1825
 msgid "Novice Iona"
 msgstr "新人艾欧纳"
 
 #. [then]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1830
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1840
 msgid "Novice Pior"
 msgstr "新人派尔"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1870
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1880
 msgid ""
 "This must have been the barracks. Remains of cots and beds litter the floor. "
 "Whatever happened here, it must have been sudden. Several skeletons still "
@@ -7060,57 +7120,57 @@ msgstr ""
 "件。有几具尸骨还躺在床上，永远也醒不过来了。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1875
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1876
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1879
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1881
 #: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1885
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1886
 #: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1889
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1891
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1895
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1899
 msgid "Restless Dead"
 msgstr "死而不休"
 
 #. [message]: type=Skeleton
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1896
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1906
 msgid "Revenge!"
 msgstr "复仇！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1901
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1911
 msgid "Well, so much for sleeping for eternity."
 msgstr "好吧，所谓永远沉睡不过如此。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1921
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1931
 msgid ""
 "Hey, what’s this? There seems to be an outline of a door in this wall. Maybe "
 "if I give it a push..."
 msgstr "嘿，这是什么？这堵墙上似乎有门。我推一下试试……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1935
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1945
 msgid "What do you know? A secret door!"
 msgstr "你们猜是什么？暗门！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1940
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1950
 msgid "Well, what’s behind the door?"
 msgstr "哦，门后是什么？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1945
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:1955
 msgid ""
 "Uh oh. The path is blocked by another of those red glowing runes. I’m not "
 "sure crossing it would be a good idea."
 msgstr "哎呀，道路被另一个红色符文挡住了，不知道穿越它会发生什么。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2004
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2005
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2014
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2015
 msgid "Failed Experiment"
 msgstr "失败的实验品"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2009
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2019
 msgid ""
 "This chamber seems to have been some sort of laboratory. The floor is "
 "littered with broken bottles and other strange equipment. What is more "
@@ -7125,17 +7185,17 @@ msgstr ""
 "可是非常清醒，可能我们把它们惹怒了。"
 
 #. [message]: speaker=Failed Experiment 1
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2014
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2024
 msgid "Graaww!"
 msgstr "哇！"
 
 #. [message]: speaker=Failed Experiment 2
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2019
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2029
 msgid "Make pain end!"
 msgstr "结束这痛苦吧！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2042
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2052
 msgid ""
 "In the center of this circle is a huge creature, with surging muscles and "
 "bloodshot eyes. I would think it was just a very big man, except for the "
@@ -7151,61 +7211,61 @@ msgstr ""
 "它，但我不知道这会有什么后果。我可不想那种东西来攻击我。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2044
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2054
 msgid "Break the circle."
 msgstr "破坏魔法圈。"
 
 #. [command]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2063
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2073
 msgid "Kromph"
 msgstr "克伦夫"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2067
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2077
 msgid "Master, what is your command?"
 msgstr "大人，您有什么指令？"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2077
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2087
 msgid "Kromph need command. Command me!"
 msgstr "克伦夫需要指示。请下令！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2082
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2092
 msgid "Follow us. Attack our enemies."
 msgstr "跟着我们。攻击我们的敌人。"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2087
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2097
 msgid "Yes, mistress. Kromph follow you. Kill enemies."
 msgstr "是，主人。克伦夫会伴随您杀敌。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2092
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2102
 msgid ""
 "Quick thinking, Nym. It seems to be some sort of magical creation. Lucky "
 "that it thought we were its master."
 msgstr "妮慕，似乎是种魔法。幸亏它把我们当成主人。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2097
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2107
 msgid "Looks like you have your own rather large pet, Nym."
 msgstr "看起来你养了个很大的宠物，妮慕。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2102
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2112
 msgid ""
 "It wouldn’t have been my first choice. But it could prove useful. I wonder "
 "what it likes to eat?"
 msgstr "它肯定不适合我，虽然挺厉害。不知道它吃什么？"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2108
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2118
 msgid "Leave that thing alone."
 msgstr "别考虑这种事了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2140
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2150
 msgid ""
 "All the paths lead to this chamber. Is this just a dead end? It seems to be "
 "some sort of temple, but it has obviously been abandoned for a long time. "
@@ -7216,93 +7276,93 @@ msgstr ""
 "不知道它们信奉什么神，祭坛里的血痕和碎骨头可不是好征兆。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2145
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2155
 msgid "I don’t like the smell of this place."
 msgstr "我不喜欢这里的味道。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2150
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2160
 msgid "I feel some sort of presence... Ugh... it makes my skin crawl."
 msgstr "我觉得有种……啊……我鸡皮疙瘩都起来了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2157
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2167
 msgid ""
 "Grog, I thought you said that you’d been here before? Where are we supposed "
 "to go from here?"
 msgstr "果洛格，我好像听你说过你到过这里。接下来我们应该往哪边走？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2163
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2173
 msgid ""
 "Nog, I thought you said that you’d been here before? Where are we supposed "
 "to go from here?"
 msgstr "诺格，我好像听你说过你到过这里。接下来我们应该往哪边走？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2169
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2179
 msgid ""
 "Rogrimir, I thought you said that you’d been here before? Where are we "
 "supposed to go from here?"
 msgstr "若格瑞莫，我好像听你说过你到过这里。接下来我们应该往哪边走？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2175
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2185
 msgid ""
 "Jarl, I thought you said that you’d been here before? Where are we supposed "
 "to go from here?"
 msgstr "查尔，我好像听你说过你到过这里。接下来我们应该往哪边走？"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2181
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2191
 msgid ""
 "I never explored this deep into the complex. But every lair has to have a "
 "back door somewhere."
 msgstr "我从没有探索到这么幽深的地方。但是这里肯定别有洞天。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2186
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2196
 msgid ""
 "Well I refuse to give up. There must be some way out. Search everywhere, "
 "people."
 msgstr "我不会放弃，肯定有生路。大家到处寻找。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2198
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2199
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2201
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2208
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2209
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2211
 msgid "Ancient Guardian"
 msgstr "远古守卫"
 
 #. [message]: speaker=Ancient Guardian 1
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2205
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2215
 msgid "Zantoff tharqan yur glit zarf!"
 msgstr "@￥&×%！"
 
 #. [message]: speaker=Ancient Guardian 2
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2210
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2220
 msgid "Uqtor dunil olgluck vara nir!"
 msgstr "》～）￥-！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2215
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2225
 msgid "It seems that the temple had some power left in it after all."
 msgstr "看来这个神殿还留有一些力量。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2220
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2230
 msgid "I have no idea what they just said, but their meaning is quite clear."
 msgstr "我听不懂他们在说什么，不过我想那意思应该是很明确的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2225
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2235
 msgid ""
 "Actions speak louder than words, and I intend to send them back to whatever "
 "stygian pits they came from!"
 msgstr "行动就是最好的言语，不管他们是什么东西，从哪里来，就给我滚回哪里去！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2251
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2261
 msgid ""
 "What’s this? Hidden underneath the edge of the altar is an iron lever. It "
 "looks slightly rusted, but with some effort I could pull it. I have no idea "
@@ -7312,26 +7372,26 @@ msgstr ""
 "它。我不知道这是干嘛用的，不过我们也别无选择了。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2253
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2263
 msgid "Pull the lever."
 msgstr "拉动拉杆。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2275
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2285
 msgid ""
 "What?! Two secret passages? What do you think this once was, a trap? Or "
 "possibly a back door?"
 msgstr "什么？！两条秘道？你们觉得这是什么，陷阱么？还是一个秘密出口？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2280
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2290
 msgid ""
 "I can’t even begin to fathom what these cultists were up to. But more "
 "importantly, which way do we go?"
 msgstr "我真弄不懂这些异教徒怎么有这么多花样。更重要的是，我们该走哪条路？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2291
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2301
 msgid ""
 "I think I hear the sound of rushing water down the western passage; it might "
 "already be flooding! It must connect back somehow to the other tunnels."
@@ -7339,21 +7399,21 @@ msgstr ""
 "我觉得听到了水冲过西面通道的声音，那边肯定淹了！看来它肯定是连回其他坑道的。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2297
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2307
 msgid ""
 "Look, the western passage is already flooding! It must connect back somehow "
 "to the other tunnels."
 msgstr "看，西面通道淹了！看来它肯定是连回其他坑道的。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2304
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2314
 msgid ""
 "There’s no time to ponder the history of this place. We’ve got to get out of "
 "here!"
 msgstr "没有时间考证这地方的历史了。我们赶紧离开这里！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2309
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2319
 msgid ""
 "Right, the eastern passage it is. I have no idea where it goes, but with the "
 "water rising, soon anywhere will be better than here."
@@ -7361,24 +7421,24 @@ msgstr ""
 "没错，走东边的通道。我不知道它通向哪里，但是只要水继续在涨，哪里都比这里好。"
 
 #. [option]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2315
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2325
 msgid "Leave it alone."
 msgstr "放开它。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2345
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2355
 msgid "This looks like some kind of burial chamber."
 msgstr "看起来是某种墓室。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2351
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2361
 msgid ""
 "Crypts like these are often heavily guarded, we would do well not to disturb "
 "the sarcophagi."
 msgstr "像这样的洞穴通常都有守卫，我们小心点别去动那棺材。"
 
 #. [message]: speaker=Crypt Guardian
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2362
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2372
 msgid ""
 "I have long waited for fools such as yourselves to dare to disturb our rest, "
 "elf. Pay the price of all such defilers!"
@@ -7386,29 +7446,29 @@ msgstr ""
 "我等了很久了，像你们这样的傻瓜敢来打搅我们休息，精灵啊。付出代价吧，捣蛋鬼！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2367
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2377
 msgid "Got any other timely advice, Zhul?"
 msgstr "朱尔，还有什么别的及时提示吗？"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2372
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2382
 msgid ""
 "We’re in luck, a fissure has opened up a crack in the northern wall. We may "
 "be able to escape that way."
 msgstr "我们挺走运，北面的墙有个裂口。也许籍此可以逃走。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2411
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2421
 msgid "You run, but you shall not escape death!"
 msgstr "你跑吧，但你跑不过死亡！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2416
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2426
 msgid "In Eloh’s name, not you again. Must I fight you a third time?"
 msgstr "以伊洛之名，怎么又是你。我真要和你打第三次不成？"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2422
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2432
 msgid ""
 "You abandoned them, Kaleh, to eternal suffering and torment. And now you "
 "shall pay the price! You too shall watch the black waters consume those you "
@@ -7418,45 +7478,45 @@ msgstr ""
 "尝尝黑暗的水流吞噬你所爱的人的痛苦吧。卡勒，拥抱黑暗吧，它找你来了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2427
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2437
 msgid ""
 "Even you shall not stop me. You shall taste the might of the Quenoth Elves!"
 msgstr "就算是你也挡不住我的。尝尝奎诺精灵的力量吧！"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2433
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2443
 msgid "Ha! Foolish boy, you know nothing."
 msgstr "哈！蠢家伙，你什么都不知道。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2448
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2458
 msgid "Quick, grab him! Don’t let him escape again."
 msgstr "快，抓住他！不要又让他跑了。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2454
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2464
 msgid "No, no, no more escaping. Please kill me, just make the pain end."
 msgstr "不，不，我不会逃了。杀了我，让这种痛楚就这样结束吧。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2459
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2469
 msgid ""
 "No, you have hounded me with your riddles for too long. I want some answers. "
 "Who are you? What’s behind that black mask?"
 msgstr "不，你谜一样地追我这么久。我要知道，你是谁，黑色面具后面有什么？"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2469
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2479
 msgid "Behold, Kaleh, your own worst enemy. Do you now see the irony?"
 msgstr "看，卡勒，我是你最坏的对手。现在你满意了？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2474
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2484
 msgid "Oh Eloh save us, it’s... it’s an elf."
 msgstr "哦伊洛在上，你……你是个精灵。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2479
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2489
 msgid ""
 "Keratur, son of Tanuil. What in Eloh’s name are you doing here? How could "
 "you do this? We thought you were dead."
@@ -7465,14 +7525,14 @@ msgstr ""
 "你已经死了。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2484
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2494
 msgid ""
 "Kaleh, we don’t have time for questions. The water is still rising and we "
 "must get our people to safety."
 msgstr "卡勒，没时间提问了。水漫道而来，我们必须带大家去安全的地方。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2489
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2499
 msgid ""
 "No matter what you have done, you are one of us, Keratur, and I will not "
 "leave you here to die in the darkness. I will carry you myself if I have to."
@@ -7481,47 +7541,47 @@ msgstr ""
 "果有必要的话，我亲自带你离开这里。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2495
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2505
 msgid "So be it. I care not."
 msgstr "那就走吧，我无所谓。"
 
 #. [set_variable]
 #. Name of the dark assassin who uses "speaker=Cloaked Figure" when talking
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2511
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2521
 msgid "Keratur"
 msgstr "凯若特"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2546
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2556
 msgid "Look, daylight! I think we finally made it out of the caves!"
 msgstr "看，阳光！我们终于走出洞穴了！"
 
 #. [message]: speaker=Nym
 #. Nym is blocked by deep water, and drowning is inevitable
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2576
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2586
 msgid "Kaleh? Zhul? I’m still stuck back here..."
 msgstr "卡勒？朱尔？我还被困在这里……"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2591
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2601
 msgid ""
 "What’s this? Someone has built an outpost at the end of the cave. Where are "
 "its occupants?"
 msgstr "这是什么？有人在这洞穴的出口建了一个哨卡。它的主人在哪里？"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2603
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2613
 msgid "Kaleh, I think you should come up and see this."
 msgstr "卡勒，来看这个。"
 
 #. [message]: speaker=Kaleh
 #. Kaleh is blocked by deep water, and drowning is inevitable
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2627
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2637
 msgid "Ack, I’m surrounded by water!"
 msgstr "咳，我被水包围了！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2647
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2657
 msgid ""
 "Oh, Eloh. They’re all dead. Butchered. Quick, we have to clean this up, we "
 "don’t want the rest of our people to have to see such horror."
@@ -7530,12 +7590,12 @@ msgstr ""
 "看到这恐怖的景象。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2652
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2662
 msgid "Now, Keratur, I will have my answers. Did you have a hand in this?"
 msgstr "凯若特，现在我想问你，这是你干的吗？"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2668
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2678
 msgid ""
 "They heard me and... and they got in the way. But they aren’t even elves, "
 "what do they matter?"
@@ -7544,12 +7604,12 @@ msgstr ""
 "关系呢？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2673
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2683
 msgid "You idiot—"
 msgstr "你个白痴——"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2678
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2688
 msgid ""
 "Quiet, Nym. But I still don’t understand how you got here. We were sure you "
 "were dead. We searched and searched, but never found your body."
@@ -7558,7 +7618,7 @@ msgstr ""
 "寻，一直没有找到你的尸体。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2683
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2693
 msgid ""
 "Heh, heh, no you didn’t find me. I awoke trapped under the rubble, and when "
 "I finally escaped the village was deserted. Just the stink of death and "
@@ -7571,12 +7631,12 @@ msgstr ""
 "从沙丘那边涌来的亡灵。这是巫师的阴谋……他们发现了我，还让我看，眼睁睁地看！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2688
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2698
 msgid "Watch what?"
 msgstr "看什么？"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2693
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2703
 msgid ""
 "They brought some humans, bound up tight. So beautiful... she had flaming "
 "red hair... they cut her... I can still hear her screaming. But that was "
@@ -7588,12 +7648,12 @@ msgstr ""
 "停地流到沙地上。我听见了他们哀怨疼痛的嚎叫……"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2698
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2708
 msgid "From the humans?"
 msgstr "人类的嚎叫？"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2703
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2713
 msgid ""
 "Faugh. No, I heard the screams of the dead, torn from their rest, their "
 "souls rose into the air howling in agony."
@@ -7602,12 +7662,12 @@ msgstr ""
 "着。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2708
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2718
 msgid "But, but we burned the bodies so they couldn’t be raised."
 msgstr "但是，但是我们已经把尸体都烧了，他们不该被复苏了啊。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2713
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2723
 msgid ""
 "Fool. That did not stop their dark power. Nothing could stop them. I felt "
 "the rush of flying spirits, and the unbearable cold, so cold. For a moment I "
@@ -7620,7 +7680,7 @@ msgstr ""
 "们嘲笑着看我爬过沙丘。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2718
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2728
 msgid ""
 "I was able to follow your trail, and I slipped among your people. No one "
 "noticed me, no I was too sneaky. And you wondered how I managed to follow "
@@ -7630,12 +7690,12 @@ msgstr ""
 "是怎么跟你来到这坑道里的？哈，是你带我来的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2723
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2733
 msgid "But why, why did you want to kill us?"
 msgstr "但是为什么，为什么你要杀死我们？"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2728
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2738
 msgid ""
 "You abandoned them! The pain, the agony, I still see their ghostly faces and "
 "hear their wails. And the necromancers kept chanting one name over and over: "
@@ -7650,17 +7710,17 @@ msgstr ""
 "这一切都是你的错，我相信了她。卡勒，原谅我吧，我只是想结束这痛苦。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2733
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2743
 msgid "I... I forgive you."
 msgstr "我……我原谅你。"
 
 #. [message]: speaker=Cloaked Figure
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2738
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2748
 msgid "I do not fear death any more."
 msgstr "我不再害怕死亡了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2751
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2761
 msgid ""
 "He’s dead. Rest in peace. Oh, what have I done? All our dead kin, desecrated "
 "and tormented for eternity."
@@ -7669,13 +7729,13 @@ msgstr ""
 "磨着。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2756
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2766
 msgid ""
 "As you said yourself, the past is the past, there is nothing you can do now."
 msgstr "就像你自己说的那样，过去的事都已经过去了，你无法改变过去。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2761
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2771
 msgid ""
 "Don’t blame yourself. You didn’t know. If we had stayed behind we too would "
 "have been killed by the undead; we could not have defended our village "
@@ -7685,7 +7745,7 @@ msgstr ""
 "那么多亡灵，我们是保不住村子的。我们也别无选择啊。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2767
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2777
 msgid ""
 "That is small consolation. My deeds have turned to ashes in my mouth. Eloh "
 "forgive me. I did not know."
@@ -7693,7 +7753,7 @@ msgstr ""
 "只是个安慰的接口罢了。我的举动把诺言变成了飞灰。伊洛原谅我吧。我不知道。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2778
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2788
 msgid ""
 "With your permission, Kaleh, I think I should go scout around a bit outside. "
 "We have no idea what lies out there. And I can sneak around unseen many "
@@ -7703,17 +7763,17 @@ msgstr ""
 "察那些未知区域而不被发现的能力，而你没有。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2783
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2793
 msgid "You can go Nym, just be careful."
 msgstr "好的，妮慕，小心点。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2788
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2798
 msgid "I’m always careful. I’ll be back soon."
 msgstr "我一直很小心。我很快就回来。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2805
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2815
 msgid ""
 "Well, at least we can use this outpost to rally our surviving troops. How "
 "many of our people made it out of the caves, Zhul?"
@@ -7722,7 +7782,7 @@ msgstr ""
 "穴了？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2810
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2820
 msgid ""
 "We’re still trying to get a head count, but between the underground horrors "
 "and the water, we lost quite a few. Recruiting new warriors is going to be "
@@ -7734,7 +7794,7 @@ msgstr ""
 "来。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2817
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2827
 msgid ""
 "Well, Nym’s right, we don’t know what’s out there. So we should set up a "
 "perimeter guard around the cave mouth and start discovering what this side "
@@ -7744,26 +7804,26 @@ msgstr ""
 "御阵型，然后探查山的这一边是什么情况。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2861
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2871
 msgid ""
 "Look, the tunnel slopes sharply downwards to the left. And it’s big enough "
 "that it should divert most of the rising water."
 msgstr "看，左边的坑道陷了下去，那坑够大，可以容纳涨来的水。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2866
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2876
 msgid "And I think I see a faint light off to the right."
 msgstr "我看见右边有隐隐约约的光亮。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2871
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2881
 msgid ""
 "Could it be? Could we actually be almost out of this seemingly never-ending "
 "darkness?"
 msgstr "难道？难道我们已经快要走出这似乎是无尽的黑暗了？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2886
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2896
 msgid ""
 "Grog, thank you so much for leading us out of the caves. We never would have "
 "found our way without your help. But with the tunnels flooded, how are you "
@@ -7773,7 +7833,7 @@ msgstr ""
 "水淹了，你怎么回去呢？"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2891
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2901
 msgid ""
 "Grog proud of little elves too. He would not have made it this far without "
 "all your help. Grog is surprised by your bravery and strength."
@@ -7782,7 +7842,7 @@ msgstr ""
 "果洛格敬佩。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2896
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2906
 msgid ""
 "Truth is that Grog not know much of sunlight lands. Sun and stars are scary, "
 "everything is open, exposed, no safe places to hide. But Grog cannot go back "
@@ -7794,7 +7854,7 @@ msgstr ""
 "坑道。他和精灵一样已经迷失了家园。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2901
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2911
 msgid ""
 "But Grog not afraid. Great leader told Grog to guide and protect elves, and "
 "Grog will keep his oath. Grog will follow elves wherever they may go and "
@@ -7808,7 +7868,7 @@ msgstr ""
 "们。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2907
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2917
 msgid ""
 "Nog, thank you so much for leading us out of the caves. We never would have "
 "found our way without your help. But with the tunnels flooded, how are you "
@@ -7818,7 +7878,7 @@ msgstr ""
 "淹了，你怎么回去呢？"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2912
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2922
 msgid ""
 "Nog proud of little elves too. He would not have made it this far without "
 "all your help. Nog is surprised by your bravery and strength."
@@ -7827,7 +7887,7 @@ msgstr ""
 "格敬佩。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2917
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2927
 msgid ""
 "Truth is that Nog not know much of sunlight lands. Sun and stars are scary, "
 "everything is open, exposed, no safe places to hide. But Nog cannot go back "
@@ -7839,7 +7899,7 @@ msgstr ""
 "他和精灵一样已经迷失了家园。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2922
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2932
 msgid ""
 "But Nog not afraid. Great leader told Nog to guide and protect elves, and "
 "Nog will keep his oath. Nog will follow elves wherever they may go and "
@@ -7852,7 +7912,7 @@ msgstr ""
 "到一条回到他洞穴里亲人身边的路。不过现在，诺格要继续追随并保护你们。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2928
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2938
 msgid ""
 "Rogrimir, I want to thank you so much for guiding us out of the caves. We "
 "never would have found our way without your help. But with the tunnels "
@@ -7863,8 +7923,8 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2933
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2954
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2943
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2964
 msgid ""
 "Och, it is I who should be congratulating you, laddie. I showed you the way, "
 "but it was you and your people who defeated the many perils and obstacles to "
@@ -7875,8 +7935,8 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2938
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2959
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2948
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2969
 msgid ""
 "But truly I cannot return the way I came and even if there are other tunnels "
 "which lead back down to my homeland, I do not know where to search for them. "
@@ -7887,8 +7947,8 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2943
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2964
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2953
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2974
 msgid ""
 "But my king told me to protect you from all dangers, and I plan to keep that "
 "oath. I do not like the above ground, it is too open and exposed; I feel "
@@ -7904,7 +7964,7 @@ msgstr ""
 "可以从这里回去，我也许可以找到一条回家乡的路。不过现在我听你差遣。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2949
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2959
 msgid ""
 "Jarl, I want to thank you so much for guiding us out of the caves. We never "
 "would have found our way without your help. But with the tunnels flooded, "
@@ -7914,14 +7974,14 @@ msgstr ""
 "淹了，你怎么回去呢？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2970
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:2980
 msgid ""
 "Your loyalty is a credit to your people. I am glad indeed to have you "
 "fighting by my side."
 msgstr "你的忠诚会令你的同胞感到骄傲的。能与你并肩作战，我由衷地感到高兴。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3001
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3011
 msgid ""
 "Looks like the guards at this outpost had been saving away a bit of loot. I "
 "don’t suppose they’re going to mind anymore if we made use of it."
@@ -7930,7 +7990,7 @@ msgstr ""
 "吧。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3135
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3145
 msgid ""
 "Praise Eloh, it is so good to be outside again. To see the sky stretching "
 "out above me, to feel the wind in my face..."
@@ -7938,32 +7998,32 @@ msgstr ""
 "赞美伊洛，重新回到这外面的感觉真好。看那天空在头顶延伸，感受那清风拂过面庞……"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3151
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3161
 msgid ""
 "We made it. Outside look strange to Grog, Grog not used to big open spaces."
 msgstr "我们成功了。外面对果洛格是陌生的，果洛格不习惯呆在开阔的大空间里。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3157
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3167
 msgid ""
 "We made it. Outside look strange to Nog, Nog not used to big open spaces."
 msgstr "我们成功了。外面对诺格是陌生的，诺格不习惯呆在开阔的大空间里。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3163
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3169
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3173
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3179
 msgid ""
 "I think we finally made it outside. I’d forgotten how big the sky is and how "
 "windy it can be."
 msgstr "我想我们终于走出来了。我都忘了天空的广阔和风的吹拂了。"
 
 #. [message]: race=quenoth,elf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3183
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3193
 msgid "Can you see very far? Do you have any idea where we are?"
 msgstr "你能看到远处吗？你知道我们在哪里吗？"
 
 #. [message]: speaker=$talking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3202
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3212
 msgid ""
 "We’ve come out on the side of a mountain, overlooking a large valley. The "
 "land seems to be much the same as the foothills south of the mountains. The "
@@ -7979,48 +8039,48 @@ msgstr ""
 #. [unit]: type=Divine Avatar, id=Eloh
 #. [side]
 #. [unit]: type=Divine Incarnation, id=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3238
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1690
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1252
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3248
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1694
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1661
 #: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:57
 #: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:110
 #: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:159
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:380
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:376
 msgid "Eloh"
 msgstr "伊洛"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3256
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3266
 msgid "Kaleh, Kaleh, come to me."
 msgstr "卡勒， 卡勒， 到我这里来。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3261
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3271
 msgid "What is the voice? It sounds so familiar."
 msgstr "什么声音？听起来如此熟悉。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3266
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3276
 msgid "Come out so that I might see you. Your god calls to you."
 msgstr "出来，我要见你。你的神召唤你。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3271
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3281
 msgid "Am I dreaming? Is this real? I’m coming, I’m coming."
 msgstr "我在做梦吗？这是真实的吗？我来了，我来了。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3280
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3290
 msgid "Hail Kaleh, it is I, Eloh."
 msgstr "你好，卡勒，是我，伊洛。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3287
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3297
 msgid "But I am not asleep? And yet I can see you? How is this possible?"
 msgstr "我不是在做梦吧？我怎么能看到您？怎么可能？"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3292
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3302
 msgid ""
 "Do you doubt my powers? You have come out of the darkness, and I appear unto "
 "you to congratulate you."
@@ -8028,31 +8088,31 @@ msgstr "你怀疑我的力量？你从黑暗中脱出，我现身来祝贺你。
 
 #. [message]: speaker=$talking_unit.id
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3307
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3324
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3317
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3334
 msgid "Kaleh, who are you talking to?"
 msgstr "卡勒，你和谁说话？"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3312
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3329
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3322
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3339
 msgid ""
 "For now, I appear only to you, for you, Kaleh, are special, you are the "
 "Chosen One."
 msgstr "现在，我只在你面前显现，只在你面前，卡勒，你是特别的，是被选中的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3317
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3327
 msgid "$talking_unit.name, be quiet, I’ll explain it all later."
 msgstr "$talking_unit.name|，安静，我稍后再解释清楚。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3334
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3344
 msgid "Be quiet Zhul, I’ll explain it all later."
 msgstr "朱尔，安静，我稍后再向你解释。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3341
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3351
 msgid ""
 "Yes, I have chosen you as the one to lead my people out of danger and death "
 "and into a life of eternal salvation. Crossing under the mountains was a "
@@ -8062,37 +8122,37 @@ msgstr ""
 "山脉是很重要的一步，而你对异教徒的制裁将证明你——"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3350
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3360
 msgid "Kaleh, a quick question—"
 msgstr "卡勒， 我有个问题——"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3357
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3367
 msgid "Not now Grog, I’m busy."
 msgstr "果洛格，现在不行， 我很忙。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3363
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3373
 msgid "Not now Nog, I’m busy."
 msgstr "诺格，现在不行， 我很忙。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3369
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3379
 msgid "Not now Rogrimir, I’m busy."
 msgstr "若格瑞莫，现在不行， 我很忙。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3375
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3385
 msgid "Not now Jarl, I’m busy."
 msgstr "查尔，现在不行， 我很忙。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3381
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3391
 msgid "What’s this? You did not kill the unbelievers?!"
 msgstr "这是怎么回事？你没有杀掉那些异教徒？！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3393
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3403
 msgid ""
 "I am sorry I could not have fulfilled your command, but we found ourselves "
 "in the middle of a war. We were vastly outnumbered and we needed help. In "
@@ -8105,7 +8165,7 @@ msgstr ""
 "们也不能活着走出那些洞穴。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3400
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3410
 msgid ""
 "I am sorry I could not have fulfilled your command, but we found ourselves "
 "in the middle of a war. We were vastly outnumbered and we needed help. In "
@@ -8117,7 +8177,7 @@ msgstr ""
 "们也不能活着走出那些洞穴。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3407
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3417
 msgid ""
 "You were weak and foolish, but I forgive you. You must remember, Kaleh, that "
 "without my guidance, your people would have died out years ago. Believe in "
@@ -8127,7 +8187,7 @@ msgstr ""
 "就灭亡了。信仰我吧，我一个便能拯救你们。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3412
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3422
 msgid ""
 "Now, in the valley live a group of humans who have also seen the light. They "
 "may seem strange, but they are my obedient followers. You must trust them, "
@@ -8137,7 +8197,7 @@ msgstr ""
 "你必须相信他们，他们会引导你们去北边。跟随他们，他们将引领你们来到我身旁。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3417
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3427
 msgid ""
 "What do you mean ‘lead you to me’? You are a god, don’t you exist "
 "everywhere? I thought you were going to show us our new home."
@@ -8146,7 +8206,7 @@ msgstr ""
 "家园展示给我们看。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3422
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3432
 msgid ""
 "Of course I am! Oh, how little you understand. Do not worry yourself with "
 "such distractions, come to me and all will be made clear."
@@ -8156,32 +8216,32 @@ msgstr ""
 
 #. [unit]: type=Human Commander, id=Sergeant Durstrag
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3430
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3565
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3439
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3573
 msgid "Sergeant Durstrag"
 msgstr "德崔格军士"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3431
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3432
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3433
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3434
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3576
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3577
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3578
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3579
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3440
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3441
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3442
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3443
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3584
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3585
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3586
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3587
 msgid "Human Guard"
 msgstr "人类守卫"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3438
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3447
 msgid ""
 "I saw the distress signal from the outpost on the bluff. Who in the Dark "
 "Lady’s name are you and what have you done with my men?"
 msgstr "我看到了哨所的惨象。以黑暗女神之名，你们是谁，你们对我的人做了什么？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3443
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3452
 msgid ""
 "My name is Kaleh, and these are my people. We come from the south and "
 "unfortunately we found your men dead—"
@@ -8189,7 +8249,7 @@ msgstr ""
 "我的名字是卡勒，这些是我们的人民。我们来自南方，不幸的是我们发现你的人死了——"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3448
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3457
 msgid ""
 "Dead?! You ‘found’ them you say? You’ll pardon me if I don’t take you at "
 "your word. We haven’t seen elves for generations, but we remember your "
@@ -8201,12 +8261,12 @@ msgstr ""
 "么？"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3453
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3462
 msgid "Well, actually they were fleeing from—"
 msgstr "好吧，其实他们是要逃离——"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3465
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3474
 msgid ""
 "A troll! This just gets better and better. We haven’t seen one of your kind "
 "up here for many years, but I have a long memory. I still remember the troll "
@@ -8216,7 +8276,7 @@ msgstr ""
 "错。我还记得我小时候的巨魔入侵事件。"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3472
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3481
 msgid ""
 "A dwarf! This just gets better and better. We haven’t seen one of your kind "
 "up here for many years, but we have long memories. I remember how your "
@@ -8228,12 +8288,12 @@ msgstr ""
 "好忽悠了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3479
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3488
 msgid "Look, if you’ll just let me explain—"
 msgstr "听着，如果你让我解释——"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3491
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3500
 msgid ""
 "Oh there is no need to explain, it’s pretty obvious what you’re up to. Here "
 "we have a whole legion of elves, consorting with trolls, sneaking up behind "
@@ -8243,7 +8303,7 @@ msgstr ""
 "线背后。在我看来这实在太像是入侵行为了。"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3498
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3507
 msgid ""
 "Oh there’s no need to explain, it’s pretty obvious what you’re up to. Here "
 "we have a whole legion of elves, consorting with dwarves, sneaking up behind "
@@ -8253,19 +8313,19 @@ msgstr ""
 "线背后。在我看来这实在太像是入侵行为了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3505
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3514
 msgid "No, no. You don’t understand! We were told you could help us."
 msgstr "不是，不。不是你想的那样！有人告诉我们，你们会帮助我们的。"
 
 #. [message]: type=Swordsman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3511
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3520
 msgid ""
 "Sir, remember the edict passed down by councilman Noblis? About any "
 "foreigners spotted on the borders?"
 msgstr "长官，您记得由诺不利斯议员通过的法令吗？关于非法入境的外国人的那个？"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3516
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3525
 msgid ""
 "I have no idea what you’re babbling about, elf, but you’re just lucky you "
 "caught me on a good day. You get to explain everything to the Iron Council. "
@@ -8277,18 +8337,18 @@ msgstr ""
 "合适的方法对付你们的。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3521
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3530
 msgid "Everything will be fine. Do as he says."
 msgstr "一切都会好起来的。照他说的做。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3526
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3535
 msgid ""
 "I am my own master. I will not be ordered around, not even by you, Eloh."
 msgstr "我是自己的控制者，不会被别人摆布，即便是你，伊洛。"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3531
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3540
 msgid ""
 "What’s that, boy? Are you talking back to me? This isn’t a negotiation. You "
 "are on my land, and under my jurisdiction. Lay down your weapons and submit "
@@ -8298,7 +8358,7 @@ msgstr ""
 "我管辖。放下武器，乖乖地听话，否则我会让你后悔没有听我的。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3537
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3545
 msgid ""
 "Kaleh, I am Eloh, bearer of the staff of Ishtar and slayer of the demon-god "
 "Zhangor. Submit to him or I shall abandon your people to suffering and "
@@ -8311,7 +8371,7 @@ msgstr ""
 "的神，但并不比沙漠烈日更宽容。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3543
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3551
 msgid ""
 "Then kill me if you must, but I will not give myself over to those who "
 "threaten me and my people. I have not come through peril and darkness just "
@@ -8321,7 +8381,7 @@ msgstr ""
 "艰难险阻，可不是为了来向你投降的。"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3548
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3556
 msgid ""
 "You dare defy me?! All who refuse to submit to the authority of the Iron "
 "Council shall be killed. By the Dark Lady, I shall not put up with this "
@@ -8332,7 +8392,7 @@ msgstr ""
 "你们废话下去了。士兵们，准备战斗！把这些异教徒赶回洞穴里去！"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3583
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3591
 msgid ""
 "You disappoint me, Kaleh. You are weak, and not worthy of my guidance... Do "
 "as you like, but know that while you may be the appointed leader of your "
@@ -8342,7 +8402,7 @@ msgstr ""
 "或许是族人推选出来的领袖，但我是你们的神，而你敢不从我，就是以身犯险！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3594
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3602
 msgid ""
 "You are not the god I grew up with. You may be all-powerful, but I will not "
 "be your puppet. I am still their leader and as long as I draw breath I will "
@@ -8352,12 +8412,12 @@ msgstr ""
 "只要还有一口气在，我就会为族人谋福祉。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3599
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3607
 msgid "Kaleh, would you mind telling me what in Uria’s name is going on."
 msgstr "卡勒，你介意告诉我这尤里安的到底是怎么回事么。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3604
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3612
 msgid ""
 "There’s no time. Right now we have to prepare ourselves for another battle. "
 "I’d better head back to the outpost and rally our troops. I fear a whole lot "
@@ -8367,20 +8427,20 @@ msgstr ""
 "那边很快就会有人来找麻烦。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3609
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3617
 msgid ""
 "Well, now we’re really in for it. I hope you know what you’re doing, Kaleh."
 msgstr "好吧，我们已经陷入麻烦了。卡勒，我希望你知道自己在做什么。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3618
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3626
 msgid ""
 "Grog no like humans either. They mean. But they sound great when they go "
 "squish."
 msgstr "果洛格也不喜欢人类。他们很小气。但是他们被压扁的时候的声音还挺好听。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3624
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3632
 msgid ""
 "Nog no like humans either. They mean. But they sound great when they go "
 "squish."
@@ -8388,30 +8448,30 @@ msgstr "诺格也不喜欢人类。他们很小气。但是他们被压扁的时
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3630
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3636
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3638
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3644
 msgid ""
 "I never liked humans much anyway. I’ll be glad to be fighting something "
 "besides undead."
 msgstr "我从来都对人类没有好感。我很高兴有亡灵以外的东西可以打。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3704
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3712
 msgid "I’m back, Kaleh."
 msgstr "卡勒，我回来了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3709
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3717
 msgid "Ah! You scared me, Nym. I didn’t hear you coming."
 msgstr "啊！你吓死我了，妮慕。我没听到你回来的声音。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3714
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3722
 msgid "Of course you didn’t. That’s why it’s called sneaking."
 msgstr "你当然没听到。否则还能叫潜行吗。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3719
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3727
 msgid ""
 "Anyway you’ve really gotten us into a mess. The good news is that the "
 "outpost isn’t guarded as heavily as you might think. The garrison seems only "
@@ -8422,12 +8482,12 @@ msgstr ""
 "密。守卫部队似乎只有一半编制。显然他们没有预料到这个方向会有大规模的攻击。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3724
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3732
 msgid "And what’s the bad news?"
 msgstr "坏消息是？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3729
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3737
 msgid ""
 "The bad news is that I overheard the commander ordering a special group of "
 "his men to get ready to ride north and summon reinforcements. It seems that "
@@ -8441,19 +8501,19 @@ msgstr ""
 "来了，我们就会处于劣势，我担心我们会被击败。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3734
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3742
 msgid ""
 "Then we’ll just have to make sure that no messenger escapes this valley to "
 "summon reinforcements."
 msgstr "那我们要确保没有任何一个信使能逃出这个山谷去请求援军。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3800
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3808
 msgid "Undead Emissary"
 msgstr "亡灵间谍"
 
 #. [message]: speaker=Undead Emissary
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3804
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3812
 msgid ""
 "Cursed elves, you tracked your filth through our halls and you defiled our "
 "sanctuary. You have besmirched our honor, and we will have our revenge. We "
@@ -8465,14 +8525,14 @@ msgstr ""
 "那天踏入我们家园的行为感到后悔！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3821
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3829
 msgid ""
 "Can’t the dead ever just stay dead? And aren’t they trapped by the flooded "
 "tunnels and caves?"
 msgstr "死了就死了，为什么还这么不安分？难道涨水的坑道和洞穴挡不住他们吗？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3826
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3834
 msgid ""
 "Undead don’t have to breathe and I don’t think a little water is going to "
 "stop them. Besides, you saw how the ghost just flew through the rock; if "
@@ -8482,24 +8542,24 @@ msgstr ""
 "岩石的，如果他们能在墙上走路，那他们还关心什么坑道涨不涨水呢？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3831
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3839
 msgid "Great. So now we’re fighting in a haunted valley."
 msgstr "好极了，现在我们在一个闹鬼的山谷里作战。"
 
 #. [unit]: type=Spectre, id=Undead Leader
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3843
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3851
 msgid "Undead Leader"
 msgstr "亡灵首领"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3858
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3866
 msgid ""
 "I don’t understand. What are these humans doing here? I’ve never seen so "
 "many in one place before."
 msgstr "我不明白，这些人类在这里做什么？从来没见过如此多的人在同一个地方。。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3863
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3871
 msgid ""
 "Humans aren’t just the bandits and outlaws you’re familiar with from the "
 "deserts, Kaleh. Remember that long ago the great human empire of Wesnoth "
@@ -8514,7 +8574,7 @@ msgstr ""
 "不善。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3868
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3876
 msgid ""
 "But now is not a time for preaching. Humans once spread to many lands, and "
 "despite all the ravages of time, I have no doubt that at least a few of them "
@@ -8526,12 +8586,12 @@ msgstr ""
 "希望别人也会这样评价我们的同胞。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3873
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3881
 msgid "There might be other elves somewhere. We can’t be sure."
 msgstr "其他地方可能还有其他精灵。还不能确认。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3878
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3886
 msgid ""
 "No, we can’t. But for now we must deal with the problem at hand. Thank you "
 "for the information, Zhul; these humans are good fighters but they are no "
@@ -8543,42 +8603,41 @@ msgstr ""
 "斗了，我是不会被这样一伙流氓给击败的。"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3916
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3924
 msgid ""
 "Send forth the messenger and his escort. Go north and bring help as soon as "
 "possible!"
 msgstr "派出信使和他的卫队。到北边去搬救兵，越快越好！"
 
 #. [unit]: type=Dragoon, id=messenger
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3932
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3940
 msgid "Human Messenger"
 msgstr "人类信使"
 
-#. [unit]: type={ON_DIFFICULTY (Cavalryman) (Cavalryman) (Dragoon)}
-#. [unit]: type={ON_DIFFICULTY (Cavalryman) (Dragoon) (Dragoon)}
-#. [unit]: type={ON_DIFFICULTY (Spearman) (Javelineer) (Swordsman)}
-#. [unit]: type={ON_DIFFICULTY (Bowman) (Bowman) (Longbowman)}
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3941
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3950
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3959
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3968
+#. [unit]: type={ON_DIFFICULTY4 (Cavalryman) (Cavalryman) (Dragoon) (Cavalryman)}
+#. [unit]: type={ON_DIFFICULTY4 (Spearman) (Javelineer) (Swordsman) (Javelineer)}
+#. [unit]: type={ON_DIFFICULTY4 (Bowman) (Bowman) (Longbowman) (Bowman)}
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3949
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3958
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3967
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3976
 msgid "Human Escort"
 msgstr "人类护卫"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3977
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:3985
 msgid ""
 "If that messenger escapes the valley, we’ll be in trouble. We have to stop "
 "him!"
 msgstr "假如信使逃出山谷，我们就有麻烦了。必须拦住他！"
 
 #. [message]: speaker=messenger
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4009
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4017
 msgid "No! I must get help!"
 msgstr "不！我必须求援！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4022
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4030
 msgid ""
 "Good. We’re safe for now. We just have to defeat Durstrag before he sends "
 "another messenger for reinforcements."
@@ -8586,57 +8645,57 @@ msgstr ""
 "好了。我们现在安全了。我们现在要在德崔格派出另一个求援的信使之前击败他。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4058
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4066
 msgid ""
 "The messenger has escaped! He will surely return with reinforcements. We are "
 "doomed!"
 msgstr "信使逃走了！他一定会带援军回来的。我们完蛋了！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4077
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4085
 msgid ""
 "Don’t worry. We’re not the monsters you seem to think we are. I will not "
 "kill you in cold blood."
 msgstr "别害怕。我们不是你们想象中的那种怪物。我不会冷血地杀死你的。"
 
 #. [message]: speaker=Sergeant Durstrag
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4082
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4090
 msgid "Faugh, boy, you know nothing! There are fates worse than death."
 msgstr "呸，小子，你什么都不知道！我亡灵的后果比让我死更可怕。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4093
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4101
 msgid "He killed himself rather than surrender to us!"
 msgstr "他宁愿自杀也不向我们投降！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4098
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4106
 msgid "They killed Sergeant Durstrag! Run for your lives!"
 msgstr "他们杀死了德崔格长官！快逃命吧！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4115
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4123
 msgid "The rest of the humans are fleeing."
 msgstr "其他人类逃跑了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4120
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4128
 msgid ""
 "Let them go. We have won this battle and I am weary of all this bloodshed."
 msgstr "让他们走吧。我们已经赢了，我也厌倦了杀戮。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4125
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4133
 msgid "What was it that the human Durstrag was so afraid of?"
 msgstr "那个人类德崔格在害怕什么？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4130
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4138
 msgid "I don’t know, but I fear we may find out."
 msgstr "我不知道，但我想我们最终会知道的。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4135
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4143
 msgid ""
 "You’re being very cryptic, Kaleh. Now that the battle is over would you care "
 "to explain to us who you were talking to back when we first met the humans?"
@@ -8645,17 +8704,17 @@ msgstr ""
 "见到那些人类的时候，你在和谁说话？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4140
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4148
 msgid "No, not yet."
 msgstr "不，还不是时候。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4145
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4153
 msgid "What’s wrong, Kaleh? Don’t you trust us?"
 msgstr "怎么了，卡勒？你不信任我们吗？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4150
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4158
 msgid ""
 "Yes, yes of course I do. But it’s just a theory. I don’t want to say more "
 "until I have proof. Give me until tomorrow night, then I’ll tell you "
@@ -8665,14 +8724,14 @@ msgstr ""
 "天晚上，我会告诉你们所有事情。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4155
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4163
 msgid ""
 "Very well. I’ve trusted your decisions and your leadership so far; I’ll wait "
 "a little longer."
 msgstr "非常好。我一直信任你的决定和你的领导；我就再等一等。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4160
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4168
 msgid ""
 "So what do we do now? The land seems to be about the same on the northern "
 "side of the mountains as it was on the south. And we can’t hang around here "
@@ -8683,7 +8742,7 @@ msgstr ""
 "人类总会带着增援回来的，山谷里也还游荡着亡灵。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4165
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4173
 msgid ""
 "Yes, I think the sooner we leave this valley the better. But we don’t know "
 "anything about the surrounding terrain. Without anyone to guide us, we have "
@@ -8696,7 +8755,7 @@ msgstr ""
 "民穿过外国的土地。我们已经失去了太多人。我不想带领大家走向一个陷阱。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4170
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4178
 msgid ""
 "When I was scouting around I think I saw a small oasis near the entrance to "
 "this valley. If we move out there we should be out of range of the undead. I "
@@ -8706,7 +8765,7 @@ msgstr ""
 "能摆脱亡灵了。我想那里是安全的，只少现在是。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4175
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4183
 msgid ""
 "Indeed. Undead ghosts such as these are often bound to the places they died: "
 "the farther away they travel, the weaker they are. So if we move out of the "
@@ -8716,7 +8775,7 @@ msgstr ""
 "越弱。所以如果我们离开这一带，我们就会很安全。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4180
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4188
 msgid ""
 "Good, we’ll move our people out and camp by the oasis. Now, Nym, you know "
 "who our best scouts are; I want you to lead a few elves to do some "
@@ -8730,12 +8789,12 @@ msgstr ""
 "况。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4185
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4193
 msgid "But hasn’t Eloh told you where to go and what dangers you face?"
 msgstr "但是难道伊洛没有告诉你该去哪里以及将要面对的危险吗？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4190
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4198
 msgid ""
 "She was... rather vague. I know we’re supposed to generally go north, but I "
 "want more information before I commit us to a direction."
@@ -8743,7 +8802,7 @@ msgstr ""
 "她曾 …… 相当不明确。我知道应该向北，但是在带领大家出发之前我想要更多信息。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4195
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4203
 msgid ""
 "Don’t you worry about us, Kaleh. We’ll be careful. I’ll organize five bands "
 "to scout out the nearby lands. We should be back in about half a day."
@@ -8752,7 +8811,7 @@ msgstr ""
 "能回来了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4200
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4208
 msgid ""
 "Good, until then we’ll settle around that oasis and set up as good a defense "
 "as we can. Until I know what’s out there, I’m not taking any chances."
@@ -8761,12 +8820,12 @@ msgstr ""
 "面的情况，我是不会冒险的。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4307
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4315
 msgid "Help, I’m drowning!"
 msgstr "救我，我要沉下去了！"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4385
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4393
 msgid ""
 "Look, the water is pouring out the side tunnel into the valley! That’s a lot "
 "of water: it’s even creating a small river. I sure wouldn’t want to be "
@@ -8776,7 +8835,7 @@ msgstr ""
 "身处那洪水的下游。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4409
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4417
 msgid ""
 "Look, up there in the valley. The water has poured out of the side tunnel "
 "and created a small river and lake. I’m glad we weren’t downstream of that "
@@ -8786,24 +8845,24 @@ msgstr ""
 "洪水冲出坑道的时候我们没有在它的下游。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4423
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4431
 msgid ""
 "I can see human reinforcements arriving on the horizon. We’ll surely be "
 "overwhelmed now! If only we had moved faster."
 msgstr "我能看到天际出现了人类的援军。我们会被击败的！除非我们移动得更快一些。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4485
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4493
 msgid "Several hours pass..."
 msgstr "几小时后。。。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4489
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4497
 msgid "Jezhar"
 msgstr "杰扎尔"
 
 #. [message]: speaker=Dummy Unit7
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4494
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4502
 msgid ""
 "Eastern scouts, reporting back! If you like sand and hot dust, there’s "
 "plenty more out there! No water, or signs of others, we had to turn back."
@@ -8812,75 +8871,75 @@ msgstr ""
 "象，我们只能折返了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4499
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4507
 msgid ""
 "No shame in that, Jezhar. Of all the scouts, only Tanstafaal and Nym have "
 "yet to return."
 msgstr "这不丢人，杰扎尔。所有的侦察员里，只有坦斯塔法尔和妮慕还没有回来。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4504
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4512
 msgid "And that has me worried. What if-"
 msgstr "这让我很担心。如果——"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4529
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4537
 msgid "In Eloh’s name, Nym, you look terrible. Are you well?"
 msgstr "伊洛保佑，妮慕，你气色好差。还好吧？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4534
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4542
 msgid "Yes. Just... let me... catch... my breath."
 msgstr "还好。只是……有些……让我……喘口气。"
 
 #. [unit]: type=Merman Netcaster, id=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4551
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4559
 msgid "Esanoo"
 msgstr "伊瑟努"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4569
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4577
 msgid "Water. Sweet water. By the gods, I thought my scales would fall off."
 msgstr "水。甘甜的水。我的神啊。我以为鳞片都要掉了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4579
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4587
 msgid "Relax, he’s a friend. Just let me explain."
 msgstr "放松点，这是朋友。我来解释。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4584
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4592
 msgid "You’re really beat up, Nym. Are you sure you’re fine?"
 msgstr "妮慕，你看起来累坏了。你确定他没问题吗？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4589
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4597
 msgid "I’m fine. But I found someone who really wanted to speak with you."
 msgstr "我还好，这个人非常想见你。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4594
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4602
 msgid "He looks like a half-man half-fish."
 msgstr "他看起来半人半鱼。"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4599
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4607
 msgid "Indeed. I come from the ocean, and long have I been looking for you."
 msgstr "是的。我来自大洋，寻找你们已经很长时间了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4604
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4612
 msgid "The ocean? What are you talking about?"
 msgstr "大洋？你在说什么呢？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4609
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4617
 msgid "Don’t try to explain, Esanoo. We’ll have to show them instead."
 msgstr "伊瑟努，不用解释。我们只能展示给他们看。"
 
 #. [message]: speaker=Esanoo
 #. Esanoo is a merman, his leader (Melusand) is female, and his brethren on this mission include a mix of genders.
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4615
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4623
 msgid ""
 "It’s not important. What’s important is that I am an emissary from one who "
 "much desires to speak with you, Kaleh. Despite the danger, our wise leader "
@@ -8890,24 +8949,24 @@ msgstr ""
 "们睿智的领袖还是派我和兄弟们到干旱的土地上来寻找你们的踪迹。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4620
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4628
 msgid "There are more of you? Where are the others?"
 msgstr "你们还有其他人？他们人呢？"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4625
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4633
 msgid ""
 "They have been captured by the foul humans. I just barely managed to hide "
 "and escape, with the help of your friend."
 msgstr "他们被邪恶的人类捉住。在你的朋友的帮助下，我至少可以躲着跑出来。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4630
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4638
 msgid "And why should we trust anything you say?"
 msgstr "为什么我们要相信你？"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4635
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4643
 msgid ""
 "Our leader thought you might be suspicious. She said that what we must talk "
 "with you about concerns the fate of your people. Apparently it concerns "
@@ -8917,12 +8976,12 @@ msgstr ""
 "柯纳戈斯”和“战戈”的事情。她说你会明白的，卡勒。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4640
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4648
 msgid "Hmmmm... Yes, yes I think I do. I don’t know why, but I trust you."
 msgstr "嗯……是的是的，我觉得明白了。不知道为什么，但我相信你。"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4645
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4653
 msgid ""
 "Thank you, Kaleh. Now I have a favor to ask of you. Our instructions were to "
 "find you and to bring you and your people to meet with our wise leader. The "
@@ -8932,12 +8991,12 @@ msgstr ""
 "睿智的领袖。但问题是，我不知道她现在躲在哪里。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4650
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4658
 msgid "You don’t know where to find your leader?"
 msgstr "你不知道去哪里找你的首领？"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4655
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4663
 msgid ""
 "It’s complicated, and I don’t know how much I am allowed to tell you. My "
 "people are fighting a desperate war against... against a powerful foe. Many "
@@ -8959,25 +9018,25 @@ msgstr ""
 "是……"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4660
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4668
 msgid ""
 "...It would be suicide for you to try to rescue them alone. Of course we "
 "will help you!"
 msgstr "……如果你试图独自去营救他们，那相当于自杀。我们当然会帮你的！"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4665
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4673
 msgid "Thank you, Nym. I am not very good at fighting on the dry ground."
 msgstr "谢谢，妮慕。我不擅长在干燥的地面上战斗。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4670
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4678
 msgid ""
 "With you back, Nym, the only scouts yet to return are Tanstafaal’s group."
 msgstr "你回来了，妮慕，坦斯塔法尔的小组是唯一还没回来的侦察员小组了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4675
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4683
 msgid ""
 "They were sent due north. From Esanoo’s description it sounds like they were "
 "headed right for the human settlement. I hope nothing bad has happened to "
@@ -8987,7 +9046,7 @@ msgstr ""
 "安。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4680
+#: data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg:4688
 msgid ""
 "Things are coming to a head, Tanstafaal and our new friends are in trouble. "
 "Time is of the essence, so let’s move out as soon as possible."
@@ -9010,50 +9069,50 @@ msgstr "达瑞斯"
 #. [side]: type=Shock Trooper, id=Zelgant
 #. [side]: type=Javelineer, id=Alastra
 #: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:57
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:87
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:148
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:184
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:235
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:90
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:154
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:193
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:250
 msgid "Human Allies"
 msgstr "人类同盟"
 
 #. [side]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:109
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:112
 msgid "Iron Council"
 msgstr "钢铁议会"
 
 #. [side]: type=Shock Trooper, id=Zelgant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:137
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:143
 msgid "Zelgant"
 msgstr "泽刚特"
 
 #. [side]: type=Javelineer, id=Alastra
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:172
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:181
 msgid "Alastra"
 msgstr "艾拉崔"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:328
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:339
 msgid "Rescue at least two merfolk by turn 16"
 msgstr "在第十六回合前至少救出两个人鱼"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:335
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:346
 msgid "Defeat Tanstafaal and Eloh"
 msgstr "击败坦斯特福和伊洛"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:346
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:355
 msgid "Capture all 4 human ships"
 msgstr "抢占全部4艘人类船只"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:353
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:362
 msgid "Three merfolk must survive"
 msgstr "至少三个人鱼存活"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:391
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:400
 msgid ""
 "Now that we’re down off the hills, you can’t even see all that water, it’s "
 "hidden by the trees. I never thought I would see so many trees in one place."
@@ -9062,7 +9121,7 @@ msgstr ""
 "么多树。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:395
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:404
 msgid ""
 "Compared to the desert it seems almost like a paradise. All this growth and "
 "vegetation, I can feel it pulsing with life."
@@ -9071,7 +9130,7 @@ msgstr ""
 "动。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:399
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:408
 msgid ""
 "And yet these trees seem different, the forest seems darker, somehow. I "
 "prefer to stay out in the open where I can see my enemies coming."
@@ -9080,14 +9139,14 @@ msgstr ""
 "开阔地里。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:406
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:415
 msgid ""
 "Trees look big and strong, like trolls. Dark, too. Grog tired of walking "
 "under hot sun."
 msgstr "树木看起来又大又壮，就像巨魔一样，还很阴凉，果洛格厌倦了在烈日下行走。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:412
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:421
 msgid ""
 "Trees look big and strong, like trolls. Dark, too. Nog tired of walking "
 "under hot sun."
@@ -9095,15 +9154,15 @@ msgstr "树木看起来又大又壮，就像巨魔一样，还很阴凉，诺格
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:418
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:424
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:427
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:433
 msgid ""
 "It looks nice and dark under the trees, less exposed to that blazing sun. "
 "I’m exhausted after walking across all that harsh sand."
 msgstr "树下看起来凉快多了，不像烈日下那样暴晒。我烦透了在贫瘠的沙地上行走。"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:430
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:439
 msgid ""
 "This is where the human encampments lie, to the northwest. They have settled "
 "a chain of islands along the coast of the water. If you break through these "
@@ -9114,7 +9173,7 @@ msgstr ""
 "们了。我想我们行动小队的其他人就被关在那里。"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:434
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:443
 msgid ""
 "Our leader wanted to make sure that if one of us was captured, we couldn’t "
 "betray her location. So she didn’t tell us where she was, but she taught us "
@@ -9128,12 +9187,12 @@ msgstr ""
 "出来。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:438
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:447
 msgid "And you said that there are only five others in your group left?"
 msgstr "你说你的行动小组里还有五个人？"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:442
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:451
 msgid ""
 "We originally numbered much more, but we were ambushed by a band of naga on "
 "the way here. Half of our force held off the naga while the rest of us fled. "
@@ -9149,59 +9208,59 @@ msgstr ""
 "三名人鱼，你们就没有办法找到我们领袖了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:446
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:455
 msgid "Wait, did you hear that?"
 msgstr "等一下。你听到了？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:451
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:460
 msgid "Someone’s coming. Quick, hide!"
 msgstr "有人来了。快，隐蔽！"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:455
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:464
 msgid "What? Huh?"
 msgstr "什么？哈？"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:462
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:463
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:551
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:555
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:556
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:559
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:562
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:471
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:472
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:560
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:564
 #: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:565
 #: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:568
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:571
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:574
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:577
 msgid "Human Scout"
 msgstr "人类哨兵"
 
 #. [message]: id=scout1
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:470
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:479
 msgid "Hey, what do we have here?"
 msgstr "哈，我们看看这是什么？"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:474
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:483
 msgid "Uh... Uh..."
 msgstr "呃……呃……"
 
 #. [message]: id=scout2
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:478
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:487
 msgid ""
 "It’s another one of those fish creatures. It must have come back to try to "
 "rescue its friends."
 msgstr "又是一只鱼怪。肯定是回来救伙伴的。"
 
 #. [message]: id=scout1
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:482
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:491
 msgid ""
 "Ha, stupid creature. But we’re in luck, the Council was looking for the last "
 "of these spies."
 msgstr "呵，愚蠢的生物。但我们很幸运，议会正在找这最后一名间谍。"
 
 #. [message]: id=scout2
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:486
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:495
 msgid ""
 "We’d better get him back to the base. They’re going to sacrifice them all in "
 "some big holy ceremony at dawn just two days from now."
@@ -9210,39 +9269,39 @@ msgstr ""
 "品杀掉。"
 
 #. [message]: id=scout1
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:490
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:499
 msgid "Yeah, we’ll be heroes!"
 msgstr "呀，我们要成英雄了！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:494
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:503
 msgid "Not if we gut you first. Attack!"
 msgstr "你们不会的，我们会先干掉你们。进攻！"
 
 #. [message]: id=scout1
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:498
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:507
 msgid "The Dark Lady protect us, they’re elves!"
 msgstr "黑暗女神保佑，他们是精灵！"
 
 #. [message]: id=scout2
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:502
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:511
 msgid "There’s tons of them! Flee, we must warn the others!"
 msgstr "成百上千的精灵！跑哇，去告诉其他人！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:520
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:529
 msgid "Well, so much for the element of surprise."
 msgstr "哈，这么多惊喜。"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:524
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:533
 msgid ""
 "Thank you. I’m sorry, I don’t know what came over me. They just jumped out "
 "of nowhere."
 msgstr "谢谢。抱歉，我也不知道怎么回事，他们不知道从哪里跳出来的。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:528
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:537
 msgid ""
 "It’s fine, you’re not used to being on dry ground, and you’ve been through a "
 "lot. Even if the humans know we’re coming, we can still take them. Just be "
@@ -9253,14 +9312,14 @@ msgstr ""
 "边。"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:532
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:541
 msgid ""
 "I sure will look forward to that. I’m afraid my scales have all dried out "
 "again. It itches something terrible."
 msgstr "我太想重新回到水里了。我担心我的鳞片又会全部干掉，它痒得要命。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:536
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:545
 msgid ""
 "Well if we’re going to save those merfolk, then we don’t have any time to "
 "lose. The humans said they would be sacrificed in just two days. We’d better "
@@ -9271,36 +9330,36 @@ msgstr ""
 "成为祭品。我们最好就在这里扎营，尽快向西北推进。我希望我们能来得及。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:574
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:577
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:580
 #: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:583
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:586
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:589
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:592
 msgid "Human Soldier"
 msgstr "人类士兵"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:638
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:647
 msgid ""
 "Wonderful! We have rescued all of my band from the humans. I cannot thank "
 "you enough."
 msgstr "太好了！我们已经救出了我所有的同伴。我无法言谢。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:645
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:654
 msgid ""
 "Indeed, we owe you a great debt. You have done well Esanoo, better than I "
 "could have hoped."
 msgstr "确实，我们欠你一个很大的人情。伊瑟努，干得好，出乎我的意料。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:651
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:660
 msgid ""
 "Esanoo said there were five merfolk left in his band. I think we have "
 "rescued them all!"
 msgstr "伊瑟努说他的小队里还有五个人鱼。我想我们已经把他们全都救出来了！"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:655
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:664
 msgid ""
 "Indeed, I think you have now freed all of us. We owe you a great debt. We "
 "are sorry that Esanoo has fallen, but we will honor him and tell everyone "
@@ -9312,15 +9371,15 @@ msgstr ""
 "们并带你们来了。就算是一条小鱼也能掀起海浪啊。"
 
 #. [message]: speaker=Darius
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:673
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:682
 msgid ""
 "Curse them! The elves have freed the merfolk. We will have our vengeance. "
 "Keep fighting, and execute plan C!"
 msgstr "诅咒他们！精灵把人鱼放了。我们要复仇。继续战斗，执行C计划！"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:708
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:746
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:716
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:754
 msgid ""
 "I have returned with the elves we sought. They have agreed to help me rescue "
 "the rest of our group from the foul humans."
@@ -9328,7 +9387,7 @@ msgstr ""
 "我带着我们要找的精灵回来了。他们答应帮我从邪恶的人类手中救出我们小队的人。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:712
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:720
 msgid ""
 "Indeed you have done well, far better than I could have hoped. We shall talk "
 "more later, but for now we have to free the rest of our brethren."
@@ -9336,7 +9395,7 @@ msgstr ""
 "你做的确实很好，比我想的还要好。我们以后再谈，我们现在要先救出我们其他同胞。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:718
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:726
 msgid ""
 "Greetings. Esanoo told us that you were looking for us, and he bravely led "
 "us here. Though he has fallen in combat, we have come to rescue the rest of "
@@ -9346,7 +9405,7 @@ msgstr ""
 "中牺牲了，但是我们还是要把你们救出来。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:722
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:730
 msgid ""
 "Yes, I recognize your face, young elf. We will remember Esanoo’s sacrifice. "
 "But for now we must rescue the rest of my brethren before they too are slain "
@@ -9356,18 +9415,18 @@ msgstr ""
 "被邪恶的人类杀死之前，把他们救出来吧。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:726
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:734
 msgid "How could he recognize your face? We’ve never seen him before."
 msgstr "他怎么会认得你？我们从来没有见过他。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:730
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:770
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:738
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:776
 msgid "We’ll ask later, for now we’ve got to keep fighting."
 msgstr "我们以后再问这个问题吧，现在我们要继续战斗。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:751
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:758
 msgid ""
 "female_speaker^Indeed you have done well, far better than I could have "
 "hoped. We shall talk more later, but for now we have to free the rest of our "
@@ -9376,7 +9435,7 @@ msgstr ""
 "你做的确实很好，比我想的还要好。我们以后再谈，我们现在要先救出我们其他同胞。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:758
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:764
 msgid ""
 "female_addressed^Greetings. Esanoo told us that you were looking for us, and "
 "he bravely led us here. Though he has fallen in combat, we have come to "
@@ -9386,7 +9445,7 @@ msgstr ""
 "中牺牲了，但是我们还是要把你们救出来。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:762
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:768
 msgid ""
 "female_speaker^Yes, I recognize your face, young elf. We will remember "
 "Esanoo’s sacrifice. But for now we must rescue the rest of my brethren "
@@ -9397,52 +9456,52 @@ msgstr ""
 
 # 修改了一下
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:766
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:772
 msgid "How could she recognize your face? We’ve never seen her before."
 msgstr "她怎么会认得你？我们从来没有见过她。"
 
 #. [unit]: type=Merman Warrior, id=Urruga
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:793
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:799
 msgid "Urruga"
 msgstr "乌如格"
 
 #. [message]: speaker=Urruga
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:811
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:817
 msgid ""
 "Free at last! Thanks be to the Sea God. But wait a minute, you’re elves?!"
 msgstr "终于自由了！感谢海神。等一下，你们是精灵？！"
 
 #. [message]: speaker=Urruga
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:823
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:829
 msgid ""
 "Thank you for rescuing me. We’ll show those humans the true fury of the "
 "merfolk!"
 msgstr "谢谢搭救。我们要让人类看看什么是真正的人鱼的愤怒！"
 
 #. [unit]: type=Merman Warrior, id=Nuvassa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:846
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:852
 msgid "Nuvassa"
 msgstr "努瓦萨"
 
 #. [message]: speaker=Nuvassa
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:872
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:878
 msgid ""
 "Thank you for rescuing me. You elves are very skilled at fighting on the dry "
 "land. I envy you."
 msgstr "谢谢搭救。你们精灵在干燥的土地上作战很有技巧，我羡慕你们。"
 
 #. [message]: speaker=$unit.id, race=quenoth,elf
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:877
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:883
 msgid "As I envy your kind’s prowess when fighting in the water."
 msgstr "我们也很羡慕你们在水中的高超战斗技能。"
 
 #. [unit]: type=Merman Spearman, id=Yantili
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:900
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:906
 msgid "Yantili"
 msgstr "阳提利"
 
 #. [message]: speaker=Yantili
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:926
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:932
 msgid ""
 "Thank you for rescuing me. I never imagined that we would actually be able "
 "to find you elves. Our leader was right after all. But more of that later..."
@@ -9450,12 +9509,12 @@ msgstr ""
 "谢谢搭救。我没想到真能找到你们精灵。我们领袖终究说对了。不过先不说这些了……"
 
 #. [unit]: type=Mermaid Priestess, id=Il-tian
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:949
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:955
 msgid "Il-tian"
 msgstr "伊天"
 
 #. [message]: speaker=Il-tian
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:975
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:981
 msgid ""
 "Thank you for rescuing me. May the Sea God’s bounty bless you and protect "
 "you. If you have any wounded I can help heal them. The blades of the vile "
@@ -9465,30 +9524,30 @@ msgstr ""
 "的剑是很可怕的。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:996
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1002
 msgid "What a dark nasty place. Something smells horrible."
 msgstr "这地方真是黑暗又恶心。气味非常难闻。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:999
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1000
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1002
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1003
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1005
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1006
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1008
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1009
 msgid "Undead Warden"
 msgstr "亡灵典狱官"
 
 #. [unit]: type=Mermaid Enchantress, id=We-jial
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1023
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1029
 msgid "We-jial"
 msgstr "薇洁"
 
 #. [message]: speaker=We-jial
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1035
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1041
 msgid "Thank you for rescuing me. How did you manage to escape?"
 msgstr "谢谢搭救。您是怎么逃脱的？"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1046
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1052
 msgid ""
 "One of the elves we were searching for helped me get away before I was "
 "caught. I can’t believe the humans imprisoned you in such a horrible place. "
@@ -9500,7 +9559,7 @@ msgstr ""
 "付出代价！"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1052
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1058
 msgid ""
 "Esanoo found the elves that we were searching for. He brought them back and "
 "they helped free us. I can’t believe the humans imprisoned you in such a "
@@ -9512,7 +9571,7 @@ msgstr ""
 "付出代价！"
 
 #. [message]: speaker=We-jial
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1058
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1064
 msgid ""
 "Do not worry yourself, now that I am free all will be set to rights. It is "
 "not our mission to defeat all the evil in this world. Protecting the elves "
@@ -9522,12 +9581,12 @@ msgstr ""
 "务。保护精灵才是最重要的。我们必须带他们去见领袖，其它都是次要的。"
 
 #. [message]: speaker=$explorer.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1062
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1068
 msgid "Yes, you are right, of course. Pardon me."
 msgstr "自然。你是正确的。原谅我。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1103
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1109
 msgid ""
 "No, too many merfolk have died! There are not enough of them left to divine "
 "the location of their leader. We should have protected the merfolk more "
@@ -9537,7 +9596,7 @@ msgstr ""
 "保护人鱼才对。现在我们的搜索已经没有希望了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1110
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1116
 msgid ""
 "Too many merfolk have died! Even if we save the rest, there will not be "
 "enough for them to divine the location of their leader. We should have "
@@ -9547,7 +9606,7 @@ msgstr ""
 "下落了。我们应该更小心保护人鱼才对。现在我们的搜索已经没有希望了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1136
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1142
 msgid ""
 "Whoa, this water is warm. Imagine if we had this back home, more water than "
 "I could drink in a lifetime! Hey... wait a minute. Faugh! This water is "
@@ -9558,7 +9617,7 @@ msgstr ""
 "这水是咸的！这味道太糟了，我喝不了这个！这些水又不能喝，要这么多干什么用？"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1163
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1169
 msgid ""
 "It really is beautiful out here, looking out over the sparkling water. If I "
 "didn’t have vile humans and traitorous elves at my back I could spend all "
@@ -9569,7 +9628,7 @@ msgstr ""
 "坐在这里。但是我必须回到战斗中去。啊，生活真是艰难。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1169
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1175
 msgid ""
 "It really is beautiful out here, looking out over the sparkling water. If I "
 "didn’t have vile humans and Eloh knows what else at my back I could spend "
@@ -9580,7 +9639,7 @@ msgstr ""
 "等着，我多想整天都坐在这里。但是我必须回到战斗中去。啊，生活真是艰难。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1186
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1192
 msgid ""
 "If I were a landwalker, I might think the view from this sandbar to be "
 "amazing. But I am a creature of the sea and I see views like this every day."
@@ -9589,14 +9648,14 @@ msgstr ""
 "种场面我见多了。"
 
 #. [message]: speaker=Zelgant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1208
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1214
 msgid ""
 "You trespass upon our land at your own peril. All who oppose the will of the "
 "Iron Council shall be crushed!"
 msgstr "你们竟敢铤而走险闯入我们的地盘。所有违抗钢铁议会的人都必须受到惩罚！"
 
 #. [message]: speaker=Alastra
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1227
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1233
 msgid ""
 "Foolish elves. We have heard of your pitiful kind. You are but worms "
 "compared to the might of the Dark Lady. Coming here shall be your undoing."
@@ -9605,7 +9664,7 @@ msgstr ""
 "是虫子罢了。你们来这里就是自寻死路。"
 
 #. [message]: speaker=Darius
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1246
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1252
 msgid ""
 "She said you would come. You may be able to defeat us, but none can defy "
 "her. You will bow down in the end. It is your destiny."
@@ -9614,20 +9673,20 @@ msgstr ""
 "的。这是你们的命运。"
 
 #. [print]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1279
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1285
 msgid ""
 "$(16 - $turn_number) turns remain to free $number_merfolk_caged| merfolk"
 msgstr "剩余回合数为$(16-$turn_number)，以释放$number_merfolk_caged|名人鱼"
 
 #. [event]
 #. [unit]: type=Necromancer, id=Hekuba
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1304
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2364
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1310
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2368
 msgid "Hekuba"
 msgstr "哈库巴"
 
 #. [message]: speaker=Hekuba
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1346
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1352
 msgid ""
 "The time has come, my brethren. On this most holy day, let us sacrifice "
 "these infidels unto The Dark Lady. Their suffering shall be a testament to "
@@ -9637,7 +9696,7 @@ msgstr ""
 "们的痛苦就是她的力量与光荣的证明！"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1373
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1379
 msgid ""
 "Oh no! Our enchantress, We-jial. Where did they hide her? What horrible fate "
 "has befallen her? If only we could have saved her in time."
@@ -9646,7 +9705,7 @@ msgstr ""
 "我们能及时救出她就好了。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1377
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1383
 msgid ""
 "The Sea God will carry her soul out to sea and bear it to the deeps. May he "
 "watch over her until the day we are all together again."
@@ -9655,7 +9714,7 @@ msgstr ""
 "天。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1383
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1389
 msgid ""
 "Esanoo said there were five merfolk captured. We only found four. Where did "
 "they hide the last one? What horrible acts have these humans committed?"
@@ -9664,7 +9723,7 @@ msgstr ""
 "受什么样的悲惨命运？"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1388
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1394
 msgid ""
 "They took We-jial, our enchantress, away from us. But she is at peace now. "
 "The Sea God will carry her soul out to sea and bear it to the deeps. May he "
@@ -9674,20 +9733,20 @@ msgstr ""
 "回到海里，让她安息的。愿神照看着她，直到我们再次团聚的那一天。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1396
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1402
 msgid "The bars of the cages are smoking and glowing red hot!"
 msgstr "笼子的杆冒烟了，而且变得红热起来！"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1405
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1411
 msgid ""
 "May the Sea God protect us. They are being burnt alive! It’s terrible, I "
 "can’t bear to watch."
 msgstr "海神保佑我们。他们正在被活活地灼烧着！太残忍了，我看不下去了。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1409
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1419
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1415
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1425
 msgid ""
 "The Sea God will carry their souls out to sea and bear them to the deeps. "
 "May he watch over them until the day we are all together again."
@@ -9696,7 +9755,7 @@ msgstr ""
 "天。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1415
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1421
 msgid ""
 "Eloh protect us. They are being burnt alive! I do not know what the purpose "
 "of the unholy sacrifice is, but it is sickening to watch."
@@ -9705,12 +9764,12 @@ msgstr ""
 "么，这一幕太恶心了。"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1450
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1456
 msgid "They are all dead. We were too late. Forgive me, wise leader!"
 msgstr "他们全死了。我们太迟了。原谅我，睿智的领袖！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1454
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1460
 msgid ""
 "We couldn’t save enough of the merfolk. We have failed. Now we shall never "
 "be able to meet the merfolk’s leader!"
@@ -9718,7 +9777,7 @@ msgstr ""
 "我们没能救出足够数量的人鱼。我们失败了。现在我们再也见不到人鱼的首领了！"
 
 #. [message]: speaker=Esanoo
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1468
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1474
 msgid ""
 "Oh Master, forgive me. I could not save them all in time. Vile humans, you "
 "shall pay twice over for what you have done!"
@@ -9726,7 +9785,7 @@ msgstr ""
 "噢主人，原谅我。我没能及时救出他们。邪恶的人类啊，我要让你们付出双倍的代价！"
 
 #. [message]: speaker=Darius
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1486
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1491
 msgid ""
 "The stinkin’ elves have freed some of the merfolk. And still they fight on. "
 "Execute plan B. And kill those merfolk!"
@@ -9735,25 +9794,25 @@ msgstr ""
 
 #. [message]: speaker=Darius
 #. [message]: speaker=Alastra
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1515
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1564
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1520
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1569
 msgid "I must go report to the Iron Council. Keep fighting!"
 msgstr "我必须去报告给钢铁议会。继续战斗！"
 
 #. [message]: speaker=Zelgant
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1535
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1540
 msgid ""
 "I go to marshal reinforcements. Do not lose heart, we will crush these puny "
 "elves."
 msgstr "我去征募援军。别失去信心，我们会碾碎这些渺小的精灵的。"
 
 #. [message]: speaker=Alastra
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1554
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1559
 msgid "I must leave for now, fight on in my stead."
 msgstr "我现在一定要离开，代替我努力战斗。"
 
 #. [message]: speaker=Hekuba
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1588
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1593
 msgid ""
 "Curse them! The elves have stolen our offering to the Lady. We will have our "
 "vengeance. Keep fighting and execute plan C!"
@@ -9766,13 +9825,13 @@ msgstr ""
 #. so far Hekuba has either watched silently (if Darius is still alive), or has said
 #. versions of Darius' lines about the sacrifice.
 #. Either way, he just walked into the shrouded area in the north-west.
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1618
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1623
 msgid "Who was that?"
 msgstr "那是谁？"
 
 #. [message]: race=merman
 #. subject is a male necromancer
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1623
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1628
 msgid ""
 "That was one of the Iron Triad. Rarely do they leave their sanctuary. They "
 "prefer to let their minions do the dirty work."
@@ -9781,22 +9840,22 @@ msgstr ""
 "活。"
 
 #. [unit]: type=Quenoth Champion, id=Tanstafaal
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1657
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1662
 msgid "Tanstafaal"
 msgstr "坦斯特福"
 
 #. [message]: speaker=Tanstafaal
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1673
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1677
 msgid "Hail, my brothers, I have returned!"
 msgstr "嘿，兄弟们，我回来了！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1677
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1681
 msgid "Tanstafaal, where have you been? We have been looking for you."
 msgstr "坦斯特福，你去哪里啦？我们都在找你。"
 
 #. [message]: speaker=Tanstafaal
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1681
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1685
 msgid ""
 "I have gone on a journey and I have seen the light. No longer will I blindly "
 "follow in your footsteps, Kaleh. I have come back to lead our people on the "
@@ -9807,39 +9866,39 @@ msgstr ""
 "我们的人民走上正确的道路。她已经指示我了，我是她神圣意愿的唯一执行者。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1685
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1689
 msgid "Who has spoken to you?"
 msgstr "谁已经指示你了？"
 
 #. [message]: speaker=Tanstafaal
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1702
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1706
 msgid ""
 "Behold, our goddess has returned to us. All bow down to Eloh, our savior!"
 msgstr "安静，我们的女神回来了。膜拜我们的救主伊洛！"
 
 #. [message]: role=mystic_speaker
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1731
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1735
 msgid "The Goddess!"
 msgstr "女神！"
 
 #. [message]: role=fighter_speaker
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1735
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1739
 msgid "Forgive me my sins!"
 msgstr "请原谅我的罪过！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1739
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1743
 msgid "That I am so blessed to gaze upon Eloh herself..."
 msgstr "我真荣幸窥见伊洛正身……"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1743
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1747
 msgid ""
 "Hail my people. In your time of trial I appear to you, to save you yet again."
 msgstr "我的人民，你们好。当你们身陷险境的时候，我向你们显现，来再次拯救你们。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1747
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1751
 msgid ""
 "I come to you with dire news: one of you has betrayed me, and is a traitor "
 "to your cause."
@@ -9848,18 +9907,18 @@ msgstr ""
 
 #. [message]: role=scout_speaker
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1755
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:329
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1759
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:324
 msgid "No!"
 msgstr "不！"
 
 #. [message]: role=rider_speaker
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1759
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1763
 msgid "Who?"
 msgstr "谁？"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1763
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1767
 msgid ""
 "Did I not say that I would deliver you from evil and bring you to the "
 "promised land? I have shepherded you out of the harsh deserts and under the "
@@ -9869,7 +9928,7 @@ msgstr ""
 "穿过贫瘠的沙漠和山脉底下。你们本来已经接近救赎了。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1767
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1771
 msgid ""
 "But there was one who grew corrupted by his power and rejected my divine "
 "plan. He sought to usurp my authority. He had no faith and believed that he "
@@ -9883,7 +9942,7 @@ msgstr ""
 "盘皆输。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1771
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1775
 msgid ""
 "Yes, I speak of your so-called leader, Kaleh. I did call out to him "
 "initially because I thought he was one of the faithful, but he betrayed my "
@@ -9898,7 +9957,7 @@ msgstr ""
 "继续跟他走下去，他最终会让你们向人鱼的邪神俯首称臣。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1775
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1779
 msgid ""
 "That is why I called out to Tanstafaal, one of my loyal followers. All is "
 "not yet lost. Follow him and I can still deliver you from your peril. But "
@@ -9910,7 +9969,7 @@ msgstr ""
 "人类争斗，还要杀死这个异教徒卡勒以及他的同党。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1785
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1789
 msgid ""
 "Wait, my people, do not be deceived. This thing that appears by Tanstafaal’s "
 "side is not our god. I too was fooled at first, but I have come to realize "
@@ -9928,7 +9987,7 @@ msgstr ""
 "否则她就要毁了我。伊洛从没有威胁我们中的任何人，也没有命令我们去做任何事。"
 
 #. [message]: role=fighter_speaker
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1789
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1793
 msgid ""
 "Why should we trust you? We have not heard Eloh’s words directly. Only now "
 "that you have led us into this folly has Eloh appeared to us."
@@ -9937,7 +9996,7 @@ msgstr ""
 "唐事之后，伊洛才显灵。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1793
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1797
 msgid ""
 "She claims to be the one who has shepherded us during this journey, but who "
 "protected you across the harsh sands, who fought the orcs and led you under "
@@ -9957,7 +10016,7 @@ msgstr ""
 "伪神。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1799
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1803
 msgid ""
 "Wait, my people, do not be deceived. This thing that appears by Tanstafaal’s "
 "side is not our god. I too was fooled at first, but I have come to realize "
@@ -9975,7 +10034,7 @@ msgstr ""
 "否则她就要毁了我。伊洛从没有威胁我们中的任何人，也没有命令我们去做任何事。"
 
 #. [message]: role=fighter_speaker
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1803
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1807
 msgid ""
 "Why should we trust you? We have not heard these words directly. Only now "
 "that you have led us into this folly has she appeared to us."
@@ -9984,7 +10043,7 @@ msgstr ""
 "后，她才显灵。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1807
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1811
 msgid ""
 "She claims to be the one who has shepherded us during this journey, but who "
 "protected you across the harsh sands, who fought the orcs and led you under "
@@ -10004,7 +10063,7 @@ msgstr ""
 "伪神。"
 
 #. [message]: speaker=Tanstafaal
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1813
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1817
 msgid ""
 "Your words are meaningless, Kaleh. My brethren, Eloh has appeared to you. "
 "She has spoken. Defy her at your own peril. I declare all who oppose Eloh "
@@ -10015,7 +10074,7 @@ msgstr ""
 "入我吧，让我们杀了冒犯神的家伙！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1817
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1821
 msgid ""
 "Eloh would never ask elf to kill elf. But it seems I have little choice. My "
 "people, I have led you this far, join with me and help me crush this new "
@@ -10025,7 +10084,7 @@ msgstr ""
 "家走到了今天，请加入我，帮我粉碎这场叛乱！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1821
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1825
 msgid ""
 "I have followed you this far Kaleh, I will not abandon you now. But I admit "
 "that my faith is shaken. If that is not our god, then what is it?"
@@ -10034,7 +10093,7 @@ msgstr ""
 "不是我们的神，那它是谁呢？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1825
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1829
 msgid ""
 "I do not know, but given what I have seen of the humans, I think following "
 "her would lead us down a dark road indeed. One that I personally do not want "
@@ -10044,13 +10103,13 @@ msgstr ""
 "道。我个人可不想看到这条道的尽头是什么。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1829
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1833
 msgid ""
 "Forgive me, Kaleh. I do not know what to believe. I... I have to ponder this."
 msgstr "卡勒，原谅我。我不知道该相信谁。我……我得考虑考虑。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1836
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1840
 msgid ""
 "Great Leader told Grog to serve you, and so Grog will still follow your "
 "command. But other elves must be out on a separate island. How will we cross "
@@ -10060,7 +10119,7 @@ msgstr ""
 "岸的岛上。我们怎样才能渡过深水区呢？"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1842
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1846
 msgid ""
 "Great Leader told Nog to serve you, and so Nog will still follow your "
 "command. But other elves must be out on a separate island. How will we cross "
@@ -10071,8 +10130,8 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1848
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1854
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1852
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1858
 msgid ""
 "The chieftain told me to serve you, and it will take more than this to "
 "shatter my confidence in you, lad. But those elves must be out on a "
@@ -10082,7 +10141,7 @@ msgstr ""
 "在另一个独立的岛上，我们怎样才能穿过深水区呢？"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1861
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1865
 msgid ""
 "I believe that in this we can help. We are very grateful for all you have "
 "done for us Kaleh, and though we assure that we mean you no harm, you are "
@@ -10097,7 +10156,7 @@ msgstr ""
 "道，帮你过去，这样你就能平息叛乱了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1894
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1898
 msgid ""
 "Thank you, I’m sure you will be very useful in the shallow waters. All right "
 "people, I don’t want to kill any more than I have to. Too much blood has "
@@ -10109,7 +10168,7 @@ msgstr ""
 "死他们。我们必须在坦斯特福摧毁我们之前，阻止他疯狂的行为。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1898
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1902
 msgid ""
 "We who have fought by your side before will stand with you Kaleh, but many "
 "of our people are fleeing and joining Tanstafaal. I’m afraid that while you "
@@ -10119,38 +10178,38 @@ msgstr ""
 "那边去了。我担心虽然你还能召回老部下，但是已经不能征募新战士了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1902
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1906
 msgid "Then we will make do with those few that we have."
 msgstr "那我们就利用这些仅有的人吧。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1919
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1920
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1921
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1922
 #: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1923
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1924
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1925
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1926
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1927
 msgid "Elvish Rebel"
 msgstr "精灵叛徒"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1956
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1960
 msgid ""
 "I’m sorry Kaleh, I cannot let our people slaughter each other. There must be "
 "a way to stop this."
 msgstr "我很抱歉卡勒，我不能让我的同胞自相残杀。一定有办法阻止这一切。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1960
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1964
 msgid "No, don’t..."
 msgstr "不，不要……"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1964
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1968
 msgid "I have no choice, goodbye."
 msgstr "我没有选择，再见。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1974
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1978
 msgid ""
 "Oh Eloh, you know how long I have faithfully served you. I ask you now a "
 "boon in return. Do not kill the boy Kaleh, he is just doing what his heart "
@@ -10162,7 +10221,7 @@ msgstr ""
 "原谅是高尚的”</b>？"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1979
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1983
 msgid ""
 "You dare to lecture me? I am a god and you are but a mortal. You of all "
 "people should know that your position is to enforce my will, not question it!"
@@ -10170,7 +10229,7 @@ msgstr ""
 "你敢给我上课？我是神，你只是个劳力。你们的立场就是服从我的愿望，毋庸置疑！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1983
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1987
 msgid ""
 "But you yourself can see that many of our people’s faith is wavering. You "
 "cannot gain their loyalty by slaughtering the boy and his friends. Be "
@@ -10182,7 +10241,7 @@ msgstr ""
 "斗。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1987
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1991
 msgid ""
 "Times have changed. Mercy is a sign of weakness. Let this be a lesson to "
 "everyone, absolute loyalty is absolute strength. It is clear that you do not "
@@ -10196,12 +10255,12 @@ msgstr ""
 "们会战胜所有敌人！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1991
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1995
 msgid "No, I—"
 msgstr "不，我——"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1995
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:1999
 msgid ""
 "No, I don’t think you shall pester me any more. You shall be as a statue, "
 "forced to watch events unfold and helpless to interfere. Yes, I think this "
@@ -10212,32 +10271,32 @@ msgstr ""
 "去干扰战斗。是的，我想这是一个合适的惩罚。然后你才能学会不质疑我的神圣意愿。"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2020
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2024
 msgid "Aarrggh! Voices in my head, make them stop!"
 msgstr "啊！我脑袋里有声音，停下！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2024
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2028
 msgid "What? What do you hear?"
 msgstr "什么？你听到了什么？"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2028
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2032
 msgid "Must... Can’t... Must... Help me!"
 msgstr "必须……不能……必须……救我！"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2046
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2050
 msgid "Must obey... Can’t resist... I... Yes, Mistress, I am yours."
 msgstr "必须服从……不能抗命……我……是的，女主人，我是你的奴隶。"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2050
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2054
 msgid "Pretty lady say elves bad. Kill elves. Kill!"
 msgstr "漂亮女神说精灵坏。杀掉精灵。杀！"
 
 #. [message]: speaker=Kromph
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2077
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2081
 msgid ""
 "Mistress gone, must follow commands, but Nym master too, Nym say must "
 "protect elves, but mistress say must kill elves, but must protect, must "
@@ -10247,40 +10306,40 @@ msgstr ""
 "要杀死精灵，但是要保护，要杀死，保护，杀死，保护，杀死，啊！！！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2086
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2090
 msgid ""
 "He just collapsed, the conflicting orders must have been too much for him."
 msgstr "他崩溃了，两个冲突的命令一定让他很为难。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2090
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2094
 msgid "Poor Kromph, at least he’s finally at rest."
 msgstr "可怜的克伦夫，他最终安息了。"
 
 #. [event]: role=Angry Crab
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2108
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2128
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2112
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2132
 msgid "Angry Crab"
 msgstr "生气的螃蟹"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2115
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2119
 msgid "Where did those things come from? They look dangerous."
 msgstr "它们从哪儿来的？危险。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2135
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2139
 msgid "What are those things? They looked like ticked off giant crabs."
 msgstr "这些是什么啊？看来像是生气的大螃蟹。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2156
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2160
 msgid ""
 "You think you can strike me down. This is just a small part of my true power."
 msgstr "你认为可以打倒我。但那只是我力量的一小部分。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2160
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2164
 msgid ""
 "Small part or no, if it is mortally possible to destroy you, I shall. Your "
 "hands are stained in our blood; you are not our god."
@@ -10289,31 +10348,31 @@ msgstr ""
 "血，你不是我们的神。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2174
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2178
 msgid "Don’t worry Kaleh, we will see each other again... I promise."
 msgstr "卡勒，不用担心，我们会再见的……我保证。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2182
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2186
 msgid "She freaks me out, but at least it seems that she can be destroyed."
 msgstr "她是个很大的威胁，不过我们已经知道她可以被击败。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2186
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2190
 msgid ""
 "That was just an apparition, but if we meet again I will make her pay for "
 "all that she has done."
 msgstr "那只是个幽灵，但是如果再次遇到，我要她偿还一切代价。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2198
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2202
 msgid ""
 "I’m sorry, Kaleh. My faith clouded my reason. But I wanted so very much to "
 "believe."
 msgstr "卡勒，我很抱歉。我的信仰蒙蔽了理智。但是我非常需要一个信仰。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2202
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2206
 msgid ""
 "You do not need to apologize. What you did was very brave. I wish to... to "
 "whatever god still watches over us, that this bloodshed was not necessary. "
@@ -10325,7 +10384,7 @@ msgstr ""
 "运。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2206
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2210
 msgid ""
 "So when you had the strange encounter with that human Durstrag and his "
 "guards, just after we escaped the caves, you were talking to Eloh, or "
@@ -10335,7 +10394,7 @@ msgstr ""
 "在和伊洛讲话，或者某个别的东西？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2210
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2214
 msgid ""
 "Yes, she appeared only to me and demanded that I surrender to the humans. "
 "When I refused she threatened me, saying she would kill me if I refused. "
@@ -10345,7 +10404,7 @@ msgstr ""
 "拒绝她，她就要杀了我。从那时起，我开始怀疑她。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2214
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2218
 msgid ""
 "It is clear that that thing was not our god. I do not know what it was, but "
 "I have to keep believing that Eloh is out there somewhere. Without our "
@@ -10355,12 +10414,12 @@ msgstr ""
 "方。没有了信仰，我们还有什么呢？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2218
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2222
 msgid "We have each other."
 msgstr "我们都还在，都在一起。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2222
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2226
 msgid ""
 "That’s not enough. Look, you’re a wonderful girl Nym, and Kaleh, you’ve "
 "shown yourself to be a great leader, but our actions have to mean something "
@@ -10372,52 +10431,52 @@ msgstr ""
 "的计划。我们必须坚持我们的信仰。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2226
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2230
 msgid "Peace, Zhul, we can discuss theology later. We still have work to do."
 msgstr "好了，朱尔，我们可以等会儿再讨论神学。我们还有别的事情要做。"
 
 #. [message]: speaker=Tanstafaal
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2248
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2252
 msgid ""
 "You cannot defeat me, I am protected by the goddess now. Finally, Kaleh, I "
 "will show everyone who is stronger!"
 msgstr "你不能击败我，我被女神护佑。最后，卡勒，我要向世界展示我比你强！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2252
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2256
 msgid "Oh Tanstafaal, I pity you. This battle was never about you."
 msgstr "哦，坦斯特福。这场战斗实际上不是你的事。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2267
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2271
 msgid ""
 "No, do not kill him. He may deserve it, but he will not die at my hands."
 msgstr "不，不要杀他。他或许应得惩罚，但是不应该死在我手里。"
 
 #. [message]: speaker=Tanstafaal
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2271
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2275
 msgid "Never Kaleh. I will not be your lackey again!"
 msgstr "永远也不会的，卡勒，我再也不会向你屈服！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2280
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2284
 msgid ""
 "Why did he have to kill himself? Oh, poor misguided Tanstafaal. We have lost "
 "too many elves today."
 msgstr "他为什么自杀？噢，可怜的坦斯特福，我们今天失去了很多同胞。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2284
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2288
 msgid "Do not blame yourself too much, it is Eloh who persuaded him to rebel."
 msgstr "不要过多责怪自己，是伊洛把他推向反叛的道路。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2288
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2292
 msgid "Yes, she too will pay for her part in all of this."
 msgstr "是，她也要为这个付出代价。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2309
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2313
 msgid ""
 "It is finished. See, my people, Tanstafaal has been killed by his own hand, "
 "and the thing pretending to be our god is gone."
@@ -10425,7 +10484,7 @@ msgstr ""
 "结束了。大伙，看，坦斯特福最终自食其果，那个自称是我们的神的家伙也已经走了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2313
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2317
 msgid ""
 "You who call yourself Eloh, I challenge you, if you are truly our god, then "
 "show yourself, and strike me down where I stand!"
@@ -10433,7 +10492,7 @@ msgstr ""
 "自称伊洛的家伙，我要挑战你。如果你真是我们的神，那就现身吧，把我击倒吧！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2320
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2324
 msgid ""
 "Nothing. Eloh may still watch over us, but that thing was not her. And yet, "
 "I do not hold a grudge against all of you who rebelled. I too was deceived "
@@ -10449,7 +10508,7 @@ msgstr ""
 "后已。"
 
 #. [message]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2327
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2331
 msgid ""
 "I think I speak for all of us when I say that we accept your offer of "
 "amnesty and will follow you again. You have proved yourself capable as a "
@@ -10461,7 +10520,7 @@ msgstr ""
 "斯特福这件事上也许错了。我们要长久地反思这件事。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2345
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2349
 msgid ""
 "Thank you. And I have also not forgotten the pledge I made to our merfolk "
 "friends. If it is possible, I would like to meet with your leader. Your "
@@ -10471,32 +10530,32 @@ msgstr ""
 "好，你们的同胞肯定也不差，至少，我可以相信你们。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2349
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2353
 msgid "Thank you."
 msgstr "谢谢你。"
 
 #. [unit]: type=Necromancer, id=Zilchis
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2376
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2380
 msgid "Zilchis"
 msgstr "吉崔斯"
 
 #. [unit]: type=Necromancer, id=Sultaria
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2387
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2391
 msgid "Sultaria"
 msgstr "索特瑞"
 
 #. [message]: speaker=Hekuba
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2396
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2400
 msgid "And what about us, little elf, did you forget about us?"
 msgstr "我们呢，小精灵，你不会忘记了我们吧？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2400
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2404
 msgid "I could never forget what you did to those merfolk."
 msgstr "我永远也不会忘了你们对这些人鱼做了什么。"
 
 #. [message]: speaker=Hekuba
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2404
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2408
 msgid ""
 "Good, for that is just a taste. You are fools to interfere with our affairs, "
 "and the Iron Council does not tolerate fools. The Dark Lady shall swallow "
@@ -10511,20 +10570,20 @@ msgstr ""
 "我们渡水。我们要像瘟疫一样推进，把这些异教徒赶出去！"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2447
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2448
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2449
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2450
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2451
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2452
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2453
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2454
 msgid "Arisen Warrior"
 msgstr "被召唤的战士"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2454
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2458
 msgid "Gosh, just when things were starting to calm down."
 msgstr "天啊，一瞬间安静下来了。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2458
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2462
 msgid ""
 "Our people are scattered and exhausted, where will we go now Kaleh? Shall we "
 "retreat into the dunes?"
@@ -10532,7 +10591,7 @@ msgstr ""
 "我们的人分散开了而且精疲力尽，卡勒我们现在该往哪里去？我们要退回沙丘去么？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2462
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2466
 msgid ""
 "Before I decide, I have just one question: How did you merfolk plan on "
 "bringing us to meet your leader, if she dwells far beneath the sea?"
@@ -10541,7 +10600,7 @@ msgstr ""
 "们的首领？"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2469
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2473
 msgid ""
 "Actually we prefer to dwell in the shallow waters, where we may frolic in "
 "the great coral reefs under the sun and moon. But I digress, we realize that "
@@ -10551,7 +10610,7 @@ msgstr ""
 "扯远了，考虑到你们不能像我们一样游泳，我想了一个办法。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2476
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2480
 msgid ""
 "The humans of the Iron Council dwell in a large island to the northwest; I "
 "was taken there several times for interrogation. It is a fearsome place, "
@@ -10564,7 +10623,7 @@ msgstr ""
 "我们可以用那个帮你们渡海。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2480
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2484
 msgid ""
 "Across the waves?! We are a people of the desert, we know nothing of "
 "piloting such vessels! And I do not like the idea of putting my life at the "
@@ -10575,8 +10634,8 @@ msgstr ""
 
 #. [message]: type=Mermaid Priestess,Mermaid Diviner,Mermaid Enchantress,Mermaid Siren
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2489
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2495
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2493
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2499
 msgid ""
 "We have picked up some knowledge of piloting while spying on the humans and "
 "we have some magical skill for controlling the winds. Once out on the open "
@@ -10589,7 +10648,7 @@ msgstr ""
 "域，可不能像这样航行两次。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2501
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2505
 msgid ""
 "We have already gone to many strange places and survived. I trust the "
 "merfolk. If they believe that they can transport us safely across the "
@@ -10599,17 +10658,17 @@ msgstr ""
 "们安全地在海上航行，我就放心把自己的性命交到他们的手中。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2505
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2509
 msgid "Wherever you go Kaleh, I will follow."
 msgstr "你卡勒到哪里，我就会跟到哪里。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2509
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2513
 msgid "Very well. You have not led us astray so far, I will not leave you now."
 msgstr "好吧。你至今都没有领我们误入歧途，我现在也不会离开的。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2516
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2520
 msgid ""
 "Grog scared of big water and bright sun, but Grog will not dishonor Great "
 "Leader. Great Leader say follow Kaleh, and Grog will do so."
@@ -10618,7 +10677,7 @@ msgstr ""
 "洛格就会一直跟着卡勒。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2522
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2526
 msgid ""
 "Nog scared of big water and bright sun, but Nog will not dishonor Great "
 "Leader. Great Leader say follow Kaleh, and Nog will do so."
@@ -10628,15 +10687,15 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2528
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2534
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2532
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2538
 msgid ""
 "Ouch, being stuck between the water and the sun is a terrible place to be, "
 "but where you go I will follow."
 msgstr "喔，上有烈日下有水流真是个可怕的境遇，但是你去哪里我都跟着。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2540
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2544
 msgid ""
 "We have attacked the humans in the past, when their boats trespass in our "
 "waters, and so they fear us greatly. Their dark mages have cast protective "
@@ -10651,7 +10710,7 @@ msgstr ""
 "们必须自己去夺船了。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2544
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2548
 msgid ""
 "There are four boats in the lagoon. Once you have captured each of the four "
 "then we can help you steer them out into the open water and to freedom. Then "
@@ -10664,31 +10723,31 @@ msgstr ""
 "的人民都载上。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2548
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2552
 msgid "Truly, there are not as many of us as there once were."
 msgstr "是啊，没有开始那么多人了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2552
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2556
 msgid ""
 "Though the cost be high, we do what we must. Come let us go capture those "
 "boats."
 msgstr "虽然耗损很大，我们要做我们必须做的。来，一起去夺船吧。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2711
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2715
 msgid ""
 "We’ve run out of time. The humans are gaining strength and will surely "
 "overwhelm us now."
 msgstr "我们没时间了。人类又聚集了力量，肯定能压过我们。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2724
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2728
 msgid "We’ve captured all four boats!"
 msgstr "我们得到了这全部四艘船！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2728
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2732
 msgid ""
 "Good, then let’s get out of here. The merfolk will help you guide the ships. "
 "I’ll muster the rest of our people and retreat from this bloody battlefield. "
@@ -10703,8 +10762,8 @@ msgstr ""
 
 #. [message]: type=Mermaid Priestess,Mermaid Diviner,Mermaid Enchantress,Mermaid Siren
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2737
-#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2743
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2741
+#: data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg:2747
 msgid ""
 "Then by the Sea God’s hand I call forth the winds. May they confound our "
 "enemies and blow these ships to safety!"
@@ -10724,41 +10783,41 @@ msgstr "美露珊德"
 #. [unit]: type=Merman Hoplite
 #. [unit]: type=Merman Spearman
 #. [unit]: type=Merman Entangler
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:90
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:98
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:106
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:114
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:122
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:130
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:85
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:93
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:101
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:109
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:117
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:125
 msgid "Merfolk Guard"
 msgstr "鱼人守卫"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:150
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:145
 msgid "Hail Kaleh, long have I waited to see you in person."
 msgstr "向你致意，卡勒。我已经期待和你的会面很久了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:155
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:150
 msgid ""
 "Greetings. I’m afraid I am at a disadvantage, for you know my name and I do "
 "not know yours."
 msgstr "您好。恐怕我是处在不利境地，您知道我的名字，而我却不知道您的。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:160
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:155
 msgid ""
 "I am known as Melusand. I am what you might call a high priest among my "
 "people."
 msgstr "我的名字是美露珊德。你可以把我理解为我们族人中的高阶牧师。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:165
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:160
 msgid "This is—"
 msgstr "这位是——"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:178
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:173
 msgid ""
 "No, you don’t have to introduce yourselves. I already know who you are and "
 "why you have been journeying all this way. And I must say, Grog, that your "
@@ -10769,12 +10828,12 @@ msgstr ""
 "得说，果洛格，你最近的举动，以及和这些优秀伙伴的相处，都为你的族人争了光。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:183
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:178
 msgid "Grog says thank you."
 msgstr "果洛格向您致谢。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:189
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:184
 msgid ""
 "No, you don’t have to introduce yourselves. I already know who you are and "
 "why you have been journeying all this way. And I must say, Nog, that your "
@@ -10785,12 +10844,12 @@ msgstr ""
 "得说，诺格，你最近的举动，以及和这些优秀伙伴的相处，都为你的族人争了光。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:194
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:189
 msgid "Nog says thank you."
 msgstr "诺格向您致谢。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:200
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:195
 msgid ""
 "No, you don’t have to introduce yourselves. I already know who you are and "
 "why you have been journeying all this way. And I must say, Rogrimir, that "
@@ -10802,13 +10861,13 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:205
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:216
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:200
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:211
 msgid "Thank you for your kindness."
 msgstr "感谢您的善意。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:211
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:206
 msgid ""
 "No, you don’t have to introduce yourselves. I already know who you are and "
 "why you have been journeying all this way. And I must say, Jarl, that your "
@@ -10819,24 +10878,24 @@ msgstr ""
 "得说，查尔，你最近的举动，以及和这些优秀伙伴的相处，都为你的族人争了光。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:224
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:219
 msgid ""
 "No, you don’t have to introduce yourselves. I already know who you are and "
 "why you have been journeying all this way."
 msgstr "不，你们不必自我介绍。我已经知道你们是谁，也知道你们这一路过来的目的。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:231
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:226
 msgid "If you know so much why did you drag us all the way out here?"
 msgstr "既然您什么都知道，为什么还要把我们一路拖到这里来？"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:236
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:231
 msgid "Patience, young lady. All will be revealed in good time."
 msgstr "请有点儿耐心，年轻的女士。一切都会在合适的时候揭晓。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:241
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:236
 msgid ""
 "I have been watching your progress with great interest, but I could not "
 "contact you directly. That is why I sent out my most trusted followers to "
@@ -10850,12 +10909,12 @@ msgstr ""
 "眼线遍布各处，我不得不防止被监听。认真绝不为过。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:246
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:241
 msgid "Whose spies?"
 msgstr "谁的间谍？"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:251
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:246
 msgid ""
 "Perhaps I should start at the beginning, for that is a good place to start. "
 "Make yourselves comfortable, this may take a while. I want to tell you a "
@@ -10865,7 +10924,7 @@ msgstr ""
 "们所说的“黄金时代”衰落的故事。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:258
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:253
 msgid ""
 "A long time ago there was a great empire of humans known as the Empire of "
 "Wesnoth. They lived peacefully alongside elves and dwarves, and drove the "
@@ -10876,12 +10935,12 @@ msgstr ""
 "黑暗势力驱逐到了地下深处。那对所有人来说，都是和平、光明、繁荣的时代。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:263
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:258
 msgid "Yes, we know about this age."
 msgstr "嗯，我们知道这个时代。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:268
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:263
 msgid ""
 "This will go much faster if you don’t interrupt me. Now, as I was saying, "
 "the Empire of Wesnoth was very learned in the magical arts and had vast "
@@ -10906,7 +10965,7 @@ msgstr ""
 
 # 修改了一下以前的翻译
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:273
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:268
 msgid ""
 "But with their prosperity and power, over the generations the humans grew "
 "arrogant. One day a young descendant of the original king decreed that "
@@ -10930,7 +10989,7 @@ msgstr ""
 "了。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:278
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:273
 msgid ""
 "The king and his family were all killed, and soon petty warlords tore apart "
 "the empire as all the known lands fell into chaos. Elves and dwarves were "
@@ -10941,7 +11000,7 @@ msgstr ""
 "和矮人也被卷进争斗中，兽人和巨魔从黑暗之地蔓延开来，混沌与黑暗吞噬了大地。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:283
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:278
 msgid ""
 "The two suns, a monument to the power and hubris of the fallen Empire of "
 "Wesnoth, scorched the earth. The fields dried up, forests died, and swamps "
@@ -10967,7 +11026,7 @@ msgstr ""
 "牺牲品。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:288
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:283
 msgid ""
 "What can we merfolk do? We see much with our magics, but we do not have the "
 "numbers, nor the power, to bring back order to the domains of the land "
@@ -10982,7 +11041,7 @@ msgstr ""
 "能勉强保全自己，更别说到了陆上我们会有多惨了，这你们也看到了。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:293
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:288
 msgid ""
 "You are probably wondering why I know all this history. Far out in the sea "
 "is a string of islands that was once colonized by some humans from the "
@@ -11006,7 +11065,7 @@ msgstr ""
 "的魔法和知识，我们解读出了那些文字，然后拼凑出了黄金时代晚期的历史事实。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:298
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:293
 msgid ""
 "The islands seemed lush and bountiful so we decided to settle in the shallow "
 "waters. But we discovered that the largest island was a strange and sinister "
@@ -11030,7 +11089,7 @@ msgstr ""
 "暗。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:303
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:298
 msgid ""
 "The island was declared cursed, and we stayed as far away from it as we "
 "could. Some said we should flee the islands, but the waters were great for "
@@ -11043,7 +11102,7 @@ msgstr ""
 "里，所以我们还是留了下来。我们以为，只要保持距离，一切都会没事的。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:308
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:303
 msgid ""
 "But then that night came, I still remember it, as if it was yesterday. As "
 "the sun set a darkness spread forth from the tower, blotting out the moon "
@@ -11060,7 +11119,7 @@ msgstr ""
 "命我们被迫弃岛而去。能保全下现在这么多人真是太幸运了。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:313
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:308
 msgid ""
 "In hindsight I blame the humans. With their experiments I think they woke "
 "something, something evil. Years later, we still suffer from the legacy of "
@@ -11079,19 +11138,19 @@ msgstr ""
 "到的人类。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:318
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:313
 msgid "Does she have a name?"
 msgstr "她有名字吗？"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:324
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:319
 msgid ""
 "She has many names. We call her the Eater of Souls. But in the old tongue "
 "her name is Yechnagoth."
 msgstr "她有很多名字。我们称她为灵魂噬者。但古语中， 她的名字是耶柯纳戈斯。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:334
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:329
 msgid ""
 "Yes, I thought that name would be familiar to you. Always is she looking for "
 "new followers. I believe that it is she who appeared unto your people in the "
@@ -11106,12 +11165,12 @@ msgstr ""
 "者，但我想也许你们正是可以消灭她的人。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:339
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:334
 msgid "You seem powerful, why can’t you destroy her yourselves?"
 msgstr "你们看起来很强大，为什么你们不去消灭她？"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:344
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:339
 msgid ""
 "Years of battle have taken their toll; my people are few in number and have "
 "not the strength to strike at her alone. But I see in you a strength and "
@@ -11121,7 +11180,7 @@ msgstr ""
 "能力与果敢，这给了我希望。如果有你们的帮忙，我们或许有机会。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:349
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:344
 msgid ""
 "You must realize that if she is not stopped, who knows how far her "
 "pestilence might spread? I have scryed far and wide and there are few that "
@@ -11132,7 +11191,7 @@ msgstr ""
 "以指望呢？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:354
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:349
 msgid ""
 "How can we trust you? How do we know you aren’t servants of Yechnagoth, sent "
 "to trick us?"
@@ -11140,7 +11199,7 @@ msgstr ""
 "我们为什么要相信你？我们怎么知道你是不是耶柯纳戈斯的爪牙，是来骗我们的？"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:359
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:354
 msgid ""
 "If you knew anything about us you would not ask such a question! The idea is "
 "an anathema to all that we stand for! You saw how my brethren risked life "
@@ -11153,7 +11212,7 @@ msgstr ""
 "够证明吗？"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:364
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:359
 msgid ""
 "Because in the end, I’m afraid you just have to trust us. If we wanted to "
 "capture you we could have already. But we are not here to force you to do "
@@ -11167,7 +11226,7 @@ msgstr ""
 "的，人类会四处追捕你们。伊洛的势力范围很广，她的复仇是很可怕的。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:369
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:364
 msgid ""
 "Indeed, that is what she is expecting. Like the few others that have "
 "resisted her for a time, she expects you to flee from her, to run away as "
@@ -11182,7 +11241,7 @@ msgstr ""
 "的大陆上依然有她无法控制的力量存在。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:374
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:369
 msgid ""
 "You have given us much to think about. But we cannot make such an important "
 "decision in an instant. Please give us time to talk among ourselves and "
@@ -11192,7 +11251,7 @@ msgstr ""
 "间，我们需要商议一下。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:379
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:374
 msgid ""
 "Of course. We will withdraw to the shallows and give you some privacy. But "
 "do not ponder for too long, for we do not have a lot of time. I will return "
@@ -11202,29 +11261,29 @@ msgstr ""
 "们没有多少时间。我稍后就来听你们的答复。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:405
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:400
 msgid "Well, what do you all think?"
 msgstr "好吧，你们都怎么看？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:410
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:405
 msgid "It’s a heck of a story."
 msgstr "真见鬼，这种事。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:415
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:410
 msgid "I’m not sure what to think. It’s all so much information."
 msgstr "一下子有这么多信息，我脑子里乱极了。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:422
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:417
 msgid ""
 "Grog not sure if he trust fish lady. What if she just want you elves to "
 "fight her war for her?"
 msgstr "果洛格不知道这位鱼女士是否可信。万一她是骗你们精灵帮她打仗呢？"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:428
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:423
 msgid ""
 "Nog not sure if he trust fish lady. What if she just want you elves to fight "
 "her war for her?"
@@ -11232,15 +11291,15 @@ msgstr "诺格不知道这位鱼女士是否可信。万一她是骗你们精灵
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:434
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:440
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:429
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:435
 msgid ""
 "I’m still not sure I trust her. What if she’s just trying to get you all to "
 "fight her war for her?"
 msgstr "我还是不确定能否信任她，万一她只是想骗你们帮她打仗呢？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:445
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:440
 msgid ""
 "The point is, it’s not her fight, it’s our fight too. I for one believe her "
 "tale. With all the power that Melusand says Yechnagoth has, how do we know "
@@ -11253,7 +11312,7 @@ msgstr ""
 "庄的人不是她呢？如果那都只是把我们的人民变成一群无脑追随者的阴谋的一部分呢？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:450
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:445
 msgid ""
 "Whether this was all planned or not, what’s important is what should we do "
 "with ourselves now? We have a duty to protect our people."
@@ -11262,7 +11321,7 @@ msgstr ""
 "全。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:455
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:450
 msgid ""
 "No, no, no! Too much blood has been spilled. This has gone on way too far "
 "for us to just end it now and walk away. You saw what she did to Keratur and "
@@ -11272,12 +11331,12 @@ msgstr ""
 "了。你们也看到她对凯若特和坦斯特福做了什么，他们的血债由我背负，我要复仇！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:460
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:455
 msgid "Even if we turn around and leave now, where will we go?"
 msgstr "即使我们要离开，还有哪里可以去呢？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:466
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:461
 msgid ""
 "I admit that Melusand does have a point. We cannot return under the "
 "mountains the way we came, the humans will be heavily guarding that path for "
@@ -11292,12 +11351,12 @@ msgstr ""
 "引我们该有多好，我们现在非常需要她。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:471
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:466
 msgid "This entire journey has been based on a lie—"
 msgstr "我们走到这地步完全是因为一个谎言——"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:477
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:472
 msgid ""
 "I know! I know! Would you like me to kill myself as punishment, or step down "
 "as leader? Imagine how I feel. I heard her voice, it was just as you had "
@@ -11314,12 +11373,12 @@ msgstr ""
 "我能看见他们的面孔。噢，我多希望这一切都没有发生！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:482
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:477
 msgid "No, no, no one is blaming you, Kaleh."
 msgstr "不，不，我不是要责怪你，卡勒。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:487
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:482
 msgid ""
 "Many who have seen dark times wish they could go back and remake the past. "
 "But that is not in our power, all we can do now is do what seems right in "
@@ -11331,20 +11390,20 @@ msgstr ""
 "戈斯正希望你那样。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:499
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:494
 msgid ""
 "Yes, remember boy, the fight is not yet lost while we still draw breath."
 msgstr "没错，记住孩子，只要我们还有一口气在，这场战争就还没输掉。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:506
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:501
 msgid ""
 "Do not give up yet, little one. The battle is not yet lost while we still "
 "fight."
 msgstr "还不能放弃，小家伙。只要我们还在抗争，这场战争就不算输。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:513
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:508
 msgid ""
 "You are right. I believe Melusand, strange as her tale sounds. From all I "
 "have seen Yechnagoth truly is a scourge on this earth, and I would gladly "
@@ -11356,7 +11415,7 @@ msgstr ""
 "机会。但是我不会强迫大家和我作出同样的选择。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:518
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:513
 msgid ""
 "She should be made to pay for all that she has done to our people, and if I "
 "should die in the attempt, then so be it. I will not leave your side now, "
@@ -11366,7 +11425,7 @@ msgstr ""
 "接受它。卡勒，我现在不会离开你。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:523
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:518
 msgid ""
 "As strange as it may sound, there are some things in this world that are "
 "more important than the fate of our people. Years from now the suns shall "
@@ -11384,7 +11443,7 @@ msgstr ""
 "和善的传承。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:530
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:525
 msgid ""
 "Even in deepest tunnels my people could not escape Yechnagoth’s power "
 "forever if she is not stopped. Against such evil I am sure the Great Leader "
@@ -11396,7 +11455,7 @@ msgstr ""
 "恐怕现在你只有果洛格一个。不过果洛格依然会全力以赴来击败她的。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:536
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:531
 msgid ""
 "Even in deepest tunnels my people could not escape Yechnagoth’s power "
 "forever if she is not stopped. Against such evil I am sure the Great Leader "
@@ -11409,8 +11468,8 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:542
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:548
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:537
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:543
 msgid ""
 "Even in the deepest tunnels underground we could not forever escape "
 "Yechnagoth’s power if she remains unchecked. Against such evil I am sure my "
@@ -11422,7 +11481,7 @@ msgstr ""
 "但是恐怕现在你只有我一个。不过我依然会全力以赴来击败她的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:553
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:548
 msgid ""
 "Then it is decided. Still in this matter we cannot speak for all our people. "
 "Those who go on this quest may never return, and this battle is certainly no "
@@ -11437,7 +11496,7 @@ msgstr ""
 "里，这样他们也许可以安宁地过完这一生。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:558
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:553
 msgid ""
 "That is very compassionate of you, but I doubt that many of our surviving "
 "people will wish to stay behind. You are our leader Kaleh, and where you go, "
@@ -11447,17 +11506,17 @@ msgstr ""
 "们的领导人，卡勒，你去哪里，我们就去哪里。"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:563
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:558
 msgid "Time passes."
 msgstr "时光飞逝。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:578
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:573
 msgid "Have you come to a decision?"
 msgstr "下决定了吗？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:583
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:578
 msgid ""
 "Yes we have. Yechnagoth has played us like fools. We have all lost loved "
 "ones because of her machinations. Her arrogance will not go unchallenged; we "
@@ -11467,7 +11526,7 @@ msgstr ""
 "的狂妄必须得到教训，我们会协助你们。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:588
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:583
 msgid ""
 "Excellent. Due to our limited numbers, we cannot mount a full frontal "
 "assault against all her forces. Instead a sneak attack may allow us to "
@@ -11485,7 +11544,7 @@ msgstr ""
 "向导，护送你们到达目的地。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:593
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:588
 msgid ""
 "Although her magic has clouded the isles from my scrying, it is the largest "
 "island, which we call Zocthanol Isle, where I sense the strongest power."
@@ -11494,12 +11553,12 @@ msgstr ""
 "屿，我们叫做左克拉诺的岛，那上面的能量是最强的。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:598
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:593
 msgid "Why is it called Zocthanol Isle?"
 msgstr "为什么叫它左克拉诺岛？"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:603
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:598
 msgid ""
 "Because Zocthanol means accursed in our tongue. Anyway, it is there that I "
 "think you will find the source of the corruption. We will not be able to "
@@ -11514,7 +11573,7 @@ msgstr ""
 "们回来之前摧毁它。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:608
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:603
 msgid ""
 "And on a related subject I can offer you a glimmer of hope in this dark "
 "time. I know that you have been searching for a home for your people. These "
@@ -11529,7 +11588,7 @@ msgstr ""
 "应这新的土地。当然了，这是以后的事了。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:613
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:608
 msgid ""
 "Before you go I have one thing to give you. I’m afraid that where you are "
 "going my magical power will be of little help. However I want you to have "
@@ -11544,22 +11603,22 @@ msgstr ""
 "展。此外，它也会在冥冥之中保护你们的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:618
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:613
 msgid "We thank you for such beautiful gifts. We will wear them with honor."
 msgstr "谢谢你给我们这么美丽的礼物。我们很荣幸能戴上它。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:623
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:618
 msgid "We have one favor to ask of you."
 msgstr "我们恳请求教您一个问题。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:628
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:623
 msgid "Yes, anything."
 msgstr "好吧，随意。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:633
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:628
 msgid ""
 "We go into this darkness knowing that perhaps none of us will return alive. "
 "But I cannot ask all my people to go with me against their will. This battle "
@@ -11574,7 +11633,7 @@ msgstr ""
 "幸福。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:638
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:633
 msgid ""
 "I will do as you ask. It is only fair. But if this battle goes ill I do not "
 "think there will be many safe places left in the known lands."
@@ -11583,7 +11642,7 @@ msgstr ""
 "全的地方了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:643
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:638
 msgid ""
 "Before we leave, there’s one thing I don’t understand. When he first met "
 "Kaleh, Esanoo said this all concerned Yechnagoth and Zhangor. We know about "
@@ -11593,14 +11652,14 @@ msgstr ""
 "戈斯和战戈。现在我们对耶柯纳戈斯已经有所了解，但是战戈呢？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:648
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:643
 msgid ""
 "I remember when Yechnagoth was posing as Eloh, she said she was the slayer "
 "of the demon lord Zhangor."
 msgstr "我记得耶柯纳戈斯冒充伊洛时，她说她消灭了魔神战戈。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:653
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:648
 msgid ""
 "I wonder where Yechnagoth heard of the story of the demon lord Zhangor. It "
 "is a sad tale and has not been told for ages, but perhaps now is the right "
@@ -11610,7 +11669,7 @@ msgstr ""
 "经好几代不再传述这件事了，不过也许现在是时候告诉你们。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:658
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:653
 msgid ""
 "It all started in the years before the Great Fall. The elves of Wesmere "
 "Forest were masters of the arcane magics. They valued knowledge above all "
@@ -11622,7 +11681,7 @@ msgstr ""
 "魔鬼战戈的注意。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:663
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:658
 msgid ""
 "Zhangor appeared to them in the guise of a beautiful elven youth and told "
 "them that a great darkness was coming, which would destroy all the knowledge "
@@ -11641,7 +11700,7 @@ msgstr ""
 "他为神。那些反对他的权威的精灵成为第一批被投入监狱，随后被杀害的牺牲品。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:668
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:663
 msgid ""
 "And so as the rest of the lands succumbed to darkness and chaos, Wesmere "
 "Forest was one of the few islands of peace and safety. But Zhangor played "
@@ -11664,7 +11723,7 @@ msgstr ""
 "人类、矮人、兽人以及任何他们能在附近土地上找到的其他生物。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:673
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:668
 msgid ""
 "By this point most of the other forests had been burned, and Eloh was "
 "leading our people south across the plains. We were surprised to find the "
@@ -11685,7 +11744,7 @@ msgstr ""
 "誓为无辜死去的孩子们报仇，于是我们尽全力进攻他们。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:678
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:673
 msgid ""
 "Driven on by their dark priests and by their fear of Zhangor’s wrath, the "
 "Wesmere elves fought stubbornly against our superior numbers. The fighting "
@@ -11707,7 +11766,7 @@ msgstr ""
 "体重重地击落到地面上。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:683
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:678
 msgid ""
 "By this point the entire forest was being engulfed by flame, and friend and "
 "foe alike fled from the inferno. With the death of their god the Wesmere "
@@ -11728,7 +11787,7 @@ msgstr ""
 "不再信奉战戈的人则得到了赦免。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:688
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:683
 msgid ""
 "Our priests also declared that Zhangor’s name and his story were forbidden "
 "knowledge, to speak of him meant death. Their constant vigilance was "
@@ -11747,12 +11806,12 @@ msgstr ""
 "更重要是多么的愚蠢。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:693
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:688
 msgid "I wonder what other forbidden lore you’ve been taught."
 msgstr "我想知道你还知道些什么被禁止的知识。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:698
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:693
 msgid ""
 "Foolish girl! Do not ask such a question. Trust me, it is better not to "
 "know. Knowledge can be a terrible weight, and not one that I would want a "
@@ -11767,7 +11826,7 @@ msgstr ""
 "一些真相。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:703
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:698
 msgid ""
 "That is very interesting. In truth, I’d never heard of Zhangor before when I "
 "told Esanoo to mention him to you, Kaleh. Let me explain. When Eloh appeared "
@@ -11790,7 +11849,7 @@ msgstr ""
 "的真实身份。"
 
 #. [message]: speaker=Melusand
-#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:708
+#: data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg:703
 msgid ""
 "And now I must bid you farewell. The merfolk you rescued will help show you "
 "the path to the island, and I must go orchestrate our diversion. We will "
@@ -11814,60 +11873,67 @@ msgstr "波依奇"
 
 #. [side]: type=Saurian Oracle, id=Boyicht
 #. [side]: type=Draug, id=Kelur
-#. [side]: type=Orcish Sovereign, id=Graghht
+#. [side]: type=Orcish Shaman, id=Zoldak
 #. [side]
+#. [side]: type=Saurian Seer, id=Tchoyob
 #: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:90
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:129
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:166
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:195
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:206
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:216
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:250
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:133
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:174
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:207
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:227
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:237
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:275
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:321
 msgid "Eloh Cultists"
 msgstr "伊洛信徒"
 
 #. [side]: type=Draug, id=Kelur
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:123
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:127
 msgid "Kelur"
 msgstr "克勒"
 
-#. [side]: type=Orcish Sovereign, id=Graghht
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:156
-msgid "Graghht"
-msgstr "哥伦夫"
+#. [side]: type=Orcish Shaman, id=Zoldak
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:164
+msgid "Zoldak"
+msgstr "佐尔达克"
+
+#. [side]: type=Saurian Seer, id=Tchoyob
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:311
+msgid "Tchoyob"
+msgstr "乔约布"
 
 #. [unit]: type=Merman Triton, id=Trapped Merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:308
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:384
 msgid "Trapped Merman"
 msgstr "被困的人鱼"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:375
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:446
 msgid "Kaleh must capture a keep"
 msgstr "卡勒 必须占领一个要塞"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:382
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:453
 msgid "Reach the black citadel in the center of the island"
 msgstr "抵达岛中央的黑暗要塞"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:390
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:461
 msgid "Defeat enemy leaders, find both keys"
 msgstr "打倒敌人首领， 找到两把钥匙"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:401
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:472
 msgid "Any unit must reach the black citadel"
 msgstr "任何单位抵达黑色大本营"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:464
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:540
 msgid "Where did this fog come from? I can’t see a thing!"
 msgstr "这些雾气从哪里来的？我什么都看不见！"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:469
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:545
 msgid ""
 "Fog and darkness cloud this place, but we can use it to our advantage. The "
 "other ships will be safe hidden out in the deep water."
@@ -11876,7 +11942,7 @@ msgstr ""
 "里。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:474
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:550
 msgid ""
 "We should find a fort before we land the rest of our people. I do not like "
 "the idea of landing everyone without a fort to protect us. Shrouded by the "
@@ -11888,7 +11954,7 @@ msgstr ""
 "合部队，我们就可以让他们过来，然后大干一场。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:479
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:555
 msgid ""
 "I think there were some human ruins in the southwestern part of the island. "
 "If you explore the land to the west, then we will swim through the shallows "
@@ -11898,14 +11964,23 @@ msgstr ""
 "许会有些发现。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:484
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:560
 msgid ""
 "That is a good plan. First find a fort, then we can explore the rest of the "
 "island."
 msgstr "就这么办。我们先找到一个要塞，然后再去探索这个岛屿的其他部分。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:523
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:607
+msgid ""
+"The jungle here doesn’t want to answer me, as if afraid of indescribable "
+"horrors within it. As much as I love nature, this place frightens me."
+msgstr ""
+"这里的丛林似乎不愿回应我，仿佛害怕其中潜藏着难以言喻的恐怖。尽管我如此热爱大"
+"自然，但这个地方还是让我感到恐惧。"
+
+#. [message]: speaker=Zhul
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:613
 msgid ""
 "Ugh. That jungle seems dark and foreboding. Do you see those eyes? There are "
 "things staring at us from the depths of the jungle, but I can’t tell what "
@@ -11915,7 +11990,7 @@ msgstr ""
 "看着我们，但我不知道那是什么。虽然我喜欢花草和树木，但我不喜欢那丛林的样子。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:528
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:620
 msgid ""
 "Indeed. It seems much more open to the south. The merfolk mentioned that "
 "there were human ruins to the southwest. Maybe we should explore there "
@@ -11925,8 +12000,17 @@ msgstr ""
 "看，南边开阔多了，人鱼说西南面有人类建筑的废墟，我们先搜索那边吧。先让更多精"
 "灵登陆，再去闯那个丛林。"
 
+#. [message]: speaker=unit
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:639
+msgid ""
+"The trees themselves seem against my presence here. They give me an ominous "
+"feeling as if something bad is going to happen if I stay here."
+msgstr ""
+"这些树似乎对我的到来心存抵触。它们让我有种不祥的预感，仿佛只要我待在这里，就"
+"会发生什么不好的事。"
+
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:545
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:656
 msgid ""
 "I don’t get it. All we see are ruins, bones, some sand and patches of grass. "
 "I thought we would be attacked the moment we set foot on this island. Where "
@@ -11936,7 +12020,7 @@ msgstr ""
 "到攻击，人都到哪里去了？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:550
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:661
 msgid ""
 "That’s what worries me. I keep thinking that something is going to jump out "
 "from behind the next rock or stone wall and attack, but everything is "
@@ -11946,12 +12030,12 @@ msgstr ""
 "里真是安静，太安静了。"
 
 #. [message]: speaker=Boyicht
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:569
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:680
 msgid "You trespass on holy ground, The One says you must die!"
 msgstr "你们竟敢闯入圣地，那个人说了，你们必须死！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:574
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:685
 msgid ""
 "Faugh! Little one, you are not worth our time. We are the Quenoth Elves! "
 "Flee and trouble us no longer or we will squash you like a bug."
@@ -11960,48 +12044,64 @@ msgstr ""
 "把你像臭虫一样捏扁。"
 
 #. [message]: speaker=Boyicht
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:579
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:690
 msgid "No, you are not The One. You no command Boyicht. Attack!"
 msgstr "不，你们不是那个人。你们无权命令波依奇。进攻！"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:585
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:586
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:587
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:591
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:592
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:593
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:597
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:598
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:599
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:696
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:697
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:698
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:702
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:703
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:704
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:708
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:709
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:710
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:714
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:715
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:716
 msgid "Fanatical Saurian"
 msgstr "狂热的蜥蜴人"
 
+#. [message]: speaker=Zhul
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:745
+msgid ""
+"This thing... instead of speaking to nature, it controls it! Destroy it, "
+"quickly!"
+msgstr "这东西……它不是在与大自然对话，而是在操控大自然！快把它毁掉！"
+
+#. [message]: speaker=Zhul
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:751
+msgid ""
+"This alien thing... Indescribable, yet so vile. It can’t be anything good."
+msgstr "这外星玩意儿……难以形容，却如此恶心。绝不可能是什么好东西。"
+
 #. [message]: speaker=Boyicht
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:620
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:768
 msgid "My death matters not. The One will kill you all. None can resist her."
 msgstr "我的死无关紧要。你们所有人都会死。没人能忤逆她。"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:633
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:780
 msgid "I say good riddance. He creeped me out."
 msgstr "终于摆脱他了。他让我很不舒服。"
 
 #. [unit]: type=Naga Myrmidon
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:648
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:666
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:796
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:818
 msgid "Naga Leader"
 msgstr "那珈首领"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:695
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:848
 msgid ""
 "I have captured the keep. This castle is somewhat ruined, but it will serve "
 "our purposes. Now, I wonder where the merfolk are?"
 msgstr "我占领了要塞。这个城堡似乎损毁了，但是可用。现在，人鱼在哪里？"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:717
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:870
 msgid ""
 "Fear not, here we are! We have explored the southern half of the island. And "
 "except for those lizards you found, and some abandoned villages, it seem to "
@@ -12011,19 +12111,21 @@ msgstr ""
 "镇，几乎都是空的。我们占领了这些村庄，支持你们。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:728
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:881
 msgid "Thanks, I think we’re going to need all the support we can get."
 msgstr "谢谢。我们正需要各种支援。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:739
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:892
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1058
 msgid ""
 "Now that you have found a fortress to protect your people, we can bring in "
 "the other ships."
 msgstr "现在，你已经看到了城堡保护你的人民，我们会带进其他船只。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:777
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:930
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1095
 msgid ""
 "Good, now we can start recruiting and recalling our warriors. Of course with "
 "so few people left, training new warriors will be very difficult and "
@@ -12033,7 +12135,7 @@ msgstr ""
 "会困难而昂贵。但如果我们输掉这场战斗，那么金币对我们而言还有什么用呢？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:782
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:935
 msgid ""
 "Now that we’ve set up a base of operations we should make our way to the "
 "black citadel in the mountains at the center of the island. I bet it’s "
@@ -12043,7 +12145,8 @@ msgstr ""
 "暗要塞。我想它应该就在那黑暗丛林中心的某处。"
 
 #. [message]: race=merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:787
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:940
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1105
 msgid ""
 "In our exploration we found a group of reinforcements, who were sent to help "
 "you, compliments of Melusand. You can recruit them into service at your "
@@ -12054,22 +12157,123 @@ msgstr ""
 "挥他们。在地面上我们帮不了什么忙，但我们可以让你们免受海上的威胁。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:792
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:945
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1110
 msgid "Thank you. I’m sure the reinforcements will be very useful."
 msgstr "谢谢，这增援太有用了。"
 
+#. [message]: speaker=Zoldak
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:992
+msgid ""
+"Welcome. I already knew you were coming but I didn’t expect you to arrive "
+"straight away. In any case, feel free to make use of our camp as it seems "
+"that we have common enemies."
+msgstr ""
+"欢迎。我早就知道你们会来，但没想到你们这么快就到了。无论如何，请随意使用我们"
+"的营地，看来我们有共同的敌人。"
+
+#. [message]: speaker=Kaleh
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:996
+msgid "Thank you Shaman. We will do so. Now, I wonder where the merfolk are?"
+msgstr "谢谢您，萨满。我们会照办的。话说回来，人鱼们现在在哪里呢？"
+
+#. [message]: speaker=Graghht
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1007
+msgid ""
+"Since you entered our fort, use it for your troops. Get them here quickly "
+"and help us."
+msgstr "既然进了我们的要塞，那就拿来召回部队吧。让他们快点来到，帮帮我们。"
+
+#. [message]: speaker=Kaleh
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1011
+msgid ""
+"Thank you, Sovereign. They will come here soon. Now, I wonder where the "
+"merfolk are?"
+msgstr "谢谢，君主。他们很快就会到这里。现在，我想知道人鱼在哪里？"
+
+#. [message]: speaker=Kaleh
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1018
+msgid ""
+"I have captured the keep. The castle is not in good condition but at least "
+"it will serve our purposes. Now, I wonder where the merfolk are?"
+msgstr ""
+"我占领了要塞。这个城堡状况不太好，但至少能满足我们的需求。现在，我想知道人鱼"
+"在哪里？"
+
+#. [message]: race=merman
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1042
+msgid ""
+"Fear not, here we are! We have explored the southern half of the island. And "
+"we found lizards living there, and some abandoned villages."
+msgstr ""
+"别担心，我们来了！我们探索了岛的南半边。我们发现那里有蜥蜴居住，还有一些废弃"
+"的村庄。"
+
+#. [message]: speaker=Nym
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1047
+msgid ""
+"Thanks, I think that villages are important but right now we’re going to "
+"need all the support we can get to help our new allies here."
+msgstr ""
+"谢谢，我认为村庄很重要，但眼下我们需要竭尽所能争取一切支援，来帮助我们在这里"
+"的新盟友。"
+
+#. [message]: speaker=Kaleh
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1100
+msgid ""
+"Now that we’ve set up a base of operations we should make our way to the "
+"black citadel in the mountains at the center of the island. It should be not "
+"too far away."
+msgstr ""
+"现在我们已经建立了一座行动基地，我们可以出发去岛中央山脉中的黑色要塞了。它应"
+"该没多远。"
+
 #. [message]: speaker=Kelur
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:831
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1149
 msgid "Feel the cold touch of death!"
 msgstr "感受死亡的冰冷吧！"
 
+#. [message]: speaker=Tchoyob
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1168
+msgid "I will slaughter you all and feast upon your bodies!"
+msgstr "我要杀光你们所有人，然后吞食你们的尸体！"
+
+#. [message]: speaker=Nym
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1187
+msgid "What is that thing?!"
+msgstr "那是什么东西？！"
+
+#. [unit]: type=Orcish Sovereign, id=Graghht
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1213
+msgid "Graghht"
+msgstr "格拉赫特"
+
 #. [message]: speaker=Graghht
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:850
-msgid "I will slaughter you all and bathe in your blood!"
-msgstr "我会把你们都杀了，用你们的血洗澡！"
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1225
+msgid ""
+"We won’t be controlled any more! We will reclaim this island as rightfully "
+"ours! Destroy the false god! Rebuild the legacy of our ancestors!"
+msgstr ""
+"我们不会再任人摆布了！我们要夺回这座岛屿，它理应属于我们！摧毁伪神！重建我们"
+"先祖的遗产！"
+
+#. [message]: speaker=Graghht
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1229
+msgid "Protect the shaman that gave us freedom! Slaughter our enemies!"
+msgstr "保护赋予我们自由的萨满！屠戮我们的敌人！"
+
+#. [message]: speaker=Nym
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1234
+msgid "What are they doing here?"
+msgstr "他们在这儿干什么？"
+
+#. [message]: speaker=Graghht
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1255
+msgid "Graaaaaaaaaaaaaaaaaaaaaghht!"
+msgstr "格——拉——赫——特！"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:876
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1285
 msgid ""
 "We’ve reached what looks like the citadel, but it is surrounded by a huge "
 "perfectly smooth obsidian wall. I can’t find any way to get in."
@@ -12078,21 +12282,21 @@ msgstr ""
 "了，我找不到它的入口。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:887
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1296
 msgid ""
-"There’s got to be something here. The orc and skeleton must have been "
+"There’s got to be something here. The saurian and skeleton must have been "
 "guarding some sort of entrance."
-msgstr "一定会有的，兽人和骷髅一定在守卫着某个入口。"
+msgstr "这儿肯定有什么东西。蜥蜴人和骷髅一定在守卫着某个入口。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:893
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1302
 msgid ""
-"Are you sure? Search carefully. The orc and skeleton must have been guarding "
-"some sort of entrance."
-msgstr "你肯定？仔细找找。兽人和骷髅一定守护着某个入口。"
+"Are you sure? Search carefully. The saurian and skeleton must have been "
+"guarding some sort of entrance."
+msgstr "你肯定？仔细找找。蜥蜴人和骷髅一定在守卫着某个入口。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:900
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1309
 msgid ""
 "Wait a minute. There’s a tiny outline of a door in the stone. But there’s no "
 "way to open it. All I see are what look like two tiny keyholes in the stone. "
@@ -12102,25 +12306,25 @@ msgstr ""
 "找这两把钥匙啊？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:913
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1322
 msgid ""
 "Hey, what about the two keys that we found on the bodies of the undead and "
-"orc leaders?"
-msgstr "嘿，要不试试我们在亡灵和兽人头领身上找到的那两把钥匙？"
+"saurian leaders?"
+msgstr "嘿，要不试试我们在亡灵和蜥蜴人头领身上找到的那两把钥匙？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:920
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1329
 msgid ""
 "I have an idea. I bet Eloh has given them to those she trusts most. And one "
-"orc and one skeleton were guarding the door. The keys must be being held by "
-"one of each faction. I bet the leaders would be in charge of such valuable "
-"objects."
+"saurian and one skeleton were guarding the door. The keys must be being held "
+"by one of each faction. I bet the leaders would be in charge of such "
+"valuable objects."
 msgstr ""
-"我想我知道。我打赌伊洛会把钥匙交给她最信任的人。守门的是一个兽人和一个骷髅，"
-"他们身上肯定各有一把钥匙，首领就是应该负责掌管这种重要的东西。"
+"我有个主意。我打赌伊洛会把钥匙交给她最信任的人。守门的是一个蜥蜴人和一个骷"
+"髅，钥匙肯定是由双方各自的首领拿着。我打赌首领就是掌管着这种重要的东西。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:950
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1359
 msgid ""
 "We’ve found both keys. Now we just have to take them and open the door to "
 "the black citadel. I tire of all this bloodshed. Wherever Yechnagoth hides, "
@@ -12130,12 +12334,12 @@ msgstr ""
 "牲，不管耶柯纳戈斯躲在哪里，我们都要找到她，让她为这一切付出代价。"
 
 #. [message]: speaker=Kelur
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:974
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1383
 msgid "Aaaargh!"
 msgstr "啊！"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:993
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1402
 msgid ""
 "Look, I found a gold key on a chain around his neck. This must be one of the "
 "keys needed to enter the black citadel."
@@ -12143,7 +12347,7 @@ msgstr ""
 "看，我发现他的脖子上挂着一个金钥匙。这肯定是进入黑暗要塞所需要的钥匙之一。"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1000
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1409
 msgid ""
 "Look, I found a gold key on a chain around his neck. I wonder what this key "
 "is for? I bet it will become useful eventually. I’ll keep it just in case."
@@ -12151,13 +12355,13 @@ msgstr ""
 "看，我发现他的脖子上挂着一个金钥匙。这钥匙干什么用的？肯定会有用处的，我现在"
 "先保管好它。"
 
-#. [message]: speaker=Graghht
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1022
+#. [message]: speaker=Tchoyob
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1431
 msgid "Nooo!!"
 msgstr "不！！"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1041
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1450
 msgid ""
 "Look, I found an iron key on a chain around his neck. This must be one of "
 "the keys needed to enter the black citadel."
@@ -12165,7 +12369,7 @@ msgstr ""
 "看，我发现他的脖子上挂着一个铁钥匙。这肯定是进入黑暗要塞所需要的钥匙之一。"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1048
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1457
 msgid ""
 "Look, I found an iron key on a chain around his neck. I wonder what this key "
 "is for? I bet it will become useful eventually. I’ll keep it just in case."
@@ -12174,39 +12378,39 @@ msgstr ""
 "先保管好它。"
 
 #. [message]: speaker=Trapped Merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1101
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1510
 msgid "Help me..."
 msgstr "救我……"
 
 #. [message]: speaker=$speaking_unit.id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1106
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1515
 msgid "A merman! He looks like he’s in bad shape."
 msgstr "一个人鱼！他看起来挺糟糕。"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1136
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1545
 msgid "Sea Serpent"
 msgstr "海蝎"
 
 #. [message]: speaker=Sea Serpent
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1140
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1549
 msgid "Raurrgghhh!!"
 msgstr "啊！！"
 
 #. [message]: speaker=second_unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1145
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1554
 msgid ""
 "A sea serpent! That thing must be 20 cubits long! It must have been living "
 "among the wreckage of that ship. I shudder to think what it was feasting on."
 msgstr "海蝎！肯定有20尺长！它肯定把船骸当做家了。我可不敢去想它吃什么。"
 
 #. [unit]: type=Merman Triton, id=Grateful Merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1169
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1578
 msgid "Grateful Merman"
 msgstr "感激的人鱼"
 
 #. [message]: speaker=Grateful Merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1182
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1591
 msgid ""
 "Thank you. I got captured by the naga and have been trapped here for ages, I "
 "don’t know how long. So close to the water, but so far. I don’t think I "
@@ -12216,25 +12420,25 @@ msgstr ""
 "却又不能逃脱，我还以为自己就要不行了。真是太可怕了。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1187
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1596
 msgid ""
 "Well, help us get revenge on the naga. We are here to destroy Yechnagoth."
 msgstr "帮我们向娜迦复仇。我们为毁灭耶柯纳戈斯而来。"
 
 #. [message]: speaker=Grateful Merman
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1192
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1601
 msgid "Gladly. Just let me recover my strength first."
 msgstr "非常乐意。但请先让我恢复力气。"
 
 #. [message]: speaker=unit
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1215
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1624
 msgid ""
 "I found a chest in the hold of this wrecked ship. It looks like sunken "
 "treasure!"
 msgstr "我从船骸里找到一个箱子，好像是沉没的财宝！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1231
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1640
 msgid ""
 "We’ve run out of time! The forces that the merfolk helped distract have "
 "returned and will surely kill us all."
@@ -12242,19 +12446,19 @@ msgstr ""
 "我们没有时间了！被人鱼的佯攻吸引走的敌军都回来了，他们一定会击败我们的。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1267
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1676
 msgid ""
 "So I see that you have finally slain both of my lieutenants. I wondered how "
 "long it would take you."
 msgstr "看来你们已经杀死了我的两位助手，你们花了不少时间吧。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1272
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1681
 msgid "We have your keys. You cannot hide from us now."
 msgstr "我们已经知道你的秘密了。现在你躲不了。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1277
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1686
 msgid ""
 "Did you really think something as simple as a pair of keys was needed to "
 "enter and leave my sanctum? The entire thing was just a charade to see how "
@@ -12264,17 +12468,17 @@ msgstr ""
 "过是个小游戏，我想看看你们到底会为你们可悲的小小心愿付出多少。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1282
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1691
 msgid "Sigh, you elves are so predictable."
 msgstr "唉，你们精灵果然不出我所料。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1287
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1696
 msgid "Talk all you want, we will have our vengeance!"
 msgstr "留下遗言吧，我们要向你复仇！"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1292
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1701
 msgid ""
 "Is that what you want? I suppose I do owe Kaleh a personal audience, after "
 "all I have put him through. Well here’s your chance. Come to me boy, and "
@@ -12286,7 +12490,7 @@ msgstr ""
 "然我现在就叫你们慢慢地痛苦死去。我一会儿再来收拾你们。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1309
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1718
 msgid ""
 "I must go and end this. But first I want to thank you all for your faith in "
 "me throughout this long journey. If I do not prevail then please flee this "
@@ -12299,12 +12503,12 @@ msgstr ""
 "么，你们都会长寿，而且子孙满堂。别让我们的牺牲被遗忘……"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1314
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1723
 msgid "Kaleh, you can’t just go in there alone. She’ll kill you!"
 msgstr "卡勒，你不能独自去。她会杀了你！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1320
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1729
 msgid ""
 "I must. Too many others have died because of my actions. I couldn’t face "
 "losing you, Nym. Now it is time for me to finish it, alone."
@@ -12313,39 +12517,39 @@ msgstr ""
 "这一切吧，独自一人。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1325
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1734
 msgid "May Eloh protect you."
 msgstr "愿伊洛保佑你。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1330
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1739
 msgid "Her will be done."
 msgstr "我要结果她。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1348
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1757
 msgid "Well, now we just have to wait..."
 msgstr "那么，现在我们就等……"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1353
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1762
 msgid "You aren’t actually going to let him face her alone?!"
 msgstr "你不会真的让他单独去见那家伙吧？！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1359
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1768
 msgid "Yes, I am. In the end it is his decision."
 msgstr "让他去吧。既然他心意已决。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1364
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1773
 msgid ""
 "I’ve saved his sorry ass all this way, I’m not going to let him go and let "
 "himself get killed now!"
 msgstr "这一路上我一直在救这傻小子的命，现在我可不会让他走，然后被杀掉的！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1371
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1779
 msgid ""
 "Nymphtessa, my darling, you have always been a rebel. But eventually you "
 "must learn to respect your leaders’ decisions. Kaleh has made his choice, "
@@ -12357,7 +12561,7 @@ msgstr ""
 "吗，他不希望我们违背他，他不希望我们也去送死。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1376
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1784
 msgid ""
 "I don’t care! Do you think I’m going to let him go in there and fight alone? "
 "He’ll be slaughtered! He needs our help. Without us he never would have even "
@@ -12368,7 +12572,7 @@ msgstr ""
 "漠都走不出去。你们尽管坐在这里祈祷，我要进去了！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1395
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1803
 msgid ""
 "Curse that girl! She’ll be the death of me. But still she doesn’t stand a "
 "chance without me. Kaleh is one thing, but Nym needs my protection. All "
@@ -12379,8 +12583,23 @@ msgstr ""
 "但妮慕需要我来保护。行吧，我也进去。你们其他人守在这里，如果半小时后我们还没"
 "出来，那你们就和人鱼一起逃离这座岛。"
 
+#. [message]: speaker=Graghht
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1820
+msgid "I am going in to help too!"
+msgstr "我也要上去帮忙了！"
+
+#. [message]: speaker=Zoldak
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1836
+msgid "Go after them. We will stay here and protect the entrance."
+msgstr "追上去。我们会留在这里守住入口。"
+
+#. [message]: speaker=Zoldak
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1854
+msgid "We will stay here and protect the entrance."
+msgstr "我们会留在这里守住入口。"
+
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1408
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1868
 msgid ""
 "Grog not going to just sit here while Kaleh does all the fighting. Kaleh "
 "will need strong fighter like Grog. Other elves may be scared, but Grog fear "
@@ -12392,7 +12611,7 @@ msgstr ""
 "碎。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1414
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1874
 msgid ""
 "Nog not going to just sit here while Kaleh does all the fighting. Kaleh will "
 "need strong fighter like Nog. Other elves may be scared, but Nog fear no "
@@ -12403,8 +12622,8 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1420
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1426
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1880
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1886
 msgid ""
 "I’ve followed that boy this far, I’m not going to just let him march in "
 "there without me. Besides, whoever heard of a dwarf being afraid of going "
@@ -12414,23 +12633,23 @@ msgstr ""
 "不敢去地下的矮人？我只是希望他们留点活给我。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1445
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1905
 msgid "What’s that strange screeching sound coming from the jungle?"
 msgstr "丛林里传出的奇怪的尖锐叫声是什么？"
 
 #. [event]
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1467
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1474
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1927
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1934
 msgid "Nocturnal Pest"
 msgstr "夜袭怪"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1487
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1947
 msgid "That’s odd. Why did those bats suddenly fly off?"
 msgstr "奇怪，为什么蝙蝠突然飞走了？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1492
+#: data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg:1952
 msgid "They must be nocturnal."
 msgstr "它们肯定是夜行性的。"
 
@@ -12440,77 +12659,77 @@ msgid "The Final Confrontation"
 msgstr "最后的对决"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:257
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:255
 msgid "Defeat the false Eloh"
 msgstr "击败假冒的伊洛"
 
 #. [objective]: condition=win
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:267
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:264
 msgid "Defeat Yechnagoth"
 msgstr "击败耶柯纳戈斯"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:303
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:299
 msgid "Kaleh! No!"
 msgstr "卡勒！不！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:329
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:325
 msgid "He’s still breathing. Eloh, what grace I have, give unto him."
 msgstr "他还有呼吸。伊洛，请把对我的慈悲都给他吧。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:338
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:334
 msgid "He’s stirring."
 msgstr "他动了。"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:358
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:354
 msgid ""
 "Aye, there’s still life in the boy. But where is the foul creature that did "
 "this to him?"
 msgstr "是啊，他还活着。那个把他弄成这样的臭家伙到哪里去了？"
 
 #. [message]: speaker=$ally_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:365
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:361
 msgid ""
 "The little one is not dead yet. But where is evil lady that did this to him?"
 msgstr "这小家伙还没死。那个把他弄成这样的恶毒女人到哪里去了？"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:397
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:393
 msgid ""
 "So, the elf’s puny friends think they can save him. But you are too late. He "
 "is already mine!"
 msgstr "哈，那精灵的卑微的朋友们以为可以拯救他。现在已经太晚了，他已经归我了！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:422
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:418
 msgid "Nym, Zhul, Grog, you shouldn’t have."
 msgstr "妮慕，朱尔，果洛格，你们不该这样做的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:428
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:424
 msgid "Nym, Zhul, Nog, you shouldn’t have."
 msgstr "妮慕，朱尔，诺格，你们不该这样做的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:434
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:430
 msgid "Nym, Zhul, Rogrimir, you shouldn’t have."
 msgstr "妮慕，朱尔，若格瑞莫，你们不该这样做的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:441
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:437
 msgid "Nym, Zhul, Jarl, you shouldn’t have."
 msgstr "妮慕，朱尔，查尔，你们不该这样做的。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:449
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:445
 msgid "Nym, Zhul, you shouldn’t have."
 msgstr "妮慕，朱尔，你们不该这样做的。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:456
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:452
 msgid ""
 "Your struggles were mildly entertaining, but futile in the end. For I am "
 "powerful beyond your imagining, and this is the seat of my power!"
@@ -12518,60 +12737,60 @@ msgstr ""
 "你们的挣扎真是可笑，是无济于事的。我的强大你们无法想象，这就是我力量的展现！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:461
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:457
 msgid "You are not Eloh. You are but a pitiful mockery of her power and glory!"
 msgstr "你不是伊洛。和她的力量和光荣相比，你只不过是个可笑的小丑！"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:466
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:462
 msgid ""
 "Is that what you think? I shall prove you wrong. Look out upon your people "
 "and despair!"
 msgstr "你是这么认为的吗？我会证明你是错的。看看外面你的族人，绝望吧！"
 
 #. [unit]: type=Quenoth Fighter, id=Anarion
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:479
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:475
 msgid "Anarion"
 msgstr "艾纳瑞"
 
 #. [unit]: type=Tauroch Rider, id=Zylea
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:506
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:502
 msgid "Zylea"
 msgstr "吉离"
 
 #. [message]: speaker=Anarion
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:518
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:514
 msgid "All hail Eloh!"
 msgstr "伊洛是全能的！"
 
 #. [message]: speaker=Zylea
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:523
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:519
 msgid "Death to the heretics!"
 msgstr "异教徒死！"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:528
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:524
 msgid "They worship their true god."
 msgstr "他们侍奉真神。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:533
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:529
 msgid "Come and bow down before your true master, boy."
 msgstr "来朝拜你的神吧，孩子。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:538
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:534
 msgid "Your wish is my command."
 msgstr "您的愿望就是我的命令。"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:583
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:579
 msgid "Argh, you stabbed me!"
 msgstr "啊，你刺我！"
 
 # Kalehssar是Kaleh的什么形式？
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:589
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:584
 msgid ""
 "I have crossed deserts, mountains, and oceans and watched my people bleed "
 "every step of the way. I did not come all this way to give up now. I am "
@@ -12582,22 +12801,22 @@ msgstr ""
 "放弃的！别叫我孩子，我是卡勒，族人的领袖，我要和你斗到最后一息！"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:595
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:590
 msgid "I command you to stop this foolishness!"
 msgstr "我命令你停止这愚蠢的举动！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:605
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:600
 msgid "The shell brooches Melusand gave us, they’re glowing!"
 msgstr "美露莎给我们的贝壳胸针在发光！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:610
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:605
 msgid "You will never dominate us, not while hope survives!"
 msgstr "只要还有希望存在，你就无法统治我们！"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:616
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:611
 msgid ""
 "So be it. You choose death? Then you shall receive it from those you hold "
 "most dear. Kill the unbelievers, let none survive!"
@@ -12605,28 +12824,28 @@ msgstr ""
 "既然你们选择了死，那么就让你最爱的人来下手吧。杀死这些异教徒，一个也别留下！"
 
 #. [message]: speaker=Anarion
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:621
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:616
 msgid "Yes mistress."
 msgstr "遵命，主人。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:626
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:621
 msgid "Ignore our brethren, we must destroy her!"
 msgstr "略过我们的同胞，我们必须消灭她！"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:669
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:664
 msgid "You think you killed me? You have no idea what you are facing."
 msgstr "你觉得你杀死我了吗？你根本不知道你将会面对什么。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:674
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:669
 msgid ""
 "Who is she really? Could it be Zhangor, back to avenge his imprisonment?"
 msgstr "她到底是谁？难道是战戈，从监狱中逃出来复仇了？"
 
 #. [message]: speaker=Eloh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:681
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:676
 msgid ""
 "Nonsense. Unlike that fool, I do not care about petty things like revenge. "
 "Nor do I depend on mortals to enact my will. No, I shall destroy you myself!"
@@ -12635,50 +12854,45 @@ msgstr ""
 "来履行我的意志。不需要，我要亲自杀了你们！"
 
 #. [message]: type=Quenoth Fighter, Tauroch Rider
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:699
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:694
 msgid "Huh? What happened?"
 msgstr "哈？发生什么事了？"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:704
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:699
 msgid ""
 "Her spell has been broken. But I don’t think we have won yet. Come aid us!"
 msgstr "她的咒语解除了，但我们还没有胜利。来帮我们！"
 
 #. [message]: type=Quenoth Fighter, Tauroch Rider
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:709
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:704
 msgid "Yes priestess."
 msgstr "遵命，祭祀。"
 
 #. [unit]: type=Central Body1, id=Yechnagoth
 #. [unit]: type=Central Body2, id=Yechnagoth
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:755
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1315
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:750
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1309
 msgid "Yechnagoth"
 msgstr "耶柯纳戈斯"
 
-#. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:849
-msgid "What is that thing?!"
-msgstr "那是什么东西？！"
-
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:855
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:844
 msgid "Eloh protect us!"
 msgstr "伊洛护佑我们！"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:896
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:890
 msgid "Curse Uria, more abominations!"
 msgstr "尤里安的，又来麻烦事！"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:901
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:895
 msgid "Is it even possible to kill this thing? It’s huge!"
 msgstr "有可能杀掉这家伙吗？它这么大！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:907
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:901
 msgid ""
 "It must have some sort of weak point. Look at those pulsing spires, I "
 "thought they were stone, but they seem to be alive. Maybe if we destroy them "
@@ -12690,7 +12904,7 @@ msgstr ""
 "它。我们现在不能停下！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1099
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1093
 msgid ""
 "That central body is healing faster than we can damage it. It’s almost as if "
 "our attacks are doing no damage at all. We got to try another tactic, and "
@@ -12700,61 +12914,61 @@ msgstr ""
 "略，快！"
 
 #. [message]: speaker=$victim_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1183
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1177
 msgid ""
 "What the heck? That central creature just hit me with some sort of slime. It "
 "hurts and I— I’m stuck!"
 msgstr "怎么回事？中间的生物向我喷了什么粘液。好疼啊，我——我动不了了！"
 
 #. [message]: speaker=$victim_id
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1190
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1184
 msgid "Ow, I’m stuck!"
 msgstr "哦，我动不了了！"
 
 #. [message]: speaker=narrator
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1302
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1296
 msgid "<big><b>Aaaurrgghh!!</b></big>"
 msgstr "<big><b>啊啊啊！！</b></big>"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1325
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1319
 msgid ""
 "I think we’re finally doing some damage. We must attack the central body, "
 "while it remains vulnerable!"
 msgstr "我们终于伤到它了。趁它现在正虚弱，我们赶紧攻击中间的躯体！"
 
 #. [message]: type=Crawling Horror
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1413
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1407
 msgid "Aiiee!!"
 msgstr "啊啊啊！！"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1439
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1433
 msgid "At last. It is finished."
 msgstr "终于……结束了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1450
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1444
 msgid "Is Yechnagoth really dead?"
 msgstr "耶柯纳戈斯真死了？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1456
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1450
 msgid "Yes, she’s dead Nym."
 msgstr "是的，妮慕，她死了。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1461
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1455
 msgid "I almost can’t believe it."
 msgstr "我真是不敢相信。"
 
 #. [message]: speaker=Zhul
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1468
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1462
 msgid "Behold, the pretender has been defeated. Eloh’s might has prevailed."
 msgstr "看呐，冒牌货被击败了，真正伊洛的信徒们获胜了。"
 
 #. [message]: speaker=Grog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1475
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1469
 msgid ""
 "Ugh. Grog is covered in blood and guts and nasty blue goo. Whatever creature "
 "was, she doesn’t smell any better dead than she did alive."
@@ -12763,7 +12977,7 @@ msgstr ""
 "难闻。"
 
 #. [message]: speaker=Nog
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1481
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1475
 msgid ""
 "Ugh. Nog is covered in blood and guts and nasty blue goo. Whatever creature "
 "was, she doesn’t smell any better dead than she did alive."
@@ -12773,8 +12987,8 @@ msgstr ""
 
 #. [message]: speaker=Rogrimir
 #. [message]: speaker=Jarl
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1481
 #: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1487
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1493
 msgid ""
 "Ugh. I’m covered in blood and guts, and this nasty blue stuff. I don’t know "
 "what in the nine hells we were fighting, but she doesn’t smell any better "
@@ -12784,7 +12998,7 @@ msgstr ""
 "底是在和什么作战，但我知道，她死了比活着还要难闻。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1505
+#: data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg:1499
 msgid "Let’s get out of here."
 msgstr "我们离开这里。"
 
@@ -12794,7 +13008,7 @@ msgid "Epilogue"
 msgstr "尾声"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:61
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:59
 msgid ""
 "I stumbled out into the daylight, scarcely believing that we were "
 "victorious. Looking out over the island it took me a moment to realize what "
@@ -12812,7 +13026,7 @@ msgstr ""
 "奴隶模样，他们已经从魔法中解脱出来了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:66
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:64
 msgid ""
 "Indeed with Yechnagoth’s death it seems that all of her minions reverted to "
 "their original chaotic tendencies. Luckily we had already destroyed most of "
@@ -12827,7 +13041,7 @@ msgstr ""
 "们。长久以来，这似乎是我们第一次获得了没有威胁的安全。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:71
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:69
 msgid ""
 "A few days later Melusand herself appeared and she declared the cleansing of "
 "this island a miracle. We made a pact between elf and merfolk and vowed to "
@@ -12854,7 +13068,7 @@ msgstr ""
 "经付出的代价的话……"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:85
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:83
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -12870,7 +13084,7 @@ msgstr ""
 "就没有这么幸运了。为什么要有这么多人死去呢？我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:113
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:111
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -12886,7 +13100,7 @@ msgstr ""
 "最后我却失去了她……我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:117
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:115
 msgid ""
 "Although I believe that our battle in the black citadel was our finest hour, "
 "I am still haunted by Nym’s death in that dark place. And so every morning "
@@ -12906,7 +13120,7 @@ msgstr ""
 "自己这一切都是值得的。但有时候，我又觉得，这只不过是个安慰自己的借口罢了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:132
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:130
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -12922,7 +13136,7 @@ msgstr ""
 "最后我却失去了她……我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:136
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:134
 msgid ""
 "Although I believe that our battle in the black citadel was our finest hour, "
 "I am still haunted by Zhul’s death in that dark place. And so every morning "
@@ -12942,7 +13156,7 @@ msgstr ""
 "自己这一切都是值得的。但有时候，我又觉得，这只不过是个安慰自己的借口罢了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:152
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:150
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -12958,7 +13172,7 @@ msgstr ""
 "了最后我却失去了他……我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:156
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:154
 msgid ""
 "Although I believe that our battle in the black citadel was our finest hour, "
 "I am still haunted by the death of Grog in that dark place. And so every "
@@ -12980,7 +13194,7 @@ msgstr ""
 "觉得，这只不过是个安慰自己的借口罢了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:162
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:160
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -12996,7 +13210,7 @@ msgstr ""
 "最后我却失去了他……我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:166
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:164
 msgid ""
 "Although I believe that our battle in the black citadel was our finest hour, "
 "I am still haunted by the death of Nog in that dark place. And so every "
@@ -13018,7 +13232,7 @@ msgstr ""
 "得，这只不过是个安慰自己的借口罢了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:172
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:170
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -13034,7 +13248,7 @@ msgstr ""
 "到了最后我却失去了他……我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:176
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:174
 msgid ""
 "Although I believe that our battle in the black citadel was our finest hour, "
 "I am still haunted by the death of Rogrimir in that dark place. And so every "
@@ -13057,7 +13271,7 @@ msgstr ""
 "着，我觉得，这只不过是个安慰自己的借口罢了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:182
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:180
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -13073,7 +13287,7 @@ msgstr ""
 "最后我却失去了他……我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:186
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:184
 msgid ""
 "Although I believe that our battle in the black citadel was our finest hour, "
 "I am still haunted by the death of Jarl in that dark place. And so every "
@@ -13095,7 +13309,7 @@ msgstr ""
 "得，这只不过是个安慰自己的借口罢了。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:203
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:201
 msgid ""
 "If you had told me at the start of our journey the price I was to pay in "
 "blood, I do not know if I would have had the strength to take that first "
@@ -13111,7 +13325,7 @@ msgstr ""
 "肩作战，但到了最后我却失去了他们……我真希望能回到过去从新开始。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:208
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:206
 msgid ""
 "Although I believe that our battle in the black citadel was our finest hour, "
 "I am still haunted by my friends’ deaths in that dark place. And so every "
@@ -13131,7 +13345,7 @@ msgstr ""
 "自己这一切都是值得的。但我还是非常想念他们每一个人。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:224
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:222
 msgid ""
 "We carried Nym to a small island to the north which had a single peak with a "
 "beautiful view of the surrounding islands. It seemed to me to be a lookout "
@@ -13152,7 +13366,7 @@ msgstr ""
 "玩笑。我多么想念她的笑声，她的笑容，她的……"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:240
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:238
 msgid ""
 "Zhul’s funeral was a huge ceremony, like those she told us about from ages "
 "ago. I led a procession of our few remaining priestesses and all of the "
@@ -13172,7 +13386,7 @@ msgstr ""
 "果，但我希望她现在在一个更好的地方，和伊洛在一起。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:258
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:256
 msgid ""
 "I am saddened by the death of Grog, but by saving my life in the end he did "
 "fulfill his life debt to me. I think he also would have been glad to have "
@@ -13193,7 +13407,7 @@ msgstr ""
 "会一直记着他的种族为我们的同胞所做的贡献。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:265
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:263
 msgid ""
 "I am saddened by the death of Nog, but by saving my life in the end he did "
 "fulfill his life debt to me. I think he also would have been glad to have "
@@ -13214,7 +13428,7 @@ msgstr ""
 "一直记着他的种族为我们的同胞所做的贡献。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:272
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:270
 msgid ""
 "I am saddened by the death of Rogrimir, but by saving my life in the end he "
 "did fulfill his life debt to me. I think he also would have been glad to "
@@ -13235,7 +13449,7 @@ msgstr ""
 "他，我们会一直记着他的种族为我们的同胞所做的贡献。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:279
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:277
 msgid ""
 "I am saddened by the death of Jarl, but by saving my life in the end he did "
 "fulfill his life debt to me. I think he also would have been glad to have "
@@ -13256,7 +13470,7 @@ msgstr ""
 "一直记着他的种族为我们的同胞所做的贡献。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:296
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:294
 msgid ""
 "Although I am not as devout as Zhul is, I thank Eloh every day that Nym "
 "survived that horrible battle in the Black Citadel. No one has been more "
@@ -13278,7 +13492,7 @@ msgstr ""
 "地生活下去。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:312
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:310
 msgid ""
 "The oldest of the surviving elves, Zhul is moving slower now, but she still "
 "has that sparkle in her eye. Despite the hardships of our journey and "
@@ -13303,7 +13517,7 @@ msgstr ""
 "又重新回来了的象征。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:330
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:328
 msgid ""
 "By saving my life, Grog fulfilled his life debt to me, but we convinced him "
 "to hang around for a while and revel in the celebrations that we held after "
@@ -13329,7 +13543,7 @@ msgstr ""
 "艰难的日子里对我们的帮助。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:337
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:335
 msgid ""
 "By saving my life, Nog fulfilled his life debt to me, but we convinced him "
 "to hang around for a while and revel in the celebrations that we held after "
@@ -13355,7 +13569,7 @@ msgstr ""
 "子里对我们的帮助。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:344
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:342
 msgid ""
 "By saving my life, Rogrimir fulfilled his life debt to me, but we convinced "
 "him to hang around for a while and revel in the celebrations that we held "
@@ -13381,7 +13595,7 @@ msgstr ""
 "们最艰难的日子里对我们的帮助。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:351
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:349
 msgid ""
 "By saving my life, Jarl fulfilled his life debt to me, but we convinced him "
 "to hang around for a while and revel in the celebrations that we held after "
@@ -13407,7 +13621,7 @@ msgstr ""
 "子里对我们的帮助。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:376
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:374
 msgid ""
 "And I will always remember Grog who died along our journey. A braver warrior "
 "I have never seen, and though he was taken from us too soon, I am glad for "
@@ -13417,7 +13631,7 @@ msgstr ""
 "开了我们。虽然相处的时间很短，但我还是很高兴能够认识他。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:383
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:381
 msgid ""
 "And I will always remember Nog who died along our journey. A braver warrior "
 "I have never seen, and though he was taken from us too soon, I am glad for "
@@ -13427,7 +13641,7 @@ msgstr ""
 "了我们。虽然相处的时间很短，但我还是很高兴能够认识他。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:390
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:388
 msgid ""
 "And I will always remember Rogrimir who died along our journey. A braver "
 "warrior I have never seen, and though he was taken from us too soon, I am "
@@ -13437,7 +13651,7 @@ msgstr ""
 "开了我们，但我还是为和他相处的那段短暂时光而感到开心。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:397
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:395
 msgid ""
 "And I will always remember Jarl who died along our journey. A braver warrior "
 "I have never seen, and though he was taken from us too soon, I am glad for "
@@ -13447,7 +13661,7 @@ msgstr ""
 "我们，但我还是为和他相处的那段短暂时光而感到开心。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:406
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:404
 msgid ""
 "So much has happened since we left the desert, but looking back upon our "
 "journey I do not want to forget Garak and his sacrifice. I doubt that we "
@@ -13465,7 +13679,7 @@ msgstr ""
 "个优秀的老师，我们会铭记他。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:411
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:409
 msgid ""
 "As for the Black Citadel, after much discussion we decided to go back to the "
 "ancient rituals for purifying unclean land, with fire. We filled the entire "
@@ -13490,7 +13704,7 @@ msgstr ""
 "而牺牲的人们的纪念。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:416
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:414
 msgid ""
 "It has been several years since the events that I chronicle here, and I’m "
 "not quite as spry and limber as I used to be, so I decided it was about time "
@@ -13513,27 +13727,27 @@ msgstr ""
 "因为这是一份礼物，我们给你们的礼物。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:458
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:456
 msgid "Hey Kaleh, how’s the writing going?"
 msgstr "嘿，卡勒，写的如何？"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:463
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:461
 msgid "Actually I just finished."
 msgstr "实际上我刚写完。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:468
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:466
 msgid "You’ve been working on that thing for months. I’m impressed."
 msgstr "你都已经写了几个月了。我真佩服你。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:473
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:471
 msgid "Yes, it feels good to finally be done."
 msgstr "嗯，现在终于结束了，感觉不错。"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:478
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:476
 msgid ""
 "Well, your timing was perfect. Zhul is dedicating the new grove to Eloh, and "
 "you know there’ll be one heck of a celebration afterwards."
@@ -13542,14 +13756,14 @@ msgstr ""
 "啦。"
 
 #. [message]: speaker=Kaleh
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:483
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:481
 msgid ""
 "I suppose we wouldn’t want to miss that. I wonder if they will still have "
 "any of that wine left from last year?"
 msgstr "那我们可不能错过啊。去年还有酒留下吗？"
 
 #. [message]: speaker=Nym
-#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:488
+#: data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg:486
 msgid "We’ll just have to find out. Come on!"
 msgstr "我们去找找看，来啊！"
 
@@ -13560,12 +13774,6 @@ msgstr "人类指挥官"
 
 #. [unit_type]: id=Human Commander, race=human
 #: data/campaigns/Under_the_Burning_Suns/units/humans/Human_Commander.cfg:31
-#, fuzzy
-#| msgid ""
-#| "In this new harsh world, might often makes right and these commanders are "
-#| "strong enough to rise to positions of leadership. Leading small groups of "
-#| "warriors, commanders rally their troops around them and show no mercy to "
-#| "their enemies, striking fiercely with both sword and bow."
 msgid ""
 "In this new harsh world, might often makes right and these Commanders are "
 "strong enough to rise to positions of leadership. Leading small groups of "
@@ -13586,7 +13794,7 @@ msgstr "中枢躯体"
 #. [unit_type]: id=Pulsing Spire, race=monster
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Body.cfg:39
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg:25
-#: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg:32
+#: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg:36
 msgid ""
 "This thing is impossible to describe, no one has seen anything like it "
 "before."
@@ -13596,7 +13804,7 @@ msgstr "这东西很难描述，因为从来没有人见过类似的东西。"
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Body.cfg:45
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Body.cfg:57
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg:41
-#: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg:38
+#: data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg:42
 msgid "energy ray"
 msgstr "能量射线"
 
@@ -13670,7 +13878,7 @@ msgid "Dawarf"
 msgstr "达瓦夫"
 
 #. [unit_type]: id=Dawarf, race=monster
-#: data/campaigns/Under_the_Burning_Suns/units/monsters/Darawf.cfg:19
+#: data/campaigns/Under_the_Burning_Suns/units/monsters/Darawf.cfg:18
 msgid ""
 "Don’t ask where the Dawarf came from. You really don’t want to know. It is a "
 "secret well guarded by the great lore-masters of Wesnoth. And it isn’t "
@@ -13709,17 +13917,17 @@ msgstr "此单位在沙漠和尘土地形上每回合回复6点生命值。"
 #. [advancement]: id=Dust1
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg:81
 msgid "a stronger Dust Devil"
-msgstr "一个强壮些的尘土魔"
+msgstr "一个壮点儿的尘土魔"
 
 #. [advancement]: id=Dust2
-#: data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg:104
+#: data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg:125
 msgid "a taller Dust Devil"
-msgstr "一个高点的尘土魔"
+msgstr "一个高点儿的尘土魔"
 
 #. [advancement]: id=Dust3
-#: data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg:119
-msgid "a fully-healed Dust Devil"
-msgstr "一个完全治愈的尘土魔"
+#: data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg:162
+msgid "a bigger Dust Devil"
+msgstr "一个大点儿的尘土魔"
 
 #. [unit_type]: id=Flesh Golem, race=monster
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Flesh_Golem.cfg:4
@@ -13728,13 +13936,6 @@ msgstr "肉魔像"
 
 #. [unit_type]: id=Flesh Golem, race=monster
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Flesh_Golem.cfg:25
-#, fuzzy
-#| msgid ""
-#| "Incredibly strong constructs, flesh golems are created by powerful "
-#| "necromancers from the bodies of fallen warriors. Though these golems "
-#| "dutifully follow every command, and attack their enemies with ceaseless "
-#| "rage, the madness that possesses them has occasionally caused them to "
-#| "turn on their masters."
 msgid ""
 "Incredibly strong constructs, Flesh Golems are created by powerful "
 "necromancers from the bodies of fallen warriors. Though these Golems "
@@ -13743,8 +13944,8 @@ msgid ""
 "on their masters."
 msgstr ""
 "肉魔像是非常强壮的造物，是强大的死灵法师利用死去战士的尸体制作的。虽然这些魔"
-"像会忠实地执行每一条命令，并狂暴地不停攻击敌人，但这种完全控制了它们的疯狂，"
-"有时会让它们转而攻击主人。"
+"像会忠实地执行每一条命令，并狂暴地不停攻击敌人，但这种疯狂完全控制了它们，有"
+"时会让它们转而攻击主人。"
 
 #. [attack]: type=impact
 #: data/campaigns/Under_the_Burning_Suns/units/monsters/Flesh_Golem.cfg:30
@@ -13757,7 +13958,7 @@ msgid "Ixthala Demon"
 msgstr "伊夏拉恶魔"
 
 #. [unit_type]: id=Ixthala Demon, race=monster
-#: data/campaigns/Under_the_Burning_Suns/units/monsters/Ixthala_Demon.cfg:22
+#: data/campaigns/Under_the_Burning_Suns/units/monsters/Ixthala_Demon.cfg:21
 msgid ""
 "Are these monsters some beast-soldiers of a bygone era? Or are they spirits "
 "from another plane of existence? Knowledge of their origins is lost, all "
@@ -13769,7 +13970,7 @@ msgstr ""
 "烦。"
 
 #. [attack]: type=fire
-#: data/campaigns/Under_the_Burning_Suns/units/monsters/Ixthala_Demon.cfg:26
+#: data/campaigns/Under_the_Burning_Suns/units/monsters/Ixthala_Demon.cfg:25
 msgid "flaming sword"
 msgstr "烈焰剑"
 
@@ -13841,14 +14042,6 @@ msgstr "奎诺弓手"
 
 #. [unit_type]: id=Quenoth Archer, race=quenoth
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Archer.cfg:22
-#, fuzzy
-#| msgid ""
-#| "With the open sands providing much less protection than the old forests "
-#| "did, the wide ranks of elvish archers that once formed the core of the "
-#| "elvish military have all but disappeared. Instead, the few who still "
-#| "dedicate themselves to the traditional weapon of their ancestors practice "
-#| "the art from the saddle, allowing them to more easily avoid the perils of "
-#| "melee combat."
 msgid ""
 "With the open sands providing much less protection than the old forests did, "
 "the wide ranks of Elvish Archers that once formed the core of the elvish "
@@ -13884,12 +14077,12 @@ msgstr ""
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg:29
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg:43
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg:56
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg:72
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg:71
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Corrupted_Elf.cfg:23
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg:28
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg:42
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg:55
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg:71
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg:70
 msgid "glaive"
 msgstr "阔剑"
 
@@ -13900,20 +14093,15 @@ msgstr "堕落精灵"
 
 #. [unit_type]: id=Corrupted Quenoth Elf, race=quenoth
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Corrupted_Elf.cfg:19
-#, fuzzy
-#| msgid ""
-#| "Imbued with a dark spirit these corrupted elves combine unhuman strength "
-#| "with potent magics to create formidable opponents. Though the elvish body "
-#| "often decays quickly, these abominations are potent weapons of the undead "
-#| "lords."
 msgid ""
 "Imbued with a dark spirit these Corrupted Elves combine unhuman strength "
 "with potent magics to create formidable opponents. Though the elvish body "
 "often decays quickly, these abominations are potent weapons of the undead "
 "lords."
 msgstr ""
-"黑暗灵魂感染了这些精灵，使其拥有了非人的强大力量和魔法，它们是可怕的敌人。虽"
-"然精灵的身体让它们衰弱得很快，但这些怪物仍然是亡灵领主的有力武器。"
+"这些堕落精灵被注入了黑暗之灵，使其拥有了非人的强大力量和魔法，它们是可怕的敌"
+"人。虽然精灵的身体让它们衰弱得很快，但这些可憎的怪物仍然是亡灵领主的有力武"
+"器。"
 
 #. [attack]: type=cold
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Corrupted_Elf.cfg:35
@@ -13987,17 +14175,7 @@ msgid "Dustbok"
 msgstr "尘步兽"
 
 #. [unit_type]: id=Quenoth Dustbok, race=monster
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Dustbok.cfg:18
-#, fuzzy
-#| msgid ""
-#| "Dustboks are nimble, graceful creatures whose timid and peaceful nature "
-#| "stands in sharp contrast to the harsh land in which they live. Because "
-#| "the scorched land cannot support herds or even territorial neighbors, "
-#| "dustboks are solitary wanderers and yet still social, curious, and "
-#| "willing to cooperate with anyone if it leads to food. While this behavior "
-#| "has led to the death of many a foolish dustbok, it has made them "
-#| "excellent partners to the Quenoth Elves, who value their speed and "
-#| "agility."
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Dustbok.cfg:19
 msgid ""
 "Dustboks are nimble, graceful creatures whose timid and peaceful nature "
 "stands in sharp contrast to the harsh land in which they live. Because the "
@@ -14044,15 +14222,6 @@ msgstr "奎诺侧击士"
 
 #. [unit_type]: id=Quenoth Flanker, race=quenoth
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg:23
-#, fuzzy
-#| msgid ""
-#| "Some fighters find that their true talents lie not within rigid spear "
-#| "ranks, but out in the sands, striking at the flanks and rear of enemy "
-#| "forces. Fast and nimble, these elves make use of the weaknesses in enemy "
-#| "formations to disrupt their lines and sow chaos on the battlefield. In "
-#| "more cutthroat conflicts, Flankers even rely on the use of poison — a "
-#| "tool whose use was frowned on by their ancestors — to cripple their foes "
-#| "before charging in for the finish."
 msgid ""
 "Some Fighters find that their true talents lie not within rigid spear ranks, "
 "but out in the sands, striking at the flanks and rear of enemy forces. Fast "
@@ -14123,7 +14292,7 @@ msgstr ""
 #. [unit_type]: id=Quenoth Outrider, race=quenoth
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Outrider.cfg:5
 msgid "Quenoth Outrider"
-msgstr "奎诺先锋骑卫"
+msgstr "奎诺游骑兵"
 
 #. [unit_type]: id=Quenoth Outrider, race=quenoth
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Outrider.cfg:23
@@ -14135,17 +14304,17 @@ msgid ""
 "riders is especially dangerous, for against them, both retreat and attrition "
 "are futile, a prospect that is only ruinous in the inhospitable desert."
 msgstr ""
-"先锋骑卫被说成是“如风一般迅疾”的骑手，他们以无与伦比的速度刮过沙漠。与他们的"
-"小兄弟不同，先锋骑卫会进行直接作战训练，他们挥舞着剑和绳球，攻击受伤的敌兵和"
-"暴露的侧翼，那是敌方战线的最薄弱处。当这些骑手成群结队时特别危险，在面对他们"
-"时，不论是撤退还是拉锯战都是徒劳的。在荒凉的沙漠之中，“无法战胜他们”的预期完"
-"全是毁灭性的。"
+"游骑兵据说是“如风一般迅疾”的骑手，他们以无与伦比的速度刮过沙漠。与他们的小兄"
+"弟不同，游骑兵会进行直接作战训练，他们挥舞着剑和绳球，攻击受伤的敌兵和暴露的"
+"侧翼，那是敌方战线的最薄弱处。当这些骑手成群结队时特别危险，在面对他们时，不"
+"论是撤退还是拉锯战都是徒劳的。在荒凉的沙漠之中，“无法战胜他们”的预期完全是毁"
+"灭性的。"
 
 #. [attack]: type=impact
 #. [effect]: type=impact
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Outrider.cfg:42
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:384
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:701
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:331
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:668
 msgid "bolas"
 msgstr "流星锤"
 
@@ -14271,6 +14440,16 @@ msgstr ""
 msgid "sand"
 msgstr "沙"
 
+#. [advancement]: id=natures_aid
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg:127
+msgid "Connection with Nature"
+msgstr "联结自然"
+
+#. [advancement]: id=extra_natures_aid
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg:175
+msgid "Nature Aid"
+msgstr "自然之助"
+
 #. [unit_type]: id=Quenoth Sun Singer, race=quenoth, gender=female
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Singer.cfg:5
 msgid "female^Quenoth Sun Singer"
@@ -14341,7 +14520,7 @@ msgid "Tauroch"
 msgstr "陶洛"
 
 #. [unit_type]: id=Tauroch, race=monster
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch.cfg:18
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch.cfg:19
 msgid ""
 "Taurochs are huge, hardened beasts of the desert, considered untamable by "
 "most surviving races. However, the elves’ affinity with nature has allowed "
@@ -14355,7 +14534,7 @@ msgstr ""
 "中的强大坐骑。"
 
 #. [attack]: type=impact
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch.cfg:22
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch.cfg:23
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Protector.cfg:52
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Rider.cfg:33
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Stalwart.cfg:45
@@ -14548,7 +14727,7 @@ msgstr ""
 
 #. [advancement]: id=swordsmanship_training
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:85
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:453
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:402
 msgid "Swordsmanship Training"
 msgstr "剑术训练"
 
@@ -14562,137 +14741,153 @@ msgstr "强力打击"
 msgid "Swordsman"
 msgstr "剑士"
 
-#. [advancement]: id=taunt
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:145
-msgid "Taunt"
-msgstr "嘲讽"
+#. [advancement]: id=strength_training
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:146
+msgid "Strength Training"
+msgstr "力量训练"
+
+#. [advancement]: id=bowmanship_training
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:158
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:482
+msgid "Bowmanship Training"
+msgstr "弓术训练"
+
+#. [advancement]: id=strong_shots
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:175
+msgid "Strong Shots"
+msgstr "强力射击"
+
+#. [advancement]: id=Bowman
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:187
+msgid "Bowman"
+msgstr "弓手"
+
+#. [advancement]: id=piercing_shot
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:207
+msgid "Piercing Shot"
+msgstr "穿刺射击"
 
 #. [advancement]: id=stronger_grip
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:286
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:233
 msgid "Stronger Grip"
-msgstr "更强的控制力"
+msgstr "更强的抓力"
 
 #. [advancement]: id=overwhelming_power
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:299
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:246
 msgid "Overwhelming Power"
-msgstr "压倒性的力量"
+msgstr "压倒性力量"
 
 #. [advancement]: id=stamina_training
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:324
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:635
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:271
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:602
 msgid "Stamina Training"
 msgstr "持久力训练"
 
 #. [advancement]: id=endurance_training
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:339
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:286
 msgid "Endurance Training"
 msgstr "耐受力训练"
 
 #. [advancement]: id=skirmisher
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:359
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:676
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:306
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:643
 msgid "Skirmisher"
 msgstr "散兵"
 
 #. [advancement]: id=training_with_bolas
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:378
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:695
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:325
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:662
 msgid "Training with Bolas"
-msgstr "用流星锤训练"
+msgstr "流星锤训练"
 
 #. [advancement]: id=slow
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:398
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:727
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:345
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:694
 msgid "Slow"
 msgstr "减速"
 
 #. [advancement]: id=opportunist
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:418
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:365
 msgid "Opportunist"
 msgstr "机会主义者"
 
-#. [advancement]: id=inspiring
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:437
-msgid "Inspiring"
-msgstr "鼓舞"
+#. [advancement]: id=leading
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:386
+msgid "Leading"
+msgstr "领导"
 
 #. [advancement]: id=accurate_strikes
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:474
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:423
 msgid "Accurate Strikes"
 msgstr "精准打击"
 
 #. [advancement]: id=faster_strikes
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:491
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:443
 msgid "Faster Strikes"
-msgstr "更快的打击"
+msgstr "快速打击"
 
 #. [advancement]: id=sword_dance
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:503
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:455
 msgid "Sword Dance"
 msgstr "剑舞"
 
-#. [advancement]: id=bowmanship_training
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:527
-msgid "Bowmanship Training"
-msgstr "弓术训练"
-
 #. [advancement]: id=quickdraw
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:544
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:499
 msgid "Quickdraw"
 msgstr "快速拉弓"
 
 #. [advancement]: id=ranger
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:556
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:511
 msgid "Ranger"
 msgstr "巡林者"
 
 #. [advancement]: id=rain_of_arrows
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:574
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:529
 msgid "Rain of Arrows"
 msgstr "箭雨"
 
-#. [advancement]: id=toxic_rain
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:603
-msgid "Toxic Rain"
-msgstr "毒雨"
-
 #. [advancement]: id=twin_arrows
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:621
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:558
 msgid "Twin Arrows"
 msgstr "双箭"
 
+#. [advancement]: id=snipe
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:570
+msgid "Snipe"
+msgstr "狙击"
+
 #. [advancement]: id=footwork
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:650
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:617
 msgid "Footwork"
 msgstr "步法"
 
 #. [advancement]: id=run_by_bolas
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:715
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:682
 msgid "Run By (Bolas)"
-msgstr ""
+msgstr "跑打（流星锤）"
 
 #. [advancement]: id=bolaship
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:747
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:714
 msgid "Bolaship"
 msgstr "流星锤术"
 
 #. [advancement]: id=herbalism
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:760
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:727
 msgid "Herbalism"
 msgstr "草药学"
 
 #. [advancement]: id=run_by_sword_and_bow
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:778
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:745
 msgid "Run By (Sword and Bow)"
-msgstr ""
+msgstr "跑打（剑与弓）"
 
 #. [unit_type]: id=Quenoth Youth, race=quenoth, gender=male,female, description={QUENOTH_YOUTH_DESCRIPTION}
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:911
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:878
 msgid "Quenoth Youth"
 msgstr "奎诺青年"
 
 #. [female]: gender=female, description={NYM_DESCRIPTION}
-#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:961
+#: data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg:928
 msgid "female^Quenoth Youth"
 msgstr "奎诺青年"
 
@@ -14836,12 +15031,6 @@ msgstr "蜘蛛巫妖"
 
 #. [unit_type]: id=Spider Lich, race=undead
 #: data/campaigns/Under_the_Burning_Suns/units/undead/Spider_Lich.cfg:18
-#, fuzzy
-#| msgid ""
-#| "No one is quite sure how spider liches are created, but they are a "
-#| "horrific sight to behold. Crawling around on huge skeletal legs, and "
-#| "wielding huge magical staves, these abominations are fearsome undead "
-#| "foes. "
 msgid ""
 "No one is quite sure how Spider Liches are created, but they are a horrific "
 "sight to behold. Crawling around on huge skeletal legs, and wielding huge "
@@ -14881,69 +15070,12 @@ msgstr "未知"
 
 #. [race]: id=hidden_race
 #: data/campaigns/Under_the_Burning_Suns/units/units.cfg:22
-#, fuzzy
-#| msgid ""
-#| "\n"
-#| "\n"
-#| "The race of this unit cannot be revealed yet. You must discover it in the "
-#| "game to be allowed to see its description."
 msgid ""
 "The race of this unit cannot be revealed yet. You must discover it in the "
 "game to be allowed to see its description."
-msgstr ""
-"\n"
-"\n"
-"此单位的种族还不能透露。你必须先在游戏中发现它，才能看到其描述。"
+msgstr "此单位的种族还不能透露。你必须先在游戏中发现它，才能看到其描述。"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:4
-msgid "uses 1 attack"
-msgstr "使用1个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:7
-msgid "uses 2 attacks"
-msgstr "使用2个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:10
-msgid "uses 3 attacks"
-msgstr "使用3个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:13
-msgid "uses 4 attacks"
-msgstr "使用4个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:16
-msgid "uses 5 attacks"
-msgstr "使用5个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:19
-msgid "uses 6 attacks"
-msgstr "使用6个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:22
-msgid "This attack uses 1 attack"
-msgstr "这个攻击使用1个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:25
-msgid "This attack uses 2 attacks"
-msgstr "这个攻击使用2个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:28
-msgid "This attack uses 3 attacks"
-msgstr "这个攻击使用3个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:31
-msgid "This attack uses 4 attacks"
-msgstr "这个攻击使用4个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:34
-msgid "This attack uses 5 attacks"
-msgstr "这个攻击使用5个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:37
-msgid "This attack uses 6 attacks"
-msgstr "这个攻击使用6个攻击次数"
-
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:78
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:40
 msgid ""
 "This attack is the first verse of the Song of Sun Ascension, which "
 "progresses by one verse each turn this unit uses a song verse attack.\n"
@@ -14957,7 +15089,7 @@ msgstr ""
 "当最后一节乐章被咏唱完毕，或因一回合未发动攻击导致乐章循环中断时，整首乐曲会"
 "重新从第一乐章开始。"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:83
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:45
 msgid ""
 "This attack is the second verse of the Song of Sun Ascension, which "
 "progresses by one verse each turn this unit uses a song verse attack.\n"
@@ -14971,7 +15103,7 @@ msgstr ""
 "当最后一节乐章被咏唱完毕，或因一回合未发动攻击导致乐章循环中断时，整首乐曲会"
 "重新从第一乐章开始。"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:88
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:50
 msgid ""
 "This attack is the third verse of the Song of Sun Ascension, which "
 "progresses by one verse each turn this unit uses a song verse attack.\n"
@@ -14987,31 +15119,31 @@ msgstr ""
 "\n"
 "使用这首乐曲还会提供持续三回合的照明能力。"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:95
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:57
 msgid "first verse"
 msgstr "第一乐章"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:98
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:60
 msgid "second verse"
 msgstr "第二乐章"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:101
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:63
 msgid "third verse"
 msgstr "第三乐章"
 
 #. [illuminates]: id=illumination_song_verse
 #. Displayed in the help
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:343
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:321
 msgid "third verse illuminates"
 msgstr "第三乐章可照明"
 
 #. [illuminates]: id=illumination_song_verse
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:349
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:327
 msgid "female^third verse illuminates"
 msgstr "第三乐章可照明"
 
 #. [illuminates]: id=illumination_song_verse
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:350
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:328
 msgid ""
 "When this ability is active after using the sun incarnate attack, this unit "
 "illuminates the surrounding area for three turns.\n"
@@ -15025,37 +15157,57 @@ msgstr ""
 
 #. [illuminates]: id=illumination_song_verse
 #. A similar string exists in the textdomain wesnoth-help
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:354
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:332
 msgid ""
 "Illumination increases the lighting level in adjacent areas. This effect "
 "lasts for three turns after activation."
 msgstr "照明增加相邻区域的亮度。这个效果在激活后持续三回合。"
 
 #. [disable]: id=once_per_turn
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:369
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:347
 msgid "once per turn"
 msgstr "每回合一次"
 
 #. [disable]: id=once_per_turn
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:370
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:348
 msgid "This attack can be used offensively only once per turn"
 msgstr "此攻击在进攻时只能每回合使用一次"
 
 #. [dummy]: id=nova
 #. weapon special
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:452
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:430
 msgid "nova"
 msgstr "新星"
 
 #. [dummy]: id=nova
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:453
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:431
 msgid ""
 "This weapon, when used offensively, deals damage to all units adjacent to "
 "the caster when it hits."
 msgstr "这个武器，在进攻时使用时，在命中时会对所有与施法者相邻的单位造成伤害。"
 
 #. [dummy]: id=nova
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:455
+#. [dummy]: id=blast
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:432
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:476
+msgid "This unit has wide-area attacks centered on the caster."
+msgstr "这个单位具有以施法者为中心的大范围攻击。"
+
+#. [dummy]: id=blast
+#. weapon special
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:472
+msgid "blast"
+msgstr "溅射"
+
+#. [dummy]: id=blast
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:473
+msgid ""
+"This weapon, when used offensively, deals damage to all units adjacent to "
+"the enemy when it hits."
+msgstr "此武器在进攻中使用，则在命中时会对所有与施法者相邻的单位造成伤害。"
+
+#. [dummy]: id=blast
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:475
 msgid ""
 "This attack is the third verse of the Song of Sun Ascension. After using it, "
 "the first verse is available in the next turn. Furthermore, invoking this "
@@ -15064,26 +15216,21 @@ msgstr ""
 "此攻击为《日升颂歌》的第三乐章。在使用它之后，下一回合即可使用第一乐章。此"
 "外，发动此攻击会提供持续三回合的照明。"
 
-#. [dummy]: id=nova
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:456
-msgid "This unit has wide-area attacks centered on the caster."
-msgstr "这个单位具有以施法者为中心的大范围攻击。"
-
 #. [dummy]: id=ray
 #. weapon special
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:496
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:516
 msgid "ray"
 msgstr "光束"
 
 #. [dummy]: id=ray
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:497
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:517
 msgid ""
 "This weapon, when used offensively, also deals damage to a unit behind the "
 "target."
 msgstr "这件武器，当用于进攻时，也会对目标身后的一个单位造成伤害。"
 
 #. [dummy]: id=ray
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:499
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:519
 msgid ""
 "This is the second verse of the Song of Sun Ascension. It is available only "
 "when the first verse was sung in the previous turn. If this was the last "
@@ -15092,40 +15239,62 @@ msgstr ""
 "这是《日升颂歌》的第二乐章。它只在前一回合唱了第一乐章的时候才能使用。如果这"
 "是最后一个乐章，那么下一回合就可以使用第一乐章。"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:658
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:678
 msgid ""
 "At the start of the turn this unit increases movement points of surrounding "
 "units by +1"
 msgstr "在回合开始，这个单位为周围的单位增加+1移动点数"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:661
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:681
 msgid ""
 "At the start of the turn this unit increases movement points of surrounding "
 "units by +2"
 msgstr "在回合开始，这个单位为周围的单位增加+2移动点数"
 
 #. [dummy]: description={STR_TAILWIND_RESTRICT_{X}}
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:665
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:685
 msgid "tailwind +"
 msgstr "顺风+"
 
+#. [chance_to_hit]: id=parry_offense_only_{VALUE}
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:693
+msgid "parry offense only: + $sub%"
+msgstr "仅进攻时，格挡：+ $sub%"
+
+#. [chance_to_hit]: id=parry_offense_only_{VALUE}
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:694
+msgid ""
+"This unit sees its defense reinforced by $sub% when this weapon is used "
+"offensively"
+msgstr "使用此武器进攻时，此单位的防御提升$sub%。"
+
+#. [chance_to_hit]: id=parry{VALUE}
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:705
+msgid "parry: + ($sub)"
+msgstr "格挡：+ $sub%"
+
+#. [chance_to_hit]: id=parry{VALUE}
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:706
+msgid "This unit sees its defense reinforced by $sub% when this weapon is used"
+msgstr "使用此武器时，此单位的防御提升$sub%。"
+
 #. [special_note]
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:785
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:829
 msgid "SPECIAL_NOTE^This unit is able to move through solid stone walls."
 msgstr "此单位可以穿越坚固的石墙。"
 
 #. [dummy]: id=teaching
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:794
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:838
 msgid "teaching"
 msgstr "传授"
 
 #. [dummy]: id=teaching
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:795
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:839
 msgid "female^teaching"
 msgstr "传授"
 
 #. [dummy]: id=teaching
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:796
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:840
 msgid ""
 "At the start of every turn, this unit redistributes its experience points to "
 "all the units of the same side adjacent to it. If no suitable unit is "
@@ -15135,12 +15304,12 @@ msgstr ""
 "身边没有符合条件的单位，那么就只是它的经验值会降为零而已。"
 
 #. [attacks]: id=shock
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:806
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:850
 msgid "shock"
 msgstr "震慑"
 
 #. [attacks]: id=shock
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:807
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:851
 msgid ""
 "When this attack is used on offense, the opponent will retaliate with one "
 "less strike than normally, to a minimum of one strike."
@@ -15149,24 +15318,24 @@ msgstr ""
 "一次。"
 
 #. [attacks]: id=shock
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:808
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:852
 msgid ""
 "This unit’s melee attack can overwhelm the defenses of enemies, preventing "
 "them from retaliating as effectively."
 msgstr "此单位的近战攻击可以压垮敌方的防御，使其无法全力反击。"
 
 #. [chance_to_hit]: id=formation
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:839
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:883
 msgid "formation"
 msgstr "布阵"
 
 #. [chance_to_hit]: id=formation
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:840
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:884
 msgid "female^formation"
 msgstr "布阵"
 
 #. [chance_to_hit]: id=formation
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:841
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:885
 msgid ""
 "This unit gains a +10% bonus to defense when another unit with the same "
 "ability is adjacent to it. However, this cannot raise the unit’s defense "
@@ -15176,22 +15345,22 @@ msgstr ""
 "无法让单位的防御升到70%以上。"
 
 #. [chance_to_hit]: id=formation
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:842
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:886
 msgid "Groups of units of this type are able to shield each other in combat."
 msgstr "此种类型的单位成群时，可以在战斗中互相保护。"
 
 #. [dummy]: id=disengage
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:865
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:909
 msgid "disengage"
 msgstr "脱战"
 
 #. [dummy]: id=disengage
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:866
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:910
 msgid "female^disengage"
 msgstr "脱战"
 
 #. [dummy]: id=disengage
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:867
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:911
 msgid ""
 "If this unit doesn’t move before attacking, it will retain its movement "
 "points after the attack."
@@ -15199,17 +15368,17 @@ msgstr ""
 "如果此单位在进攻之前没有移动，那么在进攻之后它仍然会保有自己的移动点数。"
 
 #. [dummy]: id=disengage
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:868
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:912
 msgid "This unit can move either before or after attacking."
 msgstr "此单位可以在进攻前移动，也可以在进攻后移动。"
 
 #. [dummy]: id=daze
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:876
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:920
 msgid "daze"
 msgstr "眩晕"
 
 #. [dummy]: id=daze
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:877
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:921
 msgid ""
 "When hit with this attack, an enemy suffers a 10% penalty both to their "
 "defense and chance to hit for one turn. Other specials that affect chance to "
@@ -15225,31 +15394,31 @@ msgstr ""
 "只有当命中率大于60%时，精准攻击才会受到影响。"
 
 #. [dummy]: id=daze
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:881
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:925
 msgid ""
 "This unit can daze its enemies, reducing their accuracy and defense until "
 "they end a turn."
 msgstr "此单位可以让敌方眩晕，降低他们的命中和防御，直到他们的回合结束。"
 
 #. [skirmisher]: id=distract
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:889
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:933
 msgid "distract"
 msgstr "分神"
 
 #. [skirmisher]: id=distract
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:890
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:934
 msgid "female^distract"
 msgstr "分神"
 
 #. [skirmisher]: id=distract
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:891
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:935
 msgid ""
 "This unit negates enemy Zones of Control around itself for allied units (but "
 "not for itself)."
 msgstr "此单位将使得其身周的敌方控制区域对友方单位失效（但对其自身仍然有效）。"
 
 #. [skirmisher]: id=distract
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:892
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:936
 msgid ""
 "This unit is capable of distracting opponents, allowing allied units to "
 "trespass their Zones of Control and move unhindered around them."
@@ -15258,86 +15427,52 @@ msgstr ""
 "动。"
 
 #. [dummy]: id=support
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:903
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:947
 msgid "support"
 msgstr "支援"
 
 #. [dummy]: id=support
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:904
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:948
 msgid "female^support"
 msgstr "支援"
 
 #. [dummy]: id=support
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:905
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:949
 msgid "The upkeep costs of adjacent friendly units are lowered by 1."
 msgstr "身周的友好单位的维护费用降低1。"
 
 #. [unstore_unit]
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:952
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:996
 msgid "dazed"
 msgstr "眩晕"
 
 #. [unstore_unit]
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:953
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:997
 msgid "female^dazed"
 msgstr "眩晕"
 
 #. [chance_to_hit]: id=self_dazed
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:980
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:997
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1024
 msgid "accuracy:"
-msgstr ""
+msgstr "精准度："
 
 #. [chance_to_hit]: id=self_dazed
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:981
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:998
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1025
 msgid "Because this unit is dazed, its accuracy is decreased by 10%"
-msgstr ""
-
-#. [dummy]: id=opportunist
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1378
-msgid "opportunist"
-msgstr "机会主义者"
-
-#. [dummy]: id=opportunist
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1379
-msgid ""
-"This ability makes Kaleh attack enemies with single strike of bolas when "
-"they leave his zone of control."
-msgstr "这个能力使得卡勒在敌人离开他的控制区时，用一击流星锤攻击敌人。"
-
-#. [dummy]: id=taunt
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1453
-msgid "taunt"
-msgstr "嘲讽"
-
-#. [dummy]: id=taunt
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1454
-msgid "Taunts the enemy making them try to attack Kaleh for one turn."
-msgstr "嘲讽敌人使得他们尝试攻击卡勒一回合。"
-
-#. [dummy]: id=taunted
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1491
-msgid "taunted"
-msgstr "被嘲讽"
-
-#. [dummy]: id=taunted
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1492
-msgid "This unit is taunted by Kaleh, it will try to attack him for one turn."
-msgstr "这个单位被卡勒嘲讽，它会尝试攻击他一回合。"
+msgstr "由于此单位处于眩晕状态，其精准度降低10%。"
 
 #. [leadership]: id=inspire
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1501
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1402
 msgid "inspire"
 msgstr "鼓舞"
 
 #. [leadership]: id=inspire
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1502
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1403
 msgid "female^inspire"
 msgstr "鼓舞"
 
 #. [leadership]: id=inspire
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1503
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1404
 msgid ""
 "This unit can inspire own units that are next to it, making them fight "
 "better. Adjacent own units of lower or equal level will deal 25% more damage "
@@ -15347,7 +15482,7 @@ msgstr ""
 "相同或比其低的单位将多输出25%伤害，等级每多差一级，则再多输出25%伤害。"
 
 #. [leadership]: id=inspire
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1504
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1405
 msgid ""
 "The presence of this unit inspires own units next to it to deal more damage "
 "in combat, though this only applies to units of lower or equal level."
@@ -15355,58 +15490,53 @@ msgstr ""
 "此单位的存在使周围的己方单位在战斗中造成更多伤害，虽然这只对比其低等级或与其"
 "同等级的单位有效。"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1515
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1416
 msgid "cooldown 1"
 msgstr "冷却1"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1518
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1419
 msgid "cooldown 2"
 msgstr "冷却2"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1521
-#, fuzzy
-#| msgid "After using this attack, you can't use it during your next turn."
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1422
 msgid "After using this attack, you can’t use it during your next turn."
-msgstr "在使用这个攻击之后，你在下一回合不能用它。"
+msgstr "使用此攻击之后，下一回合不能再使用。"
 
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1524
-#, fuzzy
-#| msgid ""
-#| "After using this attack, you can't use it during your next two turns."
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1425
 msgid "After using this attack, you can’t use it during your next two turns."
-msgstr "在使用这个攻击之后，你在接下来两回合不能用它。"
+msgstr "使用此攻击之后，下两回合不能再使用。"
 
 #. [dummy]: id=pierce
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1585
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1486
 msgid "pierce"
 msgstr "穿刺"
 
 #. [dummy]: id=pierce
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1586
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1487
 msgid ""
 "This weapon, when used offensively, can also deal damage to a unit behind "
 "the target."
 msgstr "这个武器，当在进攻时使用时，也可以对目标身后的一个单位造成伤害。"
 
 #. [dummy]: id=puncture
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1656
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1557
 msgid "puncture"
-msgstr ""
+msgstr "贯穿"
 
 #. [dummy]: id=puncture
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1657
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1558
 msgid ""
 "This weapon, when used offensively, can also deal damage to two units behind "
 "the target."
 msgstr "这个武器，当在进攻时使用时，也可以对目标身后的两个单位造成伤害。"
 
 #. [dummy]: id=rain_of_arrows
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1740
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1641
 msgid "rain of arrows"
 msgstr "箭雨"
 
 #. [dummy]: id=rain_of_arrows
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1741
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1642
 msgid ""
 "This weapon, when used offensively, can also deal damage to a unit behind "
 "the target and all units adjacent to the unit behind the target."
@@ -15415,16 +15545,125 @@ msgstr ""
 "有相邻单位造成伤害。"
 
 #. [dummy]: id=sword_dance
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1862
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1763
 msgid "sword dance"
 msgstr "剑舞"
 
 #. [dummy]: id=sword_dance
-#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1863
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1764
 msgid ""
-"Every time Nym hits an enemy she gains +10% accuracy and 10% parry until the "
-"end of the combat."
-msgstr "每次妮慕击中敌人时，她都会获得+10%的精确度和10%的闪避，直到战斗结束。"
+"On offense, each successful hit increases the chance to hit the opponent and "
+"decreases the chance of being hit by them by 10% each, until the end of the "
+"fight."
+msgstr ""
+"进攻时，每次成功命中都会使自身命中对手的几率提高10%，同时使被对手命中的几率降"
+"低10%，持续到战斗结束。"
+
+#. [heals]: id=natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1842
+msgid "nature’s aid +2"
+msgstr "自然之助 +2"
+
+#. [heals]: id=natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1843
+msgid "female^nature’s aid +2"
+msgstr "自然之助 +2"
+
+#. [heals]: id=natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1844
+msgid ""
+"All units on this unit’s side, regardless of distance, will heal themselves "
+"for 2 HP when starting their turn in forest or fungus."
+msgstr ""
+"此单位所属阵营的所有单位，无论距离多远，只要在森林或菌菇地形开始回合，即可自"
+"行恢复2点生命值。"
+
+#. [heals]: id=natures_aid
+#. [heals]: id=extra_natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1845
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1872
+msgid ""
+"This ability will not cure an affected unit of poison, however, only delay "
+"its effect."
+msgstr "然而，此能力并不能治愈受影响单位的中毒状态，只能延缓其效果。"
+
+#. [heals]: id=natures_aid
+#. [heals]: id=extra_natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1846
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1873
+msgid "This unit is capable of basic healing and slowing dehydration."
+msgstr "此单位具备基础治疗能力，并能延缓脱水。"
+
+#. [heals]: id=extra_natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1869
+msgid "nature’s aid +4"
+msgstr "自然之助 +4"
+
+#. [heals]: id=extra_natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1870
+msgid "female^nature’s aid +4"
+msgstr "自然之助 +4"
+
+#. [heals]: id=extra_natures_aid
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1871
+msgid ""
+"All units on this unit’s side, regardless of distance, will heal themselves "
+"for 4 HP when starting their turn in forest or fungus."
+msgstr ""
+"此单位所属阵营的所有单位，无论距离多远，只要在森林或菌菇地形开始回合，即可自"
+"行恢复4点生命值。"
+
+#. [dummy]: id=corrupting_influence
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1893
+msgid "corrupting influence"
+msgstr "堕落影响"
+
+#. [dummy]: id=corrupting_influence
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1894
+msgid "female^corrupting influence"
+msgstr "堕落影响"
+
+#. [dummy]: id=corrupting_influence
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1895
+msgid ""
+"Controls nature to deal 1 point of damage to enemy units standing in forest "
+"or fungus at the beginning of their turn."
+msgstr "操控自然，对回合开始时处于森林或菌菇中的敌方单位造成1点伤害。"
+
+#. [dummy]: id=corrupting_influence
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1896
+msgid ""
+"Cannot kill a unit, does not grant XP but stacks with other abilities with "
+"the same name."
+msgstr "无法击杀单位，不获得经验值，但可与同名的其他能力叠加。"
+
+#. [dummy]: id=corrupting_influence
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1897
+msgid "This unit is capable of control over nature."
+msgstr "此单位能够操控自然。"
+
+#. [extra_attack]: id=intercept
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1939
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1940
+msgid "intercept"
+msgstr "拦截"
+
+#. [extra_attack]: id=intercept
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1941
+msgid ""
+"When an enemy unit enters an adjacent space, the wielder immediately "
+"executes an uncountered intercepting strike with this weapon."
+msgstr ""
+"当敌方单位进入相邻格子时，装备者会立即使用此武器发动一次无法被反击的拦截打"
+"击。"
+
+#. [extra_attack]: id=intercept
+#: data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg:1942
+msgid ""
+"Delivers a full-power, uncountered attack when enemies move to an adjacent "
+"space. Activates once per turn."
+msgstr ""
+"当敌人移动至相邻格子时，发动一次无法被反击的全力攻击。每回合限触发一次。"
 
 #: data/campaigns/Under_the_Burning_Suns/utils/character-definitions.cfg:5
 msgid "Kaleh"
@@ -16280,7 +16519,7 @@ msgstr ""
 "对我们招手，然后我们走了过去……"
 
 #. [part]
-#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:219
+#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:218
 msgid ""
 "Chapter 11: Our boats slipped softly through the water, shrouded in the pre-"
 "dawn darkness. At this moment the merfolk would be launching their "
@@ -16293,7 +16532,7 @@ msgstr ""
 "岛慢慢显现出来，阴暗而且恐怖。"
 
 #. [part]
-#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:223
+#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:222
 msgid ""
 "In the end, almost all of my people decided to join in this final battle. I "
 "was surprised. They had gone through so much, and yet they still had faith "
@@ -16311,7 +16550,7 @@ msgstr ""
 "但实际上全是我在引导着大家。所以不论好坏，我也只能抱怨我自己。"
 
 #. [part]
-#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:227
+#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:226
 msgid ""
 "But Zhul is right, if we had come all this way just for a chance to help the "
 "merfolk defeat Yechnagoth then our journey was not in vain. We were "
@@ -16331,7 +16570,7 @@ msgstr ""
 "魂，还有在我们的征途中因帮助我们而献出生命的朋友们，他们的仇都必须报。"
 
 #. [part]
-#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:231
+#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:230
 msgid ""
 "This conflict is greater than just us. These lands were once places of "
 "beauty and hope. The great empires may be gone, but still people struggle to "
@@ -16348,7 +16587,7 @@ msgstr ""
 "个更好的地方。拜托了，请不要让所有的努力都白费……"
 
 #. [part]
-#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:239
+#: data/campaigns/Under_the_Burning_Suns/utils/storytxt.cfg:238
 msgid ""
 "Chapter 12: True strength is not measured in might or knowledge, but in what "
 "you can do for those you love."
@@ -16384,42 +16623,3 @@ msgstr "幻影城堡"
 #: data/campaigns/Under_the_Burning_Suns/utils/terrain.cfg:64
 msgid "Phantom Keep"
 msgstr "幻影主楼"
-
-#~ msgid ""
-#~ "stunned: This unit is stunned. It cannot enforce its Zone of Control."
-#~ msgstr "昏迷: 此单位已昏迷，无法确保其控制区域。"
-
-#~ msgid "Hunter"
-#~ msgstr "猎手"
-
-#~ msgid "Leader"
-#~ msgstr "领袖"
-
-#~ msgid "Warrior (choose only one): specialize in melee combat"
-#~ msgstr "武士（只能选一项）：近战特化"
-
-#~ msgid "Warrior (choose only one): specialize in archery"
-#~ msgstr "武士（只能选一项）：射术特化"
-
-#~ msgid "Hunter (choose only one): specialize in surprise attacks"
-#~ msgstr "猎手（只能选一项）：奇袭特化"
-
-#~ msgid "Hunter (choose only one): specialize in skirmishing"
-#~ msgstr "猎手（只能选一项）：游击特化"
-
-#~ msgid "Leader (choose only one): specialize in supporting allies"
-#~ msgstr "领袖（只能选一项）：支援特化"
-
-#~ msgid "Leader (choose only one): specialize in distracting enemies"
-#~ msgstr "领袖（只能选一项）：扰乱特化"
-
-#~ msgid "Skeleton Rider"
-#~ msgstr "骷髅骑士"
-
-#~ msgid ""
-#~ "Once great warriors across the plains, these mounted riders atop their "
-#~ "skeletal horses were raised from the sands by unholy magic to spread fear "
-#~ "and destruction."
-#~ msgstr ""
-#~ "他们是曾经驰骋平原的伟大武士，现在被邪恶的魔法唤醒，和他们的骷髅战马一起，"
-#~ "去散播恐惧与破坏。"

--- a/translations/wesnoth/po/wesnoth-wof/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-wof/zh_CN.po
@@ -1,12 +1,19 @@
+# The Battle for Wesnoth - Simplified Chinese Translations
+# Copyright (C) 2005-2026 Wesnoth development team
+# This file is distributed under the same license as the Battle for Wesnoth package.
+#
+# Translators and their initial years of participation:
+# vimacs <vimacs.hacks@gmail.com>, 2024.
+# CloudiDust <cloudidust@gmail.com>, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: wesnoth-1.20\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
 "POT-Creation-Date: 2026-08-03 03:45 UTC\n"
-"PO-Revision-Date: 2026-06-30 22:40+0800\n"
-"Last-Translator: vimacs <vimacs.hacks@gmail.com>\n"
-"Language-Team: none\n"
+"PO-Revision-Date: 2026-08-29 17:43+0800\n"
+"Last-Translator: CloudiDust <cloudidust@gmail.com>\n"
+"Language-Team: Wesnoth Simplified Chinese Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,12 +47,10 @@ msgstr ""
 
 #. [campaign]: id=Winds_of_Fate
 #: data/campaigns/Winds_of_Fate/_main.cfg:21
-#, fuzzy
-#| msgid "<i>Features full recall costs and no gold carryover.</i>"
 msgid ""
 "<i>Features XP-based recall costs and frequent scenarios with no turn limits."
 "</i>"
-msgstr "<i>本战役使用全价召回，并且金币不会带到下一幕。</i>"
+msgstr "<b>采用基于经验值的召回费用，且大量场景不设回合限制。</b>"
 
 #. [campaign]: id=Winds_of_Fate
 #: data/campaigns/Winds_of_Fate/_main.cfg:22
@@ -107,7 +112,7 @@ msgstr "图形"
 #. [about]
 #: data/campaigns/Winds_of_Fate/about.cfg:38
 msgid "Sound"
-msgstr ""
+msgstr "声效"
 
 #. [about]
 #: data/campaigns/Winds_of_Fate/about.cfg:46
@@ -128,10 +133,8 @@ msgstr "狩猎"
 #. In this campaign, the drake narrator and other drake characters speak with the Morogor dialect, which has some unique syntax and terms.
 #. The file data/campaigns/Winds_of_Fate/story/Morogor_Dialect.txt has details about how these drakes speak in English, as well as a glossary for the campaign.
 #: data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg:20
-#, fuzzy
-#| msgid "From the skies above, the glider caste felt the Winds of Fate."
 msgid "From the skies above, the glider caste felt the Winds."
-msgstr "于九天之上，滑翔者感命运之风。"
+msgstr "于九天之上，滑翔者阶层感受到了命运之风"
 
 #. [part]
 #: data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg:23
@@ -522,17 +525,10 @@ msgstr ""
 
 #. [message]: type=Fire Guardian
 #: data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg:353
-#, fuzzy
-#| msgid ""
-#| "<span  size='5000' font-style='italic'>Ward thyselves for it has arrived. "
-#| "The grey light that shades the living worlds. The calm wind that snuffs "
-#| "warm souls. The Faerie reached this world.</span>"
 msgid ""
 "Ward thyselves for it has arrived. The grey light that shades the living "
 "worlds. The calm wind that snuffs warm souls. The Faerie reached this world."
-msgstr ""
-"<span  size='5000' font-style='italic'>汝等当护，因其已至。遮蔽生界之灰光。熄"
-"灭暖魂之静风。精界已临此世。</span>"
+msgstr "汝等当护，因其已至。遮蔽生界之灰光。熄灭暖魂之静风。仙境已临此世。"
 
 #. [message]: speaker=Gorlack
 #: data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg:357
@@ -1486,14 +1482,6 @@ msgstr ""
 
 #. [part]
 #: data/campaigns/Winds_of_Fate/scenarios/02x_Victory_Feast.cfg:72
-#, fuzzy
-#| msgid ""
-#| "Perilous that way is.\n"
-#| "A wide stretch of sea unexceptional flyers might cross with fortune from "
-#| "the Winds of Fate.\n"
-#| "\n"
-#| "Then only a cluster of shoals to rest them, which might be slid past "
-#| "unnoticed with perilous ease."
 msgid ""
 "Perilous that way is.\n"
 "A wide stretch of sea unexceptional flyers might cross with fortune from the "
@@ -1629,10 +1617,8 @@ msgstr "观战者"
 
 #. [objective]: condition=win
 #: data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg:206
-#, fuzzy
-#| msgid "Hold all villages at the end of turn 18"
 msgid "Hold more villages at the end of turn 24"
-msgstr "在18回合结束时持有所有村庄"
+msgstr "在第24回合结束时占有更多的村庄"
 
 #. [objective]: condition=win
 #: data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg:211
@@ -1641,10 +1627,8 @@ msgstr "击败卡戎"
 
 #. [objective]: condition=lose
 #: data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg:215
-#, fuzzy
-#| msgid "Not hold all villages at the end of turn 18"
 msgid "Fail to hold more villages at the end of turn 24"
-msgstr "在18回合结束时没有持有所有村庄"
+msgstr "没能在第24回合结束时占有更多的村庄"
 
 #. [objective]: condition=lose
 #: data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg:219
@@ -4095,14 +4079,6 @@ msgstr ""
 
 #. [part]
 #: data/campaigns/Winds_of_Fate/scenarios/06x_Winds_of_Fate.cfg:169
-#, fuzzy
-#| msgid ""
-#| "Speak no more of your fears!\n"
-#| "\n"
-#| "So many challenges have we overcome.\n"
-#| "So many foes vanquished.\n"
-#| "Yet still you feel not how we shift the Winds of Fate by the force of our "
-#| "Will."
 msgid ""
 "Speak no more of your fears!\n"
 "\n"
@@ -4129,19 +4105,6 @@ msgstr ""
 
 #. [part]
 #: data/campaigns/Winds_of_Fate/scenarios/06x_Winds_of_Fate.cfg:185
-#, fuzzy
-#| msgid ""
-#| "Nay!\n"
-#| "\n"
-#| "We are not merely tossed about by the Winds of Fate.\n"
-#| "We <b>shape</b> them.\n"
-#| "\n"
-#| "We fumble not for a Windpath.\n"
-#| "We make it.\n"
-#| "\n"
-#| "Feel the world as it should be with all the fire of your heart.\n"
-#| "With no room left for <i>fear</i>.\n"
-#| "With all your Willful heart, make that world be!"
 msgid ""
 "Nay!\n"
 "\n"
@@ -4164,7 +4127,7 @@ msgstr ""
 "吾等乃辟路之士。\n"
 "\n"
 "以汝炽心全部火焰，感知世界应有之貌。\n"
-"不容<i>惧意</i>存隙。\n"
+"不容<b>惧意</b>存隙。\n"
 "以汝全副意志之心，令彼界成真！"
 
 # Translated by openrouter with model deepseek/deepseek-chat-v3.1:free..
@@ -4437,15 +4400,6 @@ msgstr ""
 
 #. [message]: speaker=Salennea
 #: data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg:373
-#, fuzzy
-#| msgid ""
-#| "This is my castle Saethrania — the Castle of Sharing.\n"
-#| "\n"
-#| "You may make an abode of castle Gliinoler — the Castle of Caring.\n"
-#| "\n"
-#| "My attendants will bestow whatever form of floral nourishment you most "
-#| "desire. Mayhap Bread of the Locust Fruit softened with Milk of the Hazel "
-#| "and sweetened with Sap of the Birch?"
 msgid ""
 "This is my castle Saethrania — the Castle of Virtue.\n"
 "\n"
@@ -4455,9 +4409,9 @@ msgid ""
 "desire. Mayhap Bread of the Locust Fruit softened with Milk of the Hazel and "
 "sweetened with Sap of the Birch?"
 msgstr ""
-"这是我的萨艾瑟拉尼亚城堡——分享之堡。\n"
+"这是我的萨艾瑟拉尼亚城堡——美德之堡。\n"
 "\n"
-"你可以住在格里诺勒尔城堡——关怀之堡。\n"
+"你可以住在格里诺勒尔城堡——牺牲之堡。\n"
 "\n"
 "我的仆从将献上你想要的任何滋养花食。或者是用榛乳软化，用桦汁增甜的蝗虫面包？"
 
@@ -4569,17 +4523,6 @@ msgstr ""
 
 #. [message]: speaker=narrator
 #: data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg:465
-#, fuzzy
-#| msgid ""
-#| "28th day of Greenleaf\n"
-#| "\n"
-#| "...now that I have found a powerful ally in Lord Vanar of the far side, "
-#| "the days of Lady Dionli are nigh over. I need only complete a single "
-#| "small ritual for him, the details of which he shall provide to me after I "
-#| "gather the necessary elements. I list them here so as not to forget:\n"
-#| "— A slab of cold black granite.\n"
-#| "— One of my fair young handmaidens.\n"
-#| "— A twisted metal dagger that menaces with spikes of..."
 msgid ""
 "28th day of Greenleaf\n"
 "\n"
@@ -4593,23 +4536,15 @@ msgid ""
 msgstr ""
 "绿叶28日\n"
 "\n"
-"…如今，我已寻得彼岸凡纳尔领主为强大盟友，迪翁莉女领主的末日近在眼前。我只需为"
-"他完成一个小小仪式，待我集齐所需之物，其细节自会告知于我。兹列如下，以免遗"
+"……如今，我已寻得彼岸凡纳尔领主为强大盟友，迪翁莉女领主的末日近在眼前。我只需"
+"为他完成一个小小仪式，待我集齐所需之物，其细节自会告知于我。兹列如下，以免遗"
 "忘：\n"
 "—— 一块冰冷的黑曜石板。\n"
 "—— 我的一位貌美侍女。\n"
-"—— 一柄扭曲的金属匕首，其上布满尖刺，威胁着…"
+"—— 一柄扭曲的金属匕首，其尖刺令人望而生畏……"
 
 #. [message]: speaker=narrator
 #: data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg:474
-#, fuzzy
-#| msgid ""
-#| "29th day of Greenleaf\n"
-#| "\n"
-#| "...how was I to know Vanar’s ritual would involve blood sacrifice?! Oh, "
-#| "if only the wicked “Lady” Dionli had not put me in this unenviable "
-#| "position. Now I shall need another unsalaried novice handmaiden willing "
-#| "to work for “experience”..."
 msgid ""
 "29th day of Greenleaf\n"
 "\n"
@@ -4620,19 +4555,12 @@ msgid ""
 msgstr ""
 "绿叶29日\n"
 "\n"
-"…我怎会知晓凡纳尔的祭典竟需献祭？！哦，倘若那邪恶的迪翁莉“女领主”未曾将我置于"
-"此等不堪之境，该多好。而今，我得另寻一名无薪的见习侍女，愿为“经验”而工作…"
+"……我怎会知晓凡纳尔的祭典竟需鲜血献祭？！哦，倘若那邪恶的迪翁莉“女领主”未曾将"
+"我置于此等不堪之境，该多好。而今，我得另寻一名无薪的见习侍女，愿为“经验”而工"
+"作…"
 
 #. [message]: speaker=narrator
 #: data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg:480
-#, fuzzy
-#| msgid ""
-#| "1st day of Leaffall\n"
-#| "\n"
-#| "...still more of these dreadful rituals must be completed before Vanar "
-#| "can place a curse upon my usurper. Yet if I stop now, everything I have "
-#| "sacrificed— <i>everyone</i> I have sacrificed —shall have been in vain! I "
-#| "owe it to them to continue..."
 msgid ""
 "1st day of Leaffall\n"
 "\n"
@@ -4643,9 +4571,9 @@ msgid ""
 msgstr ""
 "落叶1日\n"
 "\n"
-"…在凡纳尔能对我的篡位者施下诅咒之前，还有更多可怕的仪式必须完成。然而如果我现"
-"在停手，我已牺牲的一切——我已牺牲的<i>每个人</i>——都将付诸东流！为了他们，我必"
-"须继续下去…"
+"……在凡纳尔能对我的篡位者施下诅咒之前，还有更多可怕的仪式必须完成。然而如果我"
+"现在停手，我已牺牲的一切——我已牺牲的<b>每个人</b>——都将付诸东流！为了他们，我"
+"必须继续下去……"
 
 #. [message]: speaker=narrator
 #: data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg:486
@@ -4664,16 +4592,6 @@ msgstr ""
 
 #. [message]: speaker=narrator
 #: data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg:493
-#, fuzzy
-#| msgid ""
-#| "31st day of Leaffall\n"
-#| "\n"
-#| "...those saurians may smell of the swamp they crawl from, but they shall "
-#| "make a worthy sacrifice to Vanar! I have extended a formal invitation to "
-#| "Arinexis, a saurian ambassador, or what passes for one amongst their "
-#| "primitive and malodorous kind. I shall show this saurian and its "
-#| "entourage every courtesy and tempt them with all the delights of elvish "
-#| "cuisine— seasoned with Shavings of the Yew..."
 msgid ""
 "31st day of Leaffall\n"
 "\n"
@@ -4686,10 +4604,10 @@ msgid ""
 msgstr ""
 "落叶31日\n"
 "\n"
-"…那些蜥蜴人或许还带着它们爬出的沼泽的恶臭，但它们终将成为凡纳尔的一份合格的祭"
-"品！我已向蜥蜴人大使阿瑞尼克西斯发出了正式的邀请，在他们那原始且腥臭的族群之"
-"中的一位。我将对这只蜥蜴人及其随从施以最殷勤的款待，并用精灵美食——用紫杉刨花"
-"调味——来诱惑他们…"
+"……那些蜥蜴人或许还带着它们爬出的沼泽的恶臭，但它们终将成为凡纳尔的一份合格的"
+"祭品！我已向蜥蜴人大使阿瑞尼克西斯发出了正式的邀请，在他们那原始且腥臭的族群"
+"之中的一位。我将对这只蜥蜴人及其随从施以最殷勤的款待，并用精灵美食——用紫杉刨"
+"花调味——来诱惑他们……"
 
 #. [message]: speaker=Salennea
 #: data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg:511
@@ -4861,7 +4779,7 @@ msgstr "奇异生物"
 #. [leader]: id=Lich-Lord Selmar, type=Ancient Lich
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:72
 msgid "Lich-Lord Selmar"
-msgstr ""
+msgstr "巫妖领主塞尔玛"
 
 #. [side]
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:105
@@ -4893,7 +4811,7 @@ msgstr "戈拉克、瑞莎、阿瑞尼克西斯和泽德里克斯到达洞穴出
 msgid ""
 "Recruits and recalled veterans which exit before Gorlack does will survive, "
 "the rest will die"
-msgstr ""
+msgstr "先于戈拉克撤离的新兵与召回的老兵将会存活，其余的将会死亡。"
 
 #. [note]
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:238
@@ -4910,7 +4828,7 @@ msgstr "为了赢得尊重嘶嘶，我们和的龙的联盟必须有<b>某个嘶
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:254
 msgid "‘Sssibblings of Sssetting Sssun’"
-msgstr "“夕阳的兄弟们”嘶嘶"
+msgstr "“嘶嘶夕阳的兄弟们”"
 
 #. [message]: speaker=Arinexis
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:258
@@ -4920,7 +4838,7 @@ msgstr "“沙格拉斯与莫罗戈联盟”"
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:264
 msgid "‘Alignment of Moon and Sssun’"
-msgstr "“月日同辉”嘶嘶"
+msgstr "“月日同辉嘶嘶”"
 
 #. [message]: speaker=Arinexis
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:268
@@ -4930,7 +4848,7 @@ msgstr "“沙行者”"
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:274
 msgid "‘League of Ssseven Sssilver Ssstars and Five Fish of Firmament’"
-msgstr "“七银星与苍穹五鱼联盟”嘶嘶"
+msgstr "“七银星嘶嘶与苍穹五鱼联盟”"
 
 #. [message]: speaker=Arinexis
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:278
@@ -5103,31 +5021,6 @@ msgstr "除非你先把骨头烧掉、压碎或吃掉嘶嘶。永远不要留下
 #. "Still, our woodcutters cannot harvest any more mushroom fodder out of the forest without elves chipping away at them and the lodestone mines are nearly to the end of their (ore) veins.
 #. "Maybe I should trade this cave to that strange "lich" creature after all. Whatever it be I do not care; if the elves ever come back then they can deal with it."
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:525
-#, fuzzy
-#| msgid ""
-#| "Lodestane Mines of Gyldanwolf Clan\n"
-#| "\n"
-#| "Year of Wirk 368, 7th Month\n"
-#| "\n"
-#| "They elves wur back in the mushroom croft again, making dolly threats tae "
-#| "the laddies in that fancy tongue of thairs. Said thay wid attack if we "
-#| "gather ony mair wood tae feed oor mushrooms, it does nae even maiter if "
-#| "it be juist the pine!\n"
-#| "\n"
-#| "Hud the laddies pat up gates tae keep they elves oot fur now.\n"
-#| "\n"
-#| "If thay dae come back with an airmie we cannae handle, we hae flashpowder "
-#| "kegs aroond the load bearing walls. They elves ur sae impressed with that "
-#| "cute “magic” of thairs— think of the looks oan thair faces whin thay see "
-#| "dwarven kencraft at wirk!\n"
-#| "\n"
-#| "Still, oor woodcutters cannae harvest ony mair mushroom fodder oot of the "
-#| "forest withoot elves chipping away at thaim and the lodestane mines ur "
-#| "nearly tae the end of thair veins.\n"
-#| "\n"
-#| "Mibbie ah shuid trade this cave tae that streenge “Nova” cratur efter "
-#| "all. Whit ever it be ah dae nae care; if the elves ever come back then "
-#| "thay kin deal with it."
 msgid ""
 "Lodestane Mines of Gyldanwolf Clan\n"
 "\n"
@@ -5153,7 +5046,7 @@ msgid ""
 "Whit ever it be ah dae nae care; if the elves ever come back then thay kin "
 "deal with it."
 msgstr ""
-"金狼氏族的磁铁矿场\n"
+"金狼氏族的磁石矿场\n"
 "\n"
 "工历368年，7月\n"
 "\n"
@@ -5165,7 +5058,7 @@ msgstr ""
 "若他们果真率吾等无力抵挡之军卷土重来，俺们便在承重墙周遭布设火药桶。那些精灵"
 "对其那点小聪明“魔法”颇为自得——且待他们见识矮人的匠心，其表情定然精彩！\n"
 "\n"
-"然而，若无精灵不断侵扰，俺们伐木工便无法再入林采伐蘑菇饲料，且磁铁矿脉亦已濒"
+"然而，若无精灵不断侵扰，俺们伐木工便无法再入林采伐蘑菇饲料，且磁石矿脉亦已濒"
 "临枯竭。\n"
 "\n"
 "也罢，俺要将此洞拱手让予那古怪的“新星”之物。无论其为何物，俺也不在乎；若精灵"
@@ -5173,10 +5066,8 @@ msgstr ""
 
 #. [message]: speaker=Lich-Lord Selmar
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:575
-#, fuzzy
-#| msgid "Is that you again, Khrakrahs?"
 msgid "Come to test your luck again, Khrakrahs?"
-msgstr "那又是你吗，柯拉卡拉斯？"
+msgstr "你又来试运气了，柯拉卡拉斯？"
 
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:579
@@ -5190,13 +5081,15 @@ msgid ""
 "shall all make fine additions to my new legion. The only question is — will "
 "you serve willingly?"
 msgstr ""
+"那更好了。啊，看来他还带了不少朋友来。你们都会成为我新军团的绝佳补充。唯一的"
+"问题是——你们会自愿效劳吗？"
 
 #. [message]: speaker=Arinexis
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:589
 msgid ""
 "We sssaurians will never ssserve the likesss of a human monssster or your "
 "elf massstersss!"
-msgstr ""
+msgstr "我们蜥蜴人绝不会嘶嘶侍奉像你这样的人类怪物或你的精灵主子！嘶嘶！"
 
 #. [message]: speaker=Lich-Lord Selmar
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:595
@@ -5208,13 +5101,17 @@ msgid ""
 "Wesmere. No living thing will remain standing between me and the Ruby of "
 "Fire."
 msgstr ""
+"精灵主子？愚蠢的小蛤蟆，我岂会仅仅因区区树领主的召唤就穿越半个世界。他们手里"
+"有一样本该属于我的东西，我是来索回的。待到新月升起，通往巨人之地的大门便会开"
+"启，从中倾泻的洪流将把韦弥尔的精灵一扫而空。届时，将没有任何生灵能挡在我与火"
+"焰红宝石之间。"
 
 #. [message]: speaker=Arinexis
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:599
 msgid ""
 "You hatched your plan too late, human. We already sssacked Wesssmere, the "
 "elves are dealt with."
-msgstr ""
+msgstr "你策划得太晚了，人类。我们已经嘶嘶洗劫了韦弥尔，精灵已经被解决掉了。"
 
 #. [message]: speaker=Lich-Lord Selmar
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:605
@@ -5222,6 +5119,8 @@ msgid ""
 "You could never have done such a feat with even tenfold your motley warband. "
 "Wait... what is all that clamour behind you...?"
 msgstr ""
+"即便你那支杂牌军扩充十倍，也绝不可能完成此等壮举。等等……你身后那阵喧哗是怎么"
+"回事……？"
 
 #. [message]: speaker=Lich-Lord Selmar
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:611
@@ -5230,6 +5129,8 @@ msgid ""
 "plan will become clear to them if they so much as glimpse my unfinished "
 "portal with their faerie sight."
 msgstr ""
+"蠢货，你们竟将韦弥尔的整支大军引到了这处隐秘之地！只要他们用仙境视觉瞥见我尚"
+"未完工的传送门，我的计划就会暴露无遗。"
 
 #. [message]: speaker=Resha
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:615
@@ -5254,40 +5155,31 @@ msgid ""
 "attention, so begone! Leave the way you came and they may yet follow you "
 "away from my lair!"
 msgstr ""
+"这远远超出了你们粗鄙的理解力；那是一个强大的魔法世界，其中的魔法皆拥有自我意"
+"识。此刻你们已完全吸引了它们的注意，所以快滚！原路返回，它们兴许会跟着你们离"
+"开我的巢穴！"
 
 #. [message]: speaker=Resha
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:629
-#, fuzzy
-#| msgid ""
-#| "Gorlack, it is an ancient terror that hunts us.\n"
-#| "You must get our flight through this mountain at any cost."
 msgid ""
 "Gorlack, it is an ancient foe that hunts us.\n"
 "You must get our flight through this mountain at any cost."
 msgstr ""
-"戈拉克。此乃狩猎吾等远古之怖。\n"
+"戈拉克，此乃狩猎吾等之远古恐怖。\n"
 "汝须引吾等翼群，穿越此山，不计代价。"
 
 #. [message]: speaker=Gorlack
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:634
-#, fuzzy
-#| msgid ""
-#| "I shall have passage through this mountain.\n"
-#| "\n"
-#| "You are advised to move aside."
 msgid ""
 "I shall have passage through this mountain. You are advised to move aside."
-msgstr ""
-"我将通过这座山脉。\n"
-"\n"
-"你最好让开。"
+msgstr "我将通过这座山脉。建议你最好让开。"
 
 #. [message]: speaker=Lich-Lord Selmar
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:640
 msgid ""
 "Proceed any further and you shall pass only to the land of the dead, where I "
 "am lord and master."
-msgstr ""
+msgstr "再往前一步，你们便只配前往亡灵之地，在那里我才是主宰。"
 
 #. [message]: speaker=Arinexis
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:644
@@ -5309,6 +5201,8 @@ msgid ""
 "all, may your worst plans reach fruition so your descendants remember you "
 "with shame!"
 msgstr ""
+"你们这些喷火碍事之人，在任何时代都是祸害。我诅咒你们所有人，愿你们最恶毒的计"
+"划得逞，好让你们的后代以你们为耻！"
 
 #. [message]: speaker=Resha
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:701
@@ -5370,8 +5264,6 @@ msgstr "瑞莎……"
 
 #. [message]: speaker=Resha
 #: data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg:815
-#, fuzzy
-#| msgid "My wings catch the Winds of Fate..."
 msgid "My wings catch the Winds..."
 msgstr "我的翅膀捕捉到了命运之风……"
 
@@ -5538,14 +5430,6 @@ msgstr ""
 
 #. [message]: speaker=Khrakrahs
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:353
-#, fuzzy
-#| msgid ""
-#| "I know you are here, weakling Shek’kahan! You know better than to intrude "
-#| "upon my domain! Even if I must search this entire valley, I will find "
-#| "your hiding place.\n"
-#| "\n"
-#| "Fly, my pets! Sweep this place of every scaleless beast so I will have no "
-#| "distraction."
 msgid ""
 "I know you are here, weakling Shek’kahan! You know better than to intrude "
 "upon my domain, Brother! Even if I must search this entire valley, I will "
@@ -5566,10 +5450,8 @@ msgstr "此乃…一先祖…"
 
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:363
-#, fuzzy
-#| msgid "Shek'kahan, do you not recognize Khrakrahs...?"
 msgid "Shek’kahan, do you not recognize Khrakrahs...?"
-msgstr "沙克•卡悍，你认识柯拉卡拉斯吗…？"
+msgstr "沙克•卡悍，你不认识柯拉卡拉斯吗……？"
 
 #. [objective]: condition=win
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:367
@@ -5598,10 +5480,8 @@ msgstr "吾必归来。"
 
 #. [message]: speaker=Khrakrahs
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:466
-#, fuzzy
-#| msgid "Show yourself!"
 msgid "Show yourself, Brother!"
-msgstr "显形吧！"
+msgstr "显形吧，兄弟！"
 
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:470
@@ -5610,8 +5490,6 @@ msgstr "柯拉卡拉斯，他在这里……"
 
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:486
-#, fuzzy
-#| msgid "Behold, mighty Shek'kahan!"
 msgid "Behold, mighty Shek’kahan!"
 msgstr "看啊，强大的沙克•卡悍！"
 
@@ -5622,22 +5500,16 @@ msgstr "汝竟冒名顶替！"
 
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:496
-#, fuzzy
-#| msgid ""
-#| "Impossster?!\n"
-#| "\n"
-#| "I am elder of Green Swamp Clan and all my years Shek'kahan protected "
-#| "usss. I could never missstake sssome impossster for him!"
 msgid ""
 "Impossster?!\n"
 "\n"
 "I am elder of Green Swamp Clan and all my years Shek’kahan protected usss. I "
 "could never missstake sssome impossster for him!"
 msgstr ""
-"冒名顶替者？！\n"
+"冒名顶替者嘶嘶？！\n"
 "\n"
-"我是绿色沼泽部落的长老，我的整个岁月沙克·卡悍都保护着我们嘶嘶。我绝不会将冒名"
-"顶替者嘶嘶误认为是他！"
+"我是绿嘶嘶色沼泽部落的长老，我的整个嘶嘶岁月沙克·卡悍都保护着我们。我绝不会将"
+"冒名顶替者误认为是他！"
 
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:502
@@ -5665,28 +5537,20 @@ msgstr "诚然，汝心所信，乃汝口中之谎言…因其愿之。"
 
 #. [message]: speaker=Khrakrahs
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:528
-#, fuzzy
-#| msgid "<span color='cyan'>Zedrix, your Heart shall Reveal its Truth.</span>"
 msgid "Zedrix, your Heart shall Reveal its Truth."
-msgstr "<span color='cyan'>泽德里克斯，汝之心将揭示其真相。</span>"
+msgstr "泽德里克斯，汝之心将揭示其真相。"
 
 #. [message]: speaker=Zedrix
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:539
-#, fuzzy
-#| msgid ""
-#| "Khrakrahs... Shek’kahan is dead. He fell protecting his domain and humble "
-#| "sssubjectsss...\n"
-#| "\n"
-#| "... of which I am all that is left."
 msgid ""
 "Khrakrahs... your brother is dead. He fell protecting his domain and humble "
 "sssubjectsss...\n"
 "\n"
 "... of which I am all that is left."
 msgstr ""
-"柯拉卡拉斯…沙克•卡悍已殒。他以身为盾，护其疆域与微末之民嘶嘶…\n"
+"柯拉卡拉斯……汝弟已殒。他以身为盾，护其疆域与微末之民嘶嘶……\n"
 "\n"
-"…而我，便是那残存之孤。"
+"……而我，便是那残存之孤。"
 
 #. [message]: speaker=Khrakrahs
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:547
@@ -5695,13 +5559,6 @@ msgstr "果真如此…"
 
 #. [message]: speaker=Khrakrahs
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:553
-#, fuzzy
-#| msgid ""
-#| "It was nigh every season he would intrude upon my domain or me his. Each "
-#| "time, there was such a glorious battle between us as to impart even the "
-#| "clouds with fright. I must not have challenged him enough that he grew "
-#| "weak, vulnerable. Now another great battle between us there will never "
-#| "be. Now there is only me."
 msgid ""
 "It was nigh every season he would intrude upon my domain or me his. Each "
 "time, there was such a glorious battle between us, the sons of Drugis, as to "
@@ -5720,24 +5577,17 @@ msgstr "吾去。"
 
 #. [message]: speaker=Gorlack
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:570
-#, fuzzy
-#| msgid ""
-#| "Ancestor, you spoke that Shek'kahan grew weak...\n"
-#| "\n"
-#| "Yet to his last breath, he was fearless."
 msgid ""
 "Ancestor, you spoke that Shek’kahan grew weak...\n"
 "\n"
 "Yet to his last breath, he was fearless."
 msgstr ""
-"先祖，汝言沙克•卡悍日渐衰微…\n"
+"先祖，汝言沙克•卡悍日渐衰微……\n"
 "\n"
 "然其至终息一刻，亦无畏无惧。"
 
 #. [message]: speaker=Khrakrahs
 #: data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg:578
-#, fuzzy
-#| msgid "Yes, Shek'kahan was fearless."
 msgid "Yes, Shek’kahan was fearless."
 msgstr "然，沙克•卡悍无所畏惧。"
 
@@ -5795,12 +5645,8 @@ msgstr "存活18回合"
 #. [note]
 #: data/campaigns/Winds_of_Fate/scenarios/10_Fire_Meets_Steel.cfg:307
 #: data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg:195
-#, fuzzy
-#| msgid ""
-#| "The new eyrie doubles village income and support and trains veteran "
-#| "recruits"
 msgid "The presence of our new eyrie doubles village income and support"
-msgstr "新建的巢穴将使村庄收入与支援翻倍，并训练经验丰富的新兵"
+msgstr "新建的巢穴将使村庄收入与支援翻倍"
 
 #. [note]
 #: data/campaigns/Winds_of_Fate/scenarios/10_Fire_Meets_Steel.cfg:310
@@ -6597,12 +6443,12 @@ msgstr "可我这十三年的岁数，骨头里可都能感觉得到！"
 #. [message]: speaker=unit
 #: data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg:531
 msgid "???"
-msgstr ""
+msgstr "？？？"
 
 #. [message]: speaker=unit
 #: data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg:545
 msgid "Thisss ssstone has drake markingsss, maybe one of them can read it."
-msgstr ""
+msgstr "这嘶嘶石碑上有龙人的标记嘶嘶，也许他们中有人能读懂。"
 
 #. [message]: speaker=unit
 #: data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg:562
@@ -7028,20 +6874,6 @@ msgstr "卡拉维尔帆船"
 
 #. [unit_type]: id=Caravel, race=mechanical
 #: data/campaigns/Winds_of_Fate/units/Caravel.cfg:8
-#, fuzzy
-#| msgid ""
-#| "The sturdy and reliable caravel is the mainstay of human oceanic "
-#| "exploration, shipping and projection of influence. More seaworthy than "
-#| "lighter vessels, one might yet be spied navigating deeper rivers, where "
-#| "the maneuverabilty and shallow draft somewhat compensate for the tonnage "
-#| "of the vessel.\n"
-#| "\n"
-#| "While its modest speed compared to the vessels of other races makes "
-#| "evasion difficult, its tall fore and aft castles hold a powerful arsenal "
-#| "of ballistae to fend against pirate and sea monster alike.\n"
-#| "\n"
-#| "The caravel can dock at coastal villages, though this makes it entirely "
-#| "vulnerable."
 msgid ""
 "The sturdy and reliable Caravel is the mainstay of human oceanic "
 "exploration, shipping and projection of influence. More seaworthy than "
@@ -7160,7 +6992,7 @@ msgstr "闪电"
 #. [unit_type]: id=Stymphalian, race=monster
 #: data/campaigns/Winds_of_Fate/units/Stymphalian.cfg:5
 msgid "Stymphalian"
-msgstr "斯廷法洛斯湖怪鸟"
+msgstr "斯廷法洛斯鸟"
 
 #. [unit_type]: id=Stymphalian, race=monster
 #: data/campaigns/Winds_of_Fate/units/Stymphalian.cfg:8
@@ -7173,6 +7005,10 @@ msgid ""
 "from this bird’s call, though some drakes use their superior strength to "
 "hunt them."
 msgstr ""
+"斯廷法洛斯鸟是凶残而性情如恶魔般的食肉鸟，翱翔于天际搜寻猎物，其猎物小可至老"
+"鼠，大可至人类。它们尖锐的青铜色喙能啄穿最坚硬的骨头，巨大的翼展覆满利刃般锋"
+"利的羽毛，可成群掷向猎物。大多数人类听到这种鸟的叫声便会落荒而逃，但有些龙人"
+"会凭借更强的力量猎杀它们。"
 
 #. [attack]: type=pierce
 #: data/campaigns/Winds_of_Fate/units/Stymphalian.cfg:73
@@ -7247,17 +7083,13 @@ msgstr "我的龙，我辜负了你……"
 
 #. [floating_text]
 #: data/campaigns/Winds_of_Fate/utils/macros.cfg:80
-#, fuzzy
-#| msgid "Intendant"
 msgid "fighter intendant"
-msgstr "辅佐者"
+msgstr "战士总管"
 
 #. [floating_text]
 #: data/campaigns/Winds_of_Fate/utils/macros.cfg:108
-#, fuzzy
-#| msgid "Intendant"
 msgid "clasher intendant"
-msgstr "辅佐者"
+msgstr "冲击者总管"
 
 #. [floating_text]
 #: data/campaigns/Winds_of_Fate/utils/macros.cfg:209
@@ -7278,192 +7110,3 @@ msgstr "蓝宝石给持有者提供远程冰寒攻击的能力！"
 #: data/campaigns/Winds_of_Fate/utils/macros.cfg:223
 msgid "sapphire of ice"
 msgstr "冰之蓝宝石"
-
-#~ msgid "Hold the advantage at the end of turn 24"
-#~ msgstr "于第24回合结束时保持优势"
-
-#~ msgid "Not hold the advantage at the end of turn 24"
-#~ msgstr "在24回合结束时没有保持优势"
-
-#~ msgid ""
-#~ "Advantage is determined by adding the gold, the value of the drakes on "
-#~ "the field, and five times the income; Right-click to see the current score"
-#~ msgstr "优势由金币、阵中龙人估值及五倍收入之和判定；右键点击可见当前分数"
-
-#~ msgid "Karron will get an income of $side_2.village_gold gold per village"
-#~ msgstr "每座村庄将为卡戎获得 $side_2.village_gold 金币的收入"
-
-#~ msgid "Show Advantage"
-#~ msgstr "显示优势"
-
-#~ msgid "dialog^Advantage"
-#~ msgstr "优势"
-
-#~ msgid "Kill all the humans"
-#~ msgstr "杀了所有人类"
-
-#~ msgid ""
-#~ "This tree has been debarked by repeated scratching from animals of some "
-#~ "kind. It smells strongly of a fig tree yet it is clearly an oak."
-#~ msgstr ""
-#~ "此树树皮已被某种动物反复抓挠剥落。其气味虽浓郁如无花果树，然确系一株橡树。"
-
-#~ msgid "Avatar of Nova"
-#~ msgstr "新星化身"
-
-#~ msgid "When the heroes exit, anyone left on the map will die"
-#~ msgstr "当英雄们离开的时候，任何留在地图上的人会死掉"
-
-#~ msgid "Anyone that exits before the heroes do will survive"
-#~ msgstr "任何在英雄们之前离开的人会存活"
-
-#~ msgid "As you say."
-#~ msgstr "如你所说。"
-
-#~ msgid ""
-#~ "You have no means to threaten me. Even if you destroyed this grim avatar "
-#~ "of mine, presently speaking to you, I would continue acting through my "
-#~ "others in far off places.\n"
-#~ "\n"
-#~ "Now, I must resume my work and you must leave..."
-#~ msgstr ""
-#~ "你没有办法威胁我。就算你毁掉了我这个正在和你说话的阴森化身，我也会继续通过"
-#~ "远方的其他化身来行动。\n"
-#~ "\n"
-#~ "现在，我必须继续工作，你必须离开…"
-
-#~ msgid ""
-#~ "Wait... what is that behind you?\n"
-#~ "\n"
-#~ "<i>Faerie</i> creatures have followed you...\n"
-#~ "\n"
-#~ "If they come much closer <b><u>It</u></b> will see what has been created "
-#~ "here.\n"
-#~ "The Faerie World sees and feels through the senses of all the simpler "
-#~ "beings it has transmuted. And if it only glimpses my work in this early "
-#~ "phase, we may lose our world’s best hope against it."
-#~ msgstr ""
-#~ "等等…你身后是何物？\n"
-#~ "\n"
-#~ "<i>精界</i>生灵已然随你而来…\n"
-#~ "\n"
-#~ "如果它们再靠，<b><u>它</u></b>便会窥见此地之造物。\n"
-#~ "精界世界转生万物低等生灵，借其感知观照寰宇。若彼于此时初窥吾之伟业，吾等或"
-#~ "失此界对抗彼之最后一线生机。"
-
-#~ msgid ""
-#~ "There is <b><u>no</u></b> time for that!\n"
-#~ "\n"
-#~ "Faerie creatures are chasing you; you must leave the way you came or they "
-#~ "will follow you here."
-#~ msgstr ""
-#~ "<b><u>没有</u></b>时间了！\n"
-#~ "\n"
-#~ "精界之物正紧追不舍；你们必须原路折返，否则它们将循踪至此。"
-
-#~ msgid ""
-#~ "Stop!\n"
-#~ "\n"
-#~ "I am using nearly all my Focus to spellbind these Faerie creatures from "
-#~ "seeing the true nature of this place. I cannot hope to drive back an army "
-#~ "of dragons at the same time!\n"
-#~ "\n"
-#~ "You leave me no choice but to destroy my creation to save its secret."
-#~ msgstr ""
-#~ "停下！\n"
-#~ "\n"
-#~ "我几乎倾尽了所有专注力，才得以束缚住这些精界生灵，使他们无法洞悉此地的真实"
-#~ "本质。在此同时，我绝无余力去击退一支龙族的大军！\n"
-#~ "\n"
-#~ "你们的所作所为，已逼我别无选择——唯有摧毁我的造物，才能保全其中的秘密。"
-
-#~ msgid ""
-#~ "Yet even a disenchantment on such a scale will take all my remaining "
-#~ "Focus...\n"
-#~ "\n"
-#~ "I ask you for a truce.\n"
-#~ "I know you have no idea what is at stake here, but please, at least grant "
-#~ "me this."
-#~ msgstr ""
-#~ "然而，即便是如此规模的反魔法解咒，也将耗尽我余下的全部专注……\n"
-#~ "\n"
-#~ "我请求你们休战。\n"
-#~ "我知道你根本不了解这里关乎什么，但至少请你答应我这个请求。"
-
-#~ msgid "You will..."
-#~ msgstr "你会……"
-
-#~ msgid "have your truce."
-#~ msgstr "休战。"
-
-#~ msgid "Thank you, Gorlack and Resha."
-#~ msgstr "谢谢你们，戈拉克和瑞莎。"
-
-#~ msgid ""
-#~ "Our names are known to you, yet we have given them not...\n"
-#~ "\n"
-#~ "There is something familiar of you... from a Memory long ago—"
-#~ msgstr ""
-#~ "吾等之名，汝已知晓。然吾等未曾告之…\n"
-#~ "\n"
-#~ "汝之形貌，吾似曾相识…自那口述史久远之时起——"
-
-#~ msgid ""
-#~ "The gate blocking your passage is no more. Hurry, there is little time."
-#~ msgstr "挡住你们道路的大门不复存在。快，没什么时间了。"
-
-#~ msgid "meet your doom."
-#~ msgstr "迎接你的毁灭。"
-
-#~ msgid "Your chance for clemency has expired."
-#~ msgstr "你的宽恕机会已经过期。"
-
-#~ msgid "<span size='large'>Resha!</span>"
-#~ msgstr "<span size='large'>瑞莎！</span>"
-
-#~ msgid "Dolphin"
-#~ msgstr "海豚"
-
-#~ msgid ""
-#~ "The sight of a dolphin is seen as a good omen by the sailors of Elensefar "
-#~ "and the Ka’lian rated the creature’s sensibility nearly on par with that "
-#~ "of an elf. Among coastal orcish tribes the meat is consumed as a "
-#~ "delicacy.\n"
-#~ "\n"
-#~ "One of the rare air breathing fish, the dolphin is never too long below "
-#~ "the surface of the sea."
-#~ msgstr ""
-#~ "海豚的身影在埃仁撒伐的水手眼中是吉兆，卡利安人则认为此物的灵性堪比精灵。沿"
-#~ "海的兽人部落则将其肉奉为珍馐。\n"
-#~ "\n"
-#~ "作为稀有的呼吸空气之鱼，海豚从不在深海久留。"
-
-#~ msgid "shriek"
-#~ msgstr "尖叫"
-
-#~ msgid "Leopard"
-#~ msgstr "豹"
-
-#~ msgid ""
-#~ "The leopard is a fast and powerful ambush predator of the distant and "
-#~ "mysterious jungle realms. While dangerous in any circumstance, it is most "
-#~ "lethal when hidden in wooded areas."
-#~ msgstr ""
-#~ "猎豹是遥远神秘丛林中迅捷而致命的伏击掠食者。在任何环境下皆具威胁，然其于密"
-#~ "林之中隐匿之时，最为致命。"
-
-#~ msgid "claws"
-#~ msgstr "爪"
-
-#~ msgid ""
-#~ "A fiendish-tempered bird with a piercing, bronzy beak. It is covered in "
-#~ "hard, blade-sharp feathers that it can fling at its victims."
-#~ msgstr ""
-#~ "一种长有锐利的青铜色鸟喙，性情凶戾的鸟。其周身覆盖着坚硬如刀锋的羽毛，能将"
-#~ "其射向受害者。"
-
-#~ msgid "<span color='gold'>fighter intendant</span>"
-#~ msgstr "<span color='gold'>战士指挥官</span>"
-
-#~ msgid "<span color='gold'>clasher intendant</span>"
-#~ msgstr "<span color='gold'>冲击者指挥官</span>"


### PR DESCRIPTION
对wesnoth-ei、l、thot、utbs、wof：

1. 同步了官方pot文件，并翻译完成；
2. 更新了头部注释和元数据（如版权行中的年份、历史译员清单（加入vimacs）、Project-Id-Version），其中wof原本头部注释和元数据缺失很多，已全部补齐；
3. 移除了过时翻译条目。
